### PR TITLE
Fix inference of field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+`0.12.4.2 - 2015/04/17 - Fix version`:
+* `Fix`: Hydrator configuration: Section Field / Key type: fix inference of type, if the key `type` is not specified, an implicit conversion to the supposed good type is performed. Conversion to string was performed. 
+
 `0.12.4.1 - 2015/04/16 - Fix version`:
 * `Fix`: Fix lazyloading in inheritance context. Between two properties in the same hierarchy, only one was loaded and an error occured when we tried to load the second.
 

--- a/src/Annotation/Field.php
+++ b/src/Annotation/Field.php
@@ -18,9 +18,9 @@ final class Field
     public $name;
 
     /**
-    * @var mixed
+    * @var string
     */
-    public $type = 'string';
+    public $type = null;
 
     /**
     * @var string


### PR DESCRIPTION
Fix: Hydrator configuration: Section Field / Key type: fix inference of type, if the key type is not specified, an implicit conversion to the supposed good type is performed. Conversion to string was performed. 