### PR TITLE
Fix `ObjectExtension\LazyLoadableTrait::loadProperty()` method access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+`0.12.4.4 - 2015/08/17 - Fix version`:
+* `Fix`: Fix `loadProperty()` access in inheritance context (make this method protected).
+
 `0.12.4.3 - 2015/06/15 - Fix version`:
 * `Fix`: Fix sources loading (only the first source was loaded sometimes) and simplify the code related to the sources loaded tracking.
 

--- a/src/ObjectExtension/LazyLoadableTrait.php
+++ b/src/ObjectExtension/LazyLoadableTrait.php
@@ -13,7 +13,7 @@ trait LazyLoadableTrait
 {
     public $__isRegistered = false;
 
-    private function loadProperty($propertyName)
+    protected function loadProperty($propertyName)
     {
         if (false === $lazyLoader = $this->getLazyLoader()) {
             return; 


### PR DESCRIPTION
Fix `ObjectExtension\LazyLoadableTrait::loadProperty()` method access in inheritance context (make this method protected).