### PR TITLE
[Loaders][Coherence] Make loaders fully coherent between them

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,29 +382,32 @@ You can see more details about `class-resolver` [here](https://github.com/kassko
 * [Inherit mapping configuration](#inherit-mapping-configuration)
 * [Component configuration reference](#component-configuration-reference)
 * [Mapping configuration reference](#mapping-configuration-reference)
+  - [Config config](#config-config)
   - [CustomHydrator config](#customhydrator-config)
   - [DataSource config](#datasource-config)
-  - [DataSourceStore config](#datasourcestore-config)
-  - [Exclude config](#exclude-config)
+  - [DataSourcesStore config](#datasourcesstore-config)
   - [ExcludeDefaultSource config](#excludedefaultsource-config)
   - [Field config](#field-config)
   - [Getter config](#getter-config)
   - [Id config](#id-config)
   - [IdCompositePart config](#idcompositepart-config)
   - [Listeners config](#listeners-config)
+  - [Method config](#method-config)
   - [Object config](#object-config)
-  - [ObjectListeners config](#object-listeners-config)
-  - [PostExtract config](#postextract-config)
-  - [PostHydrate config](#posthydrate-config)
-  - [PreExtract config](#preextract-config)
-  - [PreHydrate config](#prehydrate-config)
-  - [Provider config](#provider-config)
-  - [ProviderStore config](#providerstore-config)
+  - [ObjectListeners config - DEPRECATED - SEE Listeners config](#objectlisteners-config---deprecated---see-listeners-config)
+  - [PostExtract config - DEPRECATED - SEE Listeners config](#postextract-config---deprecated---see-listeners-config)
+  - [PostHydrate config - DEPRECATED - SEE Listeners config](#posthydrate-config---deprecated---see-listeners-config)
+  - [PreExtract config - DEPRECATED - SEE Listeners config](#preextract-config---deprecated---see-listeners-config)
+  - [PreHydrate config - DEPRECATED - SEE Listeners config](#prehydrate-config---deprecated---see-listeners-config)
+  - [Provider config - DEPRECATED - SEE DataSource config](#provider-config---deprecated---see-datasource-config)
+  - [ProvidersStore config - DEPRECATED - SEE DataSourcesStore config](#providersstore-config---deprecated---see-datasourcesstore-config)
   - [RefDefaultSource config](#refdefaultsource-config)
   - [RefSource config](#refsource-config)
   - [Setter config](#setter-config)
+  - [ToExclude config](#toexclude-config)
+  - [ToInclude config](#toinclude-config)
   - [Transient config](#transient-config)
-  - [ValueObject config](#valueobject-config)
+  - [ValueObject config - DEPRECATED - SEE Config config](#valueobject-config---deprecated---see-config-config)
   - [Version config](#version-config)
 
 
@@ -1800,7 +1803,7 @@ Php format:
 
 To know more about the "Method config" usage, please see its dedicated documentation ["Method config"](#method-config).
 
-### DataSourceStore config
+### DataSourcesStore config
 
 Annotation format:
 ```php
@@ -1890,52 +1893,6 @@ Php format:
 
 To know more about the "Method config" usage, please see its dedicated documentation ["Method config"](#method-config).
 
-### Exclude config
-
-Annotation format:
-```php
-use Kassko\DataMapper\Annotation as DM;
-
-class SomeClass
-{
-    /**
-     * @DM\Exclude
-     */
-    protected $excludedField;
-
-    /**
-     * @DM\Field
-     */
-    protected $field;
-}
-```
-
-Yaml format:
-```yml
-exclude: [excludedField]
-fields:
-  excludedField:
-    name: originalFieldName
-  field:
-    name: field
-```
-
-Php format:
-```php
-[
-    'exclude' => [
-        'excludedField'
-    ],
-    'fields'  => [
-        'excludedField' => [
-            'name'     => 'originalFieldName'
-        ],
-        'field'         => [
-            'name'     => 'field'
-        ]
-    ]
-];
-```
 
 ### ExcludeDefaultSource config
 
@@ -1943,21 +1900,57 @@ Annotation format:
 ```php
 use Kassko\DataMapper\Annotation as DM;
 
+/**
+ * @DM\RefDefaultSource(id="refDefaultSourceId")
+ */
 class SomeClass
 {
+    protected $fieldToBindAutoToDefaultSource;
+
+    protected $anotherFieldToBindAutoToDefaultSource;
+
     /**
-     * @DM\ExcludeDefaultSource
+     *@DM\ExcludeDefaultSource
      */
-    protected $excludeDefaultSourceField;
+    protected $fieldNotToBindAutoToDefaultSource;
 }
 ```
 
 Yaml format:
 ```yml
+object:
+    refDefaultSource: refDefaultSourceId
+fields:
+    fieldToBindAutoToDefaultSource:
+        name: fieldToBindAutoToDefaultSource
+    anotherFieldToBindAutoToDefaultSource:
+        name: anotherFieldToBindAutoToDefaultSource
+    fieldNotToBindAutoToDefaultSource:
+        name: fieldNotToBindAutoToDefaultSource
+fieldsNotToBindToDefaultSource: [fieldNotToBindAutoToDefaultSource]
 ```
 
 Php format:
 ```php
+[
+    'object' => [
+        'refDefaultSource' => 'refDefaultSourceId'
+    ],
+    'fields' => [
+        'fieldToBindAutoToDefaultSource' => [
+            'name'      => 'fieldToBindAutoToDefaultSource',
+        ],
+        'anotherFieldToBindAutoToDefaultSource' => [
+            'name'      => 'anotherFieldToBindAutoToDefaultSource',
+        ],
+        'fieldNotToBindAutoToDefaultSource' => [
+            'name'      => 'fieldNotToBindAutoToDefaultSource',
+        ]
+    ],
+    'fieldsNotToBindToDefaultSource' => [
+        'fieldNotToBindAutoToDefaultSource'
+    ]
+];
 ```
 
 ### Field config
@@ -2302,8 +2295,8 @@ class SomeClass
 
 Yaml format:
 ```yml
+fieldExclusionPolicy: exclude_all
 object:
-    fieldExclusionPolicy: exclude_all
     providerClass: testProviderClass
     readDateConverter: testReadDateConverter
     writeDateConverter: testWriteDateConverter
@@ -2315,8 +2308,8 @@ object:
 Php format:
 ```php
 [
+    'fieldExclusionPolicy'  => 'exclude_all',
     'object'    => [
-        'fieldExclusionPolicy'  => 'exclude_all',
         'providerClass'         => 'testProviderClass',
         'readDateConverter'     => 'testReadDateConverter',
         'writeDateConverter'    => 'testWriteDateConverter',
@@ -2327,7 +2320,7 @@ Php format:
 ];
 ```
 
-### ObjectListeners config
+### ObjectListeners config - DEPRECATED - SEE Listeners Config
 
 Annotation format:
 ```php
@@ -2355,7 +2348,7 @@ Php format:
 ];
 ```
 
-### PostExtract config
+### PostExtract config - DEPRECATED - SEE Listeners Config
 
 Deprecated. Use [Listeners config](#listeners-config) instead.
 
@@ -2364,10 +2357,9 @@ Annotation format:
 use Kassko\DataMapper\Annotation as DM;
 
 /**
- * @DM\PostExtract(
- *      class="CustomHydratorClassName",
- *      method="postExtractMethodName"
- * )
+ * @DM\Object(classMappingExtensionClass="mappingExtensionClass")
+ *
+ * @DM\PostExtract(method="postExtractMethodName")
  */
 class SomeClass
 {
@@ -2376,6 +2368,9 @@ class SomeClass
 
 Yaml format:
 ```yml
+object:
+    classMappingExtensionClass: mappingExtensionClass
+
 interceptors:
     postExtract: postExtractMethodName
 ```
@@ -2383,13 +2378,14 @@ interceptors:
 Php format:
 ```php
 [
+    'object' => ['classMappingExtensionClass' => 'mappingExtensionClass'],
     'interceptors'  => [
         'postExtract'    => 'postExtractMethodName'
     ]
 ];
 ```
 
-### PostHydrate config
+### PostHydrate config - DEPRECATED - SEE Listeners Config
 
 Deprecated. Use [Listeners config](#listeners-config) instead.
 
@@ -2398,10 +2394,9 @@ Annotation format:
 use Kassko\DataMapper\Annotation as DM;
 
 /**
- * @DM\PostHydrate(
- *      class="CustomHydratorClassName",
- *      method="postHydrateMethodName"
- * )
+ * @DM\Object(classMappingExtensionClass="mappingExtensionClass")
+ *
+ * @DM\PostHydrate(method="postHydrateMethodName")
  */
 class SomeClass
 {
@@ -2410,6 +2405,9 @@ class SomeClass
 
 Yaml format:
 ```yml
+object:
+    classMappingExtensionClass: mappingExtensionClass
+
 interceptors:
     postHydrate: postHydrateMethodName
 ```
@@ -2417,13 +2415,14 @@ interceptors:
 Php format:
 ```php
 [
+    'object' => ['classMappingExtensionClass' => 'mappingExtensionClass'],
     'interceptors'  => [
         'postHydrate'    => 'postHydrateMethodName'
     ]
 ];
 ```
 
-### PreExtract config
+### PreExtract config - DEPRECATED - SEE Listeners Config
 
 Deprecated. Use [Listeners config](#listeners-config) instead.
 
@@ -2432,6 +2431,8 @@ Annotation format:
 use Kassko\DataMapper\Annotation as DM;
 
 /**
+ * @DM\Object(classMappingExtensionClass="mappingExtensionClass")
+ *
  * @DM\PreExtract(
  *      method="preExtractMethodName"
  * )
@@ -2443,6 +2444,9 @@ class SomeClass
 
 Yaml format:
 ```yml
+object:
+    classMappingExtensionClass: mappingExtensionClass
+
 interceptors:
     preExtract: preExtractMethodName
 ```
@@ -2450,13 +2454,14 @@ interceptors:
 Php format:
 ```php
 [
+    'object' => ['classMappingExtensionClass' => 'mappingExtensionClass'],
     'interceptors'  => [
         'preExtract'    => 'preExtractMethodName'
     ]
 ];
 ```
 
-### PreHydrate config
+### PreHydrate config - DEPRECATED - SEE Listeners Config
 
 Deprecated. Use [Listeners config](#listeners-config) instead.
 
@@ -2465,10 +2470,9 @@ Annotation format:
 use Kassko\DataMapper\Annotation as DM;
 
 /**
- * @DM\PreHydrate(
- *      class="CustomHydratorClassName",
- *      method="preHydrateMethodName"
- * )
+ * @DM\Object(classMappingExtensionClass="mappingExtensionClass")
+ *
+ * @DM\PreHydrate(method="preHydrateMethodName")
  */
 class SomeClass
 {
@@ -2477,6 +2481,9 @@ class SomeClass
 
 Yaml format:
 ```yml
+object:
+    classMappingExtensionClass: mappingExtensionClass
+
 interceptors:
     preHydrate: preHydrateMethodName
 ```
@@ -2484,20 +2491,21 @@ interceptors:
 Php format:
 ```php
 [
+    'object' => ['classMappingExtensionClass' => 'mappingExtensionClass'],
     'interceptors'  => [
         'preHydrate'    => 'preHydrateMethodName'
     ]
 ];
 ```
 
-### Provider config
+### Provider config - DEPRECATED - SEE DataSource Config
 
 Deprecated. Use [DataSource config](#datasource-config) instead.
 Configuration is the same as DataSource.
 
-### ProviderStore config
+### ProvidersStore config - DEPRECATED - SEE DataSourcesStore Config
 
-Deprecated. Use [DataSourceStore config](#datasourcestore-config) instead.
+Deprecated. Use [DataSourcesStore config](#datasourcesstore-config) instead.
 Configuration is the same as DataSourceStore.
 
 ### RefDefaultSource config
@@ -2517,19 +2525,22 @@ class SomeClass
 
 Yaml format:
 ```yml
+object:
+    refDefaultSource: refDefaultSourceId
 fields:
     mockField:
         name: mockFieldName
-        refSource: refDefaultSourceId
 ```
 
 Php format:
 ```php
 [
+    'object' => [
+        'refDefaultSource' => 'refDefaultSourceId'
+    ],
     'fields' => [
         'mockField' => [
             'name'      => 'mockFieldName',
-            'refSource' => 'refDefaultSourceId'
         ]
     ]
 ];
@@ -2540,16 +2551,57 @@ Php format:
 Annotation format:
 ```php
 use Kassko\DataMapper\Annotation as DM;
+
+/**
+ * @DM\DataSourcesStore({
+ *      @DM\DataSource(
+ *          id="someDataSource",
+ *          class="Kassko\Sample\PersonDataSource",
+ *          method="getData"
+ *      )
+ * })
+ */
+class SomeClass
+{
+    /**
+     * @DM\RefSource(id="someDataSource")
+     */
+    private $fieldOne;
+}
 ```
 
 Yaml format:
 ```yml
+object:
+    dataSourcesStore:
+        - id: personSource
+        class: "Kassko\\\Sample\\\PersonDataSource"
+        method: getData
+fields:
+    fieldOne:
+        name: fieldOne
+        refSource: someDataSource
 ```
 
 Php format:
 ```php
-```
-
+[
+    'object'    => [
+        'dataSourcesStore'    => [
+            [
+                'id'=> 'personSource',
+                'class'=> 'Kassko\Sample\PersonDataSource',
+                'method'=> 'getData',
+            ]
+        ]
+    ],
+    'fields'    => [
+        'fieldOne' => [
+            'name'  => 'fieldOne',
+            'refSource' => 'someDataSource',
+        ]
+    ],
+];
 ### Setter config
 
 Annotation format:
@@ -2585,6 +2637,118 @@ Php format:
             'name'      => 'firstField',
             'setter'    => ['name' => 'setterName'],
         ]
+    ]
+];
+```
+
+### ToExclude config
+
+Annotation format:
+```php
+use Kassko\DataMapper\Annotation as DM;
+
+/**
+ * Optional because it's the default settings for fieldExclusionPolicy.
+ * @DM\Object(fieldExclusionPolicy="include_all")
+ */
+class SomeClass
+{
+    /**
+     * @DM\ToExclude
+     */
+    protected $excludedField;
+
+    /**
+     * @DM\Field
+     */
+    protected $anotherField;
+}
+```
+
+Yaml format:
+```yml
+# Optional because it's the default settings for fieldExclusionPolicy.
+# object:
+#    fieldExclusionPolicy: include_all
+excludedFields: [excludedField]
+fields:
+  excludedField:
+    name: excludedField
+  anotherField:
+    name: anotherField
+```
+
+Php format:
+```php
+[
+    /*
+    //Optional because it's the default settings for fieldExclusionPolicy.
+    'object' => [
+        'fieldExclusionPolicy' => 'include_all'
+    ],
+    */
+    'excludedFields' => [
+        'excludedField'
+    ],
+    'fields'  => [
+        'excludedField' => [
+            'name'     => 'excludedField'
+        ],
+        'anotherField'         => [
+            'name'     => 'anotherField'
+        ]
+    ]
+];
+```
+
+### ToInclude config
+
+Annotation format:
+```php
+use Kassko\DataMapper\Annotation as DM;
+
+/**
+ * @DM\Object(fieldExclusionPolicy="exclude_all")
+ */
+class SomeClass
+{
+    /**
+     * @DM\Include
+     */
+    protected $includedField;
+
+    /**
+     * @DM\Field
+     */
+    protected $field;
+}
+```
+
+Yaml format:
+```yml
+fieldExclusionPolicy: exclude_all
+fieldsToInclude: [includedField]
+fields:
+    includedField:
+        name: includedField
+    anotherField:
+        name: anotherField
+```
+
+Php format:
+```php
+[
+    'fieldExclusionPolicy' => 'exclude_all'
+    'fieldsToInclude' => [
+        'includedField'
+    ],
+    'fields'  => [
+        'includedField' => [
+            'name'     => 'includedField'
+        ],
+        'anotherField' => [
+            'name'     => 'anotherField'
+        ],
     ]
 ];
 ```
@@ -2627,15 +2791,65 @@ Php format:
 ];
 ```
 
-### ValueObject config
+### ValueObject config - DEPRECATED - SEE Config Config
 
-Deprecated. Use [Listeners config](#listeners-config) instead.
+Deprecated. Use [Config config](#config-config) instead.
 
 Annotation format:
-Annotation `@Kassko\DataMapper\Annotation\ValueObject` become `@Kassko\DataMapper\Annotation\Config`.
+Annotation `@Kassko\DataMapper\Annotation\ValueObject` becomes `@Kassko\DataMapper\Annotation\Config`.
 
 Yaml and Php format:
-Key `'valueObjects'` become `'config'`.
+Now, there's a field key `'fields.some_field.config'`. Uses it instead of the global key `'valueObjects'`.
+
+Annotation format:
+```php
+use Kassko\DataMapper\Annotation as DM;
+
+class ValueObject
+{
+    /**
+     * @DM\Config(
+     *      class="\ValueObjectClass",
+     *      mappingResourceName="valueObjectResourceName",
+     *      mappingResourcePath="valueObjectResourcePath",
+     *      mappingResourceType="valueObjectResourceType"
+     * )
+     */
+    protected $firstField;
+}
+```
+
+Yaml format:
+```yml
+fields:
+  firstField:
+    name: firstField
+valueObjects:
+    firstField:
+        class: "\\\ValueObjectClass"
+        mappingResourceName: valueObjectResourceName
+        mappingResourcePath: valueObjectResourcePath
+        mappingResourceType: valueObjectResourceType
+```
+
+Php format:
+```php
+[
+    'fields' => [
+        'firstField' => [
+            'name'         => 'firstField',
+        ]
+    ],
+    'valueObjects' => [
+        'firstField'    => [
+            'class' => '\ValueObjectClass',
+            'mappingResourceName' => 'valueObjectResourceName',
+            'mappingResourcePath' => 'valueObjectResourcePath',
+            'mappingResourceType' => 'valueObjectResourceType'
+        ]
+    ]
+];
+```
 
 ### Version config
 

--- a/src/Annotation/ToExclude.php
+++ b/src/Annotation/ToExclude.php
@@ -8,6 +8,6 @@ namespace Kassko\DataMapper\Annotation;
 *
 * @author kko
 */
-final class Include
+final class ToExclude
 {
 }

--- a/src/Annotation/ToInclude.php
+++ b/src/Annotation/ToInclude.php
@@ -3,14 +3,11 @@
 namespace Kassko\DataMapper\Annotation;
 
 /**
-* @deprecated
-* @see ToExclude
-*
 * @Annotation
 * @Target("PROPERTY")
 *
 * @author kko
 */
-final class Exclude
+final class ToInclude
 {
 }

--- a/src/Annotation/Variables.php
+++ b/src/Annotation/Variables.php
@@ -13,5 +13,10 @@ final class Variables
 	/**
     * @var array
     */
-    private $variables = [];
+    public $variables = [];
+
+    public function __construct(array $variables)
+    {
+		$this->variables = $variables;
+    }
 }

--- a/src/ClassMetadata/Model/Method.php
+++ b/src/ClassMetadata/Model/Method.php
@@ -10,7 +10,7 @@ class Method
 	/**
      * @var string
      */
-    private $class;
+    private $class = '##this';
 
     /**
      * @var string
@@ -24,7 +24,9 @@ class Method
 
     public function __construct($class = null, $function = null, array $args = [])
     {
-        $this->class = $class; 
+        if (null !== $class) {
+            $this->class = $class; 
+        }
         $this->function = $function; 
         $this->args = $args;    
     }

--- a/src/ClassMetadataLoader/AnnotationLoader.php
+++ b/src/ClassMetadataLoader/AnnotationLoader.php
@@ -22,8 +22,9 @@ class AnnotationLoader implements LoaderInterface
     private static $objectAnnotationName = DM\Object::class;
     private static $listenersAnnotationName = DM\Listeners::class;
     private static $fieldAnnotationName = DM\Field::class;
-    private static $includeAnnotationName = 'Kassko\\DataMapper\\Annotation\\Include';//DM\Include::class;
-    private static $excludeAnnotationName = DM\Exclude::class;
+    private static $includeAnnotationName = DM\ToInclude::class;
+    private static $excludeAnnotationName = DM\ToExclude::class;
+    private static $oldExcludeAnnotationName = DM\Exclude::class;//Deprecated. Use DM\ToExclude instead. 
     private static $idAnnotationName = DM\Id::class;
     private static $idCompositePartAnnotationName = DM\IdCompositePart::class;
     private static $versionAnnotationName = DM\Version::class;
@@ -240,7 +241,7 @@ class AnnotationLoader implements LoaderInterface
                         break;
 
                     case self::$variablesAnnotationName:
-                        $variables[$mappedFieldName] = (array)$annotation;
+                        $variables[$mappedFieldName] = (array)$annotation->variables['value'];
                         break;
 
                     case self::$includeAnnotationName:
@@ -248,6 +249,7 @@ class AnnotationLoader implements LoaderInterface
                         break;
 
                     case self::$excludeAnnotationName:
+                    case self::$oldExcludeAnnotationName:
                         $excludedFields[$mappedFieldName] = true;
                         break;
 

--- a/src/ClassMetadataLoader/KeysConfiguration.php
+++ b/src/ClassMetadataLoader/KeysConfiguration.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Kassko\DataMapper\ClassMetadataLoader;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder; 
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class KeysConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $builder = new TreeBuilder();
+        $rootNode = $builder->root('root');
+
+        $rootNode//->addDefaultsIfNotSet()     
+            ->children()
+                ->arrayNode('object')//->addDefaultsIfNotSet()
+                    ->append($this->sourceStoreNode('dataSourcesStore'))
+                    ->append($this->sourceStoreNode('providersStore'))
+                    ->children()
+                        ->enumNode('fieldExclusionPolicy')/** @deprecated @see root.fieldExclusionPolicy */
+                            ->values(['include_all', 'exclude_all'])
+                            //->defaultValue('include_all')
+                        ->end()
+                        ->scalarNode('readDateConverter')->defaultNull()->end()
+                        ->scalarNode('writeDateConverter')->defaultNull()->end()
+                        ->scalarNode('classMappingExtensionClass')->defaultNull()->end()
+                        ->scalarNode('fieldMappingExtensionClass')->defaultNull()->end()
+                        ->booleanNode('propertyAccessStrategy')->defaultFalse()->end()
+                        ->arrayNode('customHydrator')//->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('class')->defaultNull()->end()
+                                ->scalarNode('hydrateMethod')->defaultNull()->end()
+                                ->scalarNode('extractMethod')->defaultNull()->end()
+                            ->end()
+                        ->end()
+                        ->scalarNode('providerClass')->defaultNull()->end()
+                        ->booleanNode('readOnly')->defaultFalse()->end()
+                    ->end()
+                ->end()
+                ->arrayNode('fields')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('name')->defaultNull()->end()
+                            ->scalarNode('type')->defaultNull()->end()
+                            ->scalarNode('class')->defaultNull()->end()
+                            ->scalarNode('defaultValue')->defaultNull()->end()
+                            ->scalarNode('readConverter')->defaultNull()->end()
+                            ->scalarNode('writeConverter')->defaultNull()->end()
+                            ->scalarNode('readDateConverter')->defaultNull()->end()
+                            ->scalarNode('writeDateConverter')->defaultNull()->end()
+                            ->scalarNode('fieldMappingExtensionClass')->defaultNull()->end()
+                            ->scalarNode('refSource')->defaultNull()->end()
+                            ->append($this->propertyWrapperNode('getter'))
+                            ->append($this->propertyWrapperNode('setter'))
+                            ->append($this->sourceNode('dataSource'))
+                            ->append($this->sourceNode('provider'))
+                            ->append($this->configNode('config'))
+                            ->append($this->smartScalarNode('variables'))
+                        ->end()
+                        ->validate()
+                        ->always(function ($v) {
+                            if (empty($v['config']) && ! empty($v['valueObjects'])) {
+                                $v['config'] = $v['valueObjects'];
+                                unset($v['include']);
+                            }
+                            return $v;
+                        })
+                        ->end()
+                    ->end()
+                ->end()
+                ->enumNode('fieldExclusionPolicy')
+                    ->values(['include_all', 'exclude_all'])
+                    //->defaultValue('include_all')
+                ->end()
+                ->append($this->smartScalarNode('fieldsToInclude'))
+                ->append($this->smartScalarNode('fieldsToExclude'))
+                ->append($this->smartScalarNode('include')) /** @deprecated @see fieldsToInclude **/
+                ->append($this->smartScalarNode('exclude')) /** @deprecated @see fieldsToExclude **/
+                ->append($this->smartScalarNode('fieldsNotToBindToDefaultSource')) 
+                ->scalarNode('refDefaultSource')->defaultNull()->end()
+                ->arrayNode('listeners')//->addDefaultsIfNotSet()
+                    ->append($this->methodsNode('preHydrate'))
+                    ->append($this->methodsNode('postHydrate'))
+                    ->append($this->methodsNode('preExtract'))
+                    ->append($this->methodsNode('postExtract'))
+                ->end()
+                ->arrayNode('interceptors')
+                    ->children()
+                        ->append($this->interceptorNode('preHydrate'))
+                        ->append($this->interceptorNode('postHydrate'))
+                        ->append($this->interceptorNode('preExtract'))
+                        ->append($this->interceptorNode('postExtract'))
+                    ->end()
+                ->end()
+                ->append($this->smartScalarNode('objectListeners'))
+                ->append($this->valueObjectsNode('valueObjects'))
+                ->scalarNode('id')->defaultNull()->end()
+                ->arrayNode('idComposite')->prototype('scalar')->end()->end()
+                ->append($this->smartScalarNode('transient'))
+                ->scalarNode('version')->defaultNull()->end()
+            ->end()
+            ->validate()
+            ->always(function ($v) {
+                if (! isset($v['fieldExclusionPolicy'])) {
+                    if (isset($v['object']['fieldExclusionPolicy'])) {
+                        $v['fieldExclusionPolicy'] =  $v['object']['fieldExclusionPolicy'];
+                        unset($v['object']['fieldExclusionPolicy']); 
+                    } else {
+                        $v['fieldExclusionPolicy'] = 'include_all';
+                    }
+                }
+
+                if (empty($v['fieldsToExclude']) && ! empty($v['exclude'])) {
+                    $v['fieldsToExclude'] = $v['exclude'];
+                    unset($v['exclude']);
+                }
+
+                if (empty($v['fieldsToInclude']) && ! empty($v['include'])) {
+                    $v['fieldsToInclude'] = $v['include'];
+                    unset($v['include']);
+                }
+
+                if (isset($v['valueObjects']) && ! empty($v['valueObjects']) && isset($v['fields']) && ! empty($v['fields'])) {
+                    $fields = &$v['fields'];
+                    foreach ($fields as &$field) {
+                        $field['config'] = $v['valueObjects'][$field['name']];
+                    }
+                }
+
+                return $v;
+            })
+            ->end()
+        ;
+
+        //@todo     Implement in all loaders
+        //variables
+
+        return $builder;
+    }
+
+    private function propertyWrapperNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $node
+            //->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('prefix')->defaultNull()->end()
+                ->scalarNode('name')->defaultNull()->end()
+            ->end()
+        ;
+        
+        return $node;
+    }
+
+    private function sourceStoreNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $childNode = $node->prototype('array');
+        $this->configureSourceNode($childNode);
+        
+        return $node;
+    }
+
+    private function sourceNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $this->configureSourceNode($node);
+        
+        return $node;
+    }
+
+    private function configureSourceNode(NodeDefinition $node)
+    {
+        $this->configureMethodNode($node);
+        
+        $node
+            //->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('id')->defaultNull()->end()
+                ->booleanNode('lazyLoading')->defaultFalse()->end()
+                ->booleanNode('supplySeveralFields')->defaultFalse()->end()
+                ->arrayNode('depends')->prototype('scalar')->defaultValue([])->end()->end()
+                ->enumNode('onFail')
+                    ->defaultValue('checkReturnValue')
+                    ->values(['checkReturnValue', 'checkException'])
+                ->end()
+                ->scalarNode('exceptionClass')->defaultValue('\Exception')->end()
+                ->enumNode('badReturnValue')
+                    ->defaultValue('null')
+                    ->values(['null', 'false', 'emptyString', 'emptyArray'])
+                ->end()
+                ->scalarNode('fallbackSourceId')->defaultNull()->end()
+            ->end()
+            ->append($this->methodNode('preprocessor'))
+            ->append($this->methodNode('processor'))
+            ->append($this->methodsNode('preprocessors'))
+            ->append($this->methodsNode('processors'))
+        ;
+    }
+
+    private function methodsNode($nodesName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodesName);
+
+        $node
+            ->beforeNormalization()
+                ->always()
+                ->then(function ($v) {
+
+                    if (empty($v)) {
+                        return $v;
+                    }
+
+                    if (isset($v['items'])) {
+                        $v = $v['items'];
+                    }
+
+                    /**
+                     * If only one method, make an array with this only one method
+                     * So transforms
+                     * ['some_config_key' => ['some_methods_config_key' => ['class' => 'SomeClass', 'method' => someMethod]]] 
+                     * to 
+                     * ['some_config_key' => [some_methods_config_key => [['class' => 'SomeClass', 'method' => someMethod]]]]
+                     */
+                    if (! is_array(current($v))) {
+                        return [$v];
+                    }
+
+                    return $v;
+                })
+            ->end()
+        ;
+
+        $childNode =  $node->prototype('array');
+        $this->configureMethodNode($childNode);
+
+        return $node;
+    }
+
+    private function methodNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $this->configureMethodNode($node);
+
+        return $node;
+    }
+
+    private function configNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $this->configureConfigNode($node);        
+
+        return $node;
+    }
+
+    private function valueObjectsNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $childNode =  $node->prototype('array');
+        $this->configureConfigNode($childNode);
+
+        return $node;
+    }
+
+    private function configureConfigNode(NodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->scalarNode('class')->defaultNull()->end()
+                ->scalarNode('mappingResourceName')->defaultNull()->end()
+                ->scalarNode('mappingResourcePath')->defaultNull()->end()
+                ->scalarNode('mappingResourceType')->defaultNull()->end()
+            ->end()
+        ;
+    }
+
+    private function configureMethodNode(NodeDefinition $node)
+    {
+        $node
+            //->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('class')->defaultValue('##this')->end()
+                ->scalarNode('method')->defaultNull()->end()
+                ->append($this->smartScalarNode('args'))
+            ->end()
+        ;
+    }
+
+    private function interceptorNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $node
+            ->children()
+                ->scalarNode('class')->defaultNull()->end()
+                ->scalarNode('method')->defaultNull()->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function smartScalarNode($nodeName)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($nodeName);
+
+        $node
+            ->defaultValue([])
+            ->beforeNormalization()
+                ->always(function ($v) { return (array)$v; })
+            ->end()
+            ->prototype('scalar')->end()
+        ;
+
+        return $node;
+    }
+}

--- a/src/Hydrator/Hydrator.php
+++ b/src/Hydrator/Hydrator.php
@@ -244,13 +244,8 @@ class Hydrator extends AbstractHydrator
                 }
             }
         } else {
-
-            list($customHydratorClass, , $customExtractMethod) = $this->metadata->getCustomHydratorInfo();
-            $customHydrator = $this->classResolver ? $this->classResolver->resolve($customHydratorClass) : new $customHydratorClass;
-            
-            if (! method_exists($customHydrator, '__call') && ! (method_exists($customHydrator, $customExtractMethod) && is_callable([$customHydrator, $customExtractMethod]))) {
-                throw new \BadMethodCallException(sprintf('Failure on call method "%s::%s".', get_class($customHydrator), $customExtractMethod));
-            }
+            list($customHydratorClass, , $customExtractMethod) = $this->metadata->getCustomHydratorInfo();            
+            $this->executeMethod($object, new ClassMetadata\Model\Method($customHydratorClass, $customExtractMethod));
         }
 
         //Value objects extraction.
@@ -318,10 +313,8 @@ class Hydrator extends AbstractHydrator
                 }
             }
         } else {
-
             list($customHydratorClass, $customHydrateMethod) = $this->metadata->getCustomHydratorInfo();
-            $customHydrator = $this->classResolver ? $this->classResolver->resolve($customHydratorClass) : new $customHydratorClass;
-            $customHydrator->$customHydrateMethod($data, $object);
+            $this->executeMethod($object, new ClassMetadata\Model\Method($customHydratorClass, $customHydrateMethod));
         }
 
         //DataSources hydration.

--- a/tests/ClassMetadataLoader/ArrayLoaderTest.php
+++ b/tests/ClassMetadataLoader/ArrayLoaderTest.php
@@ -21,16 +21,13 @@ class ArrayLoaderTest extends AnnotationLoaderTest
 
         $loaderMock = $this->getMockBuilder(
             'Kassko\DataMapper\ClassMetadataLoader\ArrayLoader'
-        )->setMethods(array('normalizeFormat', 'normalizeData', 'loadData'))->getMockForAbstractClass();
+        )->setMethods(array('normalize', 'loadData'))->getMockForAbstractClass();
 
         $data = array('testData' => time());
         $expectedResult = 'testResult' . time();
 
         $loaderMock->expects($this->once())
-            ->method('normalizeFormat')
-            ->with($data);
-        $loaderMock->expects($this->once())
-            ->method('normalizeData')
+            ->method('normalize')
             ->with($data);
         $loaderMock->expects($this->once())
             ->method('loadData')

--- a/tests/ClassMetadataLoader/Fixture/Metadata/Config.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/Config.php
@@ -3,7 +3,7 @@ namespace Kassko\DataMapperTest\ClassMetadataLoader\Fixture\Metadata;
 
 use Kassko\DataMapper\Annotation as DM;
 
-class ValueObject
+class Config
 {
     /**
      * @DM\Config(
@@ -23,15 +23,13 @@ class ValueObject
         return [
             'fields' => [
                 'firstField' => [
-                    'name'         => 'firstField',
-                ]
-            ],
-            'valueObjects' => [
-                'firstField'    => [
-                    'class' => '\ValueObjectClass',
-                    'mappingResourceName' => 'valueObjectResourceName',
-                    'mappingResourcePath' => 'valueObjectResourcePath',
-                    'mappingResourceType' => 'valueObjectResourceType'
+                    'name'         => 'firstFieldName',
+                    'config' => [
+                        'class' => '\ValueObjectClass',
+                        'mappingResourceName' => 'valueObjectResourceName',
+                        'mappingResourcePath' => 'valueObjectResourcePath',
+                        'mappingResourceType' => 'valueObjectResourceType'
+                    ]
                 ]
             ]
         ];
@@ -45,9 +43,8 @@ class ValueObject
         return <<<EOF
 fields:
   firstField:
-    name: firstField
-valueObjects:
-    firstField:
+    name: firstFieldName
+    config:
         class: "\\\ValueObjectClass"
         mappingResourceName: valueObjectResourceName
         mappingResourcePath: valueObjectResourcePath

--- a/tests/ClassMetadataLoader/Fixture/Metadata/DataSource.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/DataSource.php
@@ -42,18 +42,8 @@ class DataSource
                         'exceptionClass'      => '\RuntimeException',
                         'badReturnValue'      => 'emptyString',
                         'fallbackSourceId'    => 'firstFieldFallbackSourceId',
-                        'preprocessor'        => [
-                            'class'  => '##this',
-                            'method' => 'fooPreprocessor',
-                            'args'   => []
-                        ],
-                        'processor'           => [
-                            'class'  => '##this',
-                            'method' => 'barProcessor',
-                            'args'   => []
-                        ],
-                        'preprocessors'       => [],
-                        'processors'          => [],
+                        'preprocessor'        => ['method' => 'fooPreprocessor'],
+                        'processor'           => ['method' => 'barProcessor'],                    
                         'class'               => '\stdClass',
                         'method'              => 'someMethod',
                         'args'                => ['argument#1', 'argument#2']
@@ -82,15 +72,9 @@ fields:
       badReturnValue: emptyString
       fallbackSourceId: firstFieldFallbackSourceId
       preprocessor:
-        class: "##this"
         method: fooPreprocessor
-        args: []
       processor:
-        class: "##this"
         method: barProcessor
-        args: []
-      preprocessors: []
-      processors: []
       class: "\\\stdClass"
       method: someMethod
       args: [argument#1, argument#2]

--- a/tests/ClassMetadataLoader/Fixture/Metadata/DataSourcesStore.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/DataSourcesStore.php
@@ -45,16 +45,8 @@ class DataSourcesStore
                         'badReturnValue' => 'emptyString',
                         'fallbackSourceId' => 'testFallbackSourceId',
                         'depends' => ['#dependsFirst'],
-                        'preprocessor' => [
-                            'class' => '',
-                            'method' => 'somePreprocessor',
-                            'args' => []
-                        ],
-                        'processor' => [
-                            'class' => '',
-                            'method' => 'someProcessor',
-                            'args' => []
-                        ]
+                        'preprocessor' => ['method' => 'somePreprocessor'],
+                        'processor' => ['method' => 'someProcessor']
                     ]
                 ]
             ]
@@ -81,13 +73,9 @@ object:
      fallbackSourceId: testFallbackSourceId
      depends: [#dependsFirst]
      preprocessor:
-       class: ""
        method: somePreprocessor
-       args: []
      processor:
-       class: ""
        method: someProcessor
-       args: []
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/DataSourcesStoreMultiplesDepends.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/DataSourcesStoreMultiplesDepends.php
@@ -25,25 +25,6 @@ class DataSourcesStoreMultiplesDepends
                         'id'                  => 'personSource',
                         'depends'             => [
                             '#dependsFirst', '#dependsSecond', '#dependsThird'
-                        ],
-                        'class'               => 'Kassko\Sample\PersonDataSource',
-                        'method'              => 'getData',
-                        'args'                => ['#id'],
-                        'lazyLoading'         => true,
-                        'supplySeveralFields' => true,
-                        'onFail'              => 'checkException',
-                        'exceptionClass'      => '\RuntimeException',
-                        'badReturnValue'      => 'emptyString',
-                        'fallbackSourceId'    => 'testFallbackSourceId',
-                        'preprocessor'        => [
-                            'class'  => '',
-                            'method' => 'somePreprocessor',
-                            'args'   => []
-                        ],
-                        'processor'           => [
-                            'class'  => '',
-                            'method' => 'someProcessor',
-                            'args'   => []
                         ]
                     ]
                 ]
@@ -58,26 +39,9 @@ class DataSourcesStoreMultiplesDepends
     {
         return <<<EOF
 object:
-  dataSourcesStore:
-   - id: personSource
-     class: "Kassko\\\Sample\\\PersonDataSource"
-     method: getData
-     args: [#id]
-     lazyLoading: true
-     supplySeveralFields: true
-     onFail: checkException
-     exceptionClass: \RuntimeException
-     badReturnValue: emptyString
-     fallbackSourceId: testFallbackSourceId
-     depends: [#dependsFirst, #dependsSecond, #dependsThird]
-     preprocessor:
-       class: ""
-       method: somePreprocessor
-       args: []
-     processor:
-       class: ""
-       method: someProcessor
-       args: []
+    dataSourcesStore:
+        - id: personSource
+          depends: [#dependsFirst, #dependsSecond, #dependsThird]
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/DataSourcesStoreMultiplesProcessors.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/DataSourcesStoreMultiplesProcessors.php
@@ -31,45 +31,13 @@ class DataSourcesStoreMultiplesProcessors
                 'dataSourcesStore' => [
                     [
                         'id'                  => 'personSource',
-                        'depends'             => [
-                            '#dependsFirst', '#dependsSecond', '#dependsThird'
-                        ],
-                        'class'               => 'Kassko\Sample\PersonDataSource',
-                        'method'              => 'getData',
-                        'args'                => ['#id'],
-                        'lazyLoading'         => true,
-                        'supplySeveralFields' => true,
-                        'onFail'              => 'checkException',
-                        'exceptionClass'      => '\RuntimeException',
-                        'badReturnValue'      => 'emptyString',
-                        'fallbackSourceId'    => 'testFallbackSourceId',
                         'preprocessors'       => [
-                            'items' => [
-                                [
-                                    'method' => 'somePreprocessorA',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ],
-                                [
-                                    'method' => 'somePreprocessorB',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ]
-                            ]
+                            ['method' => 'somePreprocessorA'],
+                            ['method' => 'somePreprocessorB']
                         ],
                         'processors'          => [
-                            'items' => [
-                                [
-                                    'method' => 'someProcessorA',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ],
-                                [
-                                    'method' => 'someProcessorB',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ]
-                            ]
+                            ['method' => 'someProcessorA'],
+                            ['method' => 'someProcessorB']                            
                         ]
                     ]
                 ]
@@ -88,30 +56,12 @@ object:
    - id: personSource
      class: "Kassko\\\Sample\\\PersonDataSource"
      method: getData
-     args: [#id]
-     lazyLoading: true
-     supplySeveralFields: true
-     onFail: checkException
-     exceptionClass: \RuntimeException
-     badReturnValue: emptyString
-     fallbackSourceId: testFallbackSourceId
-     depends: [#dependsFirst, #dependsSecond, #dependsThird]
      preprocessors:
-       items:
-         - class: "##this"
-           method: somePreprocessorA
-           args: []
-         - class: "##this"
-           method: somePreprocessorB
-           args: []
+      - method: somePreprocessorA
+      - method: somePreprocessorB
      processors:
-       items:
-         - class: "##this"
-           method: someProcessorA
-           args: []
-         - class: "##this"
-           method: someProcessorB
-           args: []
+      - method: someProcessorA
+      - method: someProcessorB
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/ExcludeDefaultSource.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/ExcludeDefaultSource.php
@@ -5,10 +5,14 @@ use Kassko\DataMapper\Annotation as DM;
 
 class ExcludeDefaultSource
 {
+    protected $fieldToBindAutoToDefaultSource;
+
+    protected $anotherFieldToBindAutoToDefaultSource;
+
     /**
-     * @DM\ExcludeDefaultSource
+     *@DM\ExcludeDefaultSource
      */
-    protected $excludeDefaultSourceField;
+    protected $fieldNotToBindAutoToDefaultSource;
 
     /**
      * @return array
@@ -16,6 +20,20 @@ class ExcludeDefaultSource
     public static function loadInnerPhpMetadata()
     {
         return [
+            'fields' => [
+                'fieldToBindAutoToDefaultSource' => [
+                    'name'      => 'fieldToBindAutoToDefaultSource',
+                ],
+                'anotherFieldToBindAutoToDefaultSource' => [
+                    'name'      => 'anotherFieldToBindAutoToDefaultSource',
+                ],
+                'fieldNotToBindAutoToDefaultSource' => [
+                    'name'      => 'fieldNotToBindAutoToDefaultSource',
+                ]
+            ],
+            'fieldsNotToBindToDefaultSource' => [
+                'fieldNotToBindAutoToDefaultSource'
+            ]
         ];
     }
 
@@ -25,6 +43,14 @@ class ExcludeDefaultSource
     public static function loadInnerYamlMetadata()
     {
         return <<<EOF
+fields:
+    fieldToBindAutoToDefaultSource:
+        name: fieldToBindAutoToDefaultSource
+    anotherFieldToBindAutoToDefaultSource:
+        name: anotherFieldToBindAutoToDefaultSource
+    fieldNotToBindAutoToDefaultSource:
+        name: fieldNotToBindAutoToDefaultSource
+fieldsNotToBindToDefaultSource: [fieldNotToBindAutoToDefaultSource]        
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/Field.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/Field.php
@@ -60,12 +60,11 @@ class Field
                     'readDateConverter'          => 'readDateConvertSecondField',
                     'writeDateConverter'         => 'writeDateConvertSecondField',
                     'fieldMappingExtensionClass' => 'ExtensionClass',
-                    'defaultValue'               => 12
+                    'defaultValue'               => 12,
                 ],
                 'dateField' => [
                     'name'                       => 'DateField',
                     'type'                       => 'date',
-                    'readDateConverter'          => null, //We can omit this key instead of specify it with the value null.
                 ]
             ]
         ];
@@ -96,13 +95,6 @@ fields:
   dateField:
     name: DateField
     type: date
-    readDateConverter: null # We can omit this key instead of specify it with the value null.
-    writeDateConverter: ~ # Identical to null. We can omit this key too.
 EOF;
     }
 }
-
-/**
- * (1) Allows to test the normalization process. 
- * It will add the missing entries (readConverter, writeConverter) and set them to null.
- */

--- a/tests/ClassMetadataLoader/Fixture/Metadata/PostExtract.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/PostExtract.php
@@ -20,7 +20,7 @@ class PostExtract
     {
         return [
             'interceptors'  => [
-                'postExtract'    => 'postExtractMethodName'
+                'postExtract'    => ['class' => 'CustomHydratorClassName', 'method' => 'postExtractMethodName']
             ]
         ];
     }
@@ -32,7 +32,9 @@ class PostExtract
     {
         return <<<EOF
 interceptors:
-  postExtract: postExtractMethodName
+  postExtract: 
+    class: CustomHydratorClassName
+    method: postExtractMethodName
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/PostHydrate.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/PostHydrate.php
@@ -20,7 +20,7 @@ class PostHydrate
     {
         return [
             'interceptors'  => [
-                'postHydrate'    => 'postHydrateMethodName'
+                'postHydrate'    => ['class' => 'CustomHydratorClassName', 'method' => 'postHydrateMethodName']
             ]
         ];
     }
@@ -32,7 +32,9 @@ class PostHydrate
     {
         return <<<EOF
 interceptors:
-  postHydrate: postHydrateMethodName
+  postHydrate:  
+    class: CustomHydratorClassName
+    method: postHydrateMethodName
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/PreExtract.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/PreExtract.php
@@ -19,7 +19,7 @@ class PreExtract
     {
         return [
             'interceptors'  => [
-                'preExtract'    => 'preExtractMethodName'
+                'preExtract'    =>  ['method' => 'preExtractMethodName']
             ]
         ];
     }
@@ -31,7 +31,8 @@ class PreExtract
     {
         return <<<EOF
 interceptors:
-  preExtract: preExtractMethodName
+  preExtract: 
+    method: preExtractMethodName
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/PreHydrate.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/PreHydrate.php
@@ -7,7 +7,7 @@ use Kassko\DataMapper\Annotation as DM;
  * Class PreHydrate
  * 
  * @DM\PreHydrate(
- *      class="CustomHydratorClassName",
+ *      class="SomeClass",
  *      method="preHydrateMethodName"
  * )
  */
@@ -20,7 +20,7 @@ class PreHydrate
     {
         return [
             'interceptors'  => [
-                'preHydrate'    => 'preHydrateMethodName'
+                'preHydrate'    => ['class' => 'SomeClass', 'method' => 'preHydrateMethodName']
             ]
         ];
     }
@@ -32,7 +32,9 @@ class PreHydrate
     {
         return <<<EOF
 interceptors:
-  preHydrate: preHydrateMethodName
+  preHydrate: 
+    class: SomeClass
+    method: preHydrateMethodName
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/Provider.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/Provider.php
@@ -42,18 +42,8 @@ class Provider
                         'exceptionClass'      => '\RuntimeException',
                         'badReturnValue'      => 'emptyString',
                         'fallbackSourceId'    => 'firstFieldFallbackSourceId',
-                        'preprocessor'        => [
-                            'class'  => '##this',
-                            'method' => 'fooPreprocessor',
-                            'args'   => []
-                        ],
-                        'processor'           => [
-                            'class'  => '##this',
-                            'method' => 'barProcessor',
-                            'args'   => []
-                        ],
-                        'preprocessors'       => [],
-                        'processors'          => [],
+                        'preprocessor'        => ['method' => 'fooPreprocessor'],
+                        'processor'           => ['method' => 'barProcessor'],
                         'class'               => '\stdClass',
                         'method'              => 'someMethod',
                         'args'                => ['argument#1', 'argument#2']
@@ -82,15 +72,9 @@ fields:
       badReturnValue: emptyString
       fallbackSourceId: firstFieldFallbackSourceId
       preprocessor:
-        class: "##this"
         method: fooPreprocessor
-        args: []
       processor:
-        class: "##this"
         method: barProcessor
-        args: []
-      preprocessors: []
-      processors: []
       class: "\\\stdClass"
       method: someMethod
       args: [argument#1, argument#2]

--- a/tests/ClassMetadataLoader/Fixture/Metadata/ProvidersStoreMultiplesDepends.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/ProvidersStoreMultiplesDepends.php
@@ -24,16 +24,7 @@ class ProvidersStoreMultiplesDepends
                     'name'      => 'mockFieldName',
                     'provider'  => [
                         'id'    => 'personSource',
-                        'class' => 'class',
-                        'method'=> 'method',
-                        'args'  => ['arg#1'],
-                        'lazyLoading' => true,
-                        'supplySeveralFields' => true,
                         'depends' => ['#dependsFirst', '#dependsSecond', '#dependsThird'],
-                        'onFail' => 'checkException',
-                        'exceptionClass' => '\RuntimeException',
-                        'badReturnValue' => 'emptyArray',
-                        'fallbackSourceId' => 'fallbackSourceId#1'
                     ]
                 ]
             ]
@@ -51,16 +42,7 @@ fields:
     name: mockFieldName
     provider:
       id: personSource
-      class: class
-      method: method
-      args: [arg#1]
-      lazyLoading: true
-      supplySeveralFields: true
       depends: [#dependsFirst, #dependsSecond, #dependsThird]
-      onFail: checkException
-      exceptionClass: "\\\RuntimeException"
-      badReturnValue: emptyArray
-      fallbackSourceId: fallbackSourceId#1
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/ProvidersStoreMultiplesProcessors.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/ProvidersStoreMultiplesProcessors.php
@@ -32,43 +32,13 @@ class ProvidersStoreMultiplesProcessors
                     'name'     => 'mockFieldName',
                     'provider' => [
                         'id'                  => 'personSource',
-                        'class'               => 'class',
-                        'method'              => 'method',
-                        'args'                => ['arg#1'],
-                        'lazyLoading'         => true,
-                        'supplySeveralFields' => true,
-                        'depends'             => [],
-                        'onFail'              => 'checkException',
-                        'exceptionClass'      => '\RuntimeException',
-                        'badReturnValue'      => 'emptyArray',
-                        'fallbackSourceId'    => 'fallbackSourceId#1',
                         'preprocessors'       => [
-                            'items' => [
-                                [
-                                    'method' => 'somePrepocessorA',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ],
-                                [
-                                    'method' => 'somePrepocessorB',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ]
-                            ]
+                          ['method' => 'somePrepocessorA'],
+                          ['method' => 'somePrepocessorB']
                         ],
                         'processors'          => [
-                            'items' => [
-                                [
-                                    'method' => 'someProcessorA',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ],
-                                [
-                                    'method' => 'someProcessorB',
-                                    'class'  => '##this',
-                                    'args'   => []
-                                ]
-                            ]
+                          ['method' => 'someProcessorA'],
+                          ['method' => 'someProcessorB']
                         ]
                     ]
                 ]
@@ -87,32 +57,12 @@ fields:
     name: mockFieldName
     provider:
       id: personSource
-      class: class
-      method: method
-      args: [arg#1]
-      lazyLoading: true
-      supplySeveralFields: true
-      depends: []
-      onFail: checkException
-      exceptionClass: "\\\RuntimeException"
-      badReturnValue: emptyArray
-      fallbackSourceId: fallbackSourceId#1
       preprocessors:
-        items:
-          - method: somePrepocessorA
-            class: "##this"
-            args: []
-          - method: somePrepocessorB
-            class: "##this"
-            args: []
+        - method: somePrepocessorA
+        - method: somePrepocessorB
       processors:
-        items:
-          - method: someProcessorA
-            class: "##this"
-            args: []
-          - method: someProcessorB
-            class: "##this"
-            args: []
+        - method: someProcessorA
+        - method: someProcessorB
 EOF;
     }
 }

--- a/tests/ClassMetadataLoader/Fixture/Metadata/ToExclude.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/ToExclude.php
@@ -3,10 +3,10 @@ namespace Kassko\DataMapperTest\ClassMetadataLoader\Fixture\Metadata;
 
 use Kassko\DataMapper\Annotation as DM;
 
-class Exclude
+class ToExclude
 {
     /**
-     * @DM\Exclude
+     * @DM\ToExclude
      */
     protected $excludedField;
 
@@ -21,7 +21,7 @@ class Exclude
     public static function loadInnerPhpMetadata()
     {
         return [
-            'exclude' => [
+            'fieldsToExclude' => [
                 'excludedField'
             ],
             'fields'  => [

--- a/tests/ClassMetadataLoader/Fixture/Metadata/ToInclude.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/ToInclude.php
@@ -3,12 +3,15 @@ namespace Kassko\DataMapperTest\ClassMetadataLoader\Fixture\Metadata;
 
 use Kassko\DataMapper\Annotation as DM;
 
-class Exclude
+/**
+ * @DM\Object(fieldExclusionPolicy="exclude_all")
+ */
+class ToInclude
 {
     /**
-     * @DM\Exclude
+     * @DM\ToInclude
      */
-    protected $excludedField;
+    protected $includedField;
 
     /**
      * @DM\Field
@@ -21,12 +24,13 @@ class Exclude
     public static function loadInnerPhpMetadata()
     {
         return [
-            'exclude' => [
-                'excludedField'
+            'fieldExclusionPolicy' => 'exclude_all',
+            'fieldsToInclude' => [
+                'includedField'
             ],
             'fields'  => [
-                'excludedField' => [
-                    'name'     => 'excludedField'
+                'includedField' => [
+                    'name'     => 'includedField'
                 ],
                 'field'         => [
                     'name'     => 'field'
@@ -41,10 +45,12 @@ class Exclude
     public static function loadInnerYamlMetadata()
     {
         return <<<EOF
-exclude: [excludedField] # Test if the deprecated key "exclude" (now "fieldsToExclude") still works.
+object:        
+  fieldExclusionPolicy: exclude_all # Test if the deprecated key "object.fieldExclusionPolicy" (now "fieldExclusionPolicy") still works.       
+fieldsToInclude: [includedField]
 fields:
-  excludedField:
-    name: excludedField
+  includedField:
+    name: includedField
   field:
     name: field
 EOF;

--- a/tests/ClassMetadataLoader/Fixture/Metadata/Variables.php
+++ b/tests/ClassMetadataLoader/Fixture/Metadata/Variables.php
@@ -1,0 +1,47 @@
+<?php
+namespace Kassko\DataMapperTest\ClassMetadataLoader\Fixture\Metadata;
+
+use Kassko\DataMapper\Annotation as DM;
+
+class Variables
+{
+    /**
+     * @DM\Variables({"var_a" = "foo", "var_b" = "123"})
+     */
+    protected $firstField;
+
+    protected $secondField;
+
+    /**
+     * @return array
+     */
+    public static function loadInnerPhpMetadata()
+    {
+        return [
+            'fields' => [
+                'firstField' => [
+                    'variables' => [
+                        'var_a' => 'foo',
+                        'var_b' => '123'
+                    ]
+                ],
+                'secondField'
+            ]
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public static function loadInnerYamlMetadata()
+    {
+        return <<<EOF
+fields:
+    firstField:
+        variables:
+            var_a: foo
+            var_b: 123
+    secondField: ~
+EOF;
+    }
+}

--- a/tests/ClassMetadataLoader/KeysConfigurationTest.php
+++ b/tests/ClassMetadataLoader/KeysConfigurationTest.php
@@ -1,0 +1,190 @@
+<?php
+namespace Kassko\DataMapperTest\ClassMetadataLoader;
+
+use Kassko\DataMapper\ClassMetadataLoader\ArrayLoader;
+use Kassko\DataMapper\ClassMetadataLoader\KeysConfiguration;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * Class KeysConfigurationTest
+ * 
+ * @author kko
+ */
+class KeysConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @dataProvider someDataProvider
+     */
+    public function one($data)
+    {
+        //$data = ['root' => $data];
+
+        //ArrayLoader::normalize($data);
+
+        $this->assertTrue(true);
+    }
+
+    public function someDataProvider()
+    {
+        return [
+            [
+                [
+                    'fields' => ['fieldOne' => null]
+                ]
+            ],
+        ];
+        return [
+            [[]],
+            [
+                [
+                    'fields' => ['fieldOne' => []]
+                ]
+            ],
+            [
+                [
+                    'fields' => ['fieldOne' => ['name' => 'foo']]
+                ]
+            ],
+            [
+                [
+                    'fields' => ['fieldOne' => ['name' => 'foo'], ['dataSource' => []]]
+                ]
+            ],
+            [
+                [
+                    'object'    => 
+                    [
+                        'fieldExclusionPolicy'  => 'exclude_all',
+                        'providerClass'         => 'testProviderClass',
+                        'readDateConverter'     => 'testReadDateConverter',
+                        'writeDateConverter'    => 'testWriteDateConverter',
+                        'propertyAccessStrategy'=> true,
+                        'fieldMappingExtensionClass' => 'testFieldMappingExtensionClass',
+                        'classMappingExtensionClass' => 'testClassMappingExtensionClass',
+
+                        'dataSourcesStore'    => 
+                        [
+                            [
+                                'id'=> 'personSource',
+                                'class'=> 'Kassko\Sample\PersonDataSource',
+                                'method'=> 'getData',
+                                'args' => ['#id'],
+                                'lazyLoading' => true,
+                                'supplySeveralFields' => true,
+                                'onFail'    => 'checkException',
+                                'exceptionClass' => '\RuntimeException',
+                                'badReturnValue' => 'emptyString',
+                                'fallbackSourceId' => 'testFallbackSourceId',
+                                'depends' => ['#dependsFirst'],
+                                'preprocessor' => [
+                                    'class' => '',
+                                    'method' => 'somePreprocessor',
+                                    'args' => []
+                                ],
+                                'processor' => [
+                                    'class' => '',
+                                    'method' => 'someProcessor',
+                                    'args' => []
+                                ],
+                                'preprocessors'       => [//todo: normalize to remove dimension "items" in under preprocessors
+                                    [
+                                        'method' => 'somePreprocessorA',
+                                        'class'  => '##this',
+                                        'args'   => []
+                                    ],
+                                    [
+                                        'method' => 'somePreprocessorB',
+                                        'class'  => '##this',
+                                        'args'   => []
+                                    ]
+                                ],
+                                'processors'          => [//todo: idem
+                                    [
+                                        'method' => 'someProcessorA',
+                                        'class'  => '##this',
+                                        'args'   => []
+                                    ],
+                                    [
+                                        'method' => 'someProcessorB',
+                                        'class'  => '##this',
+                                        'args'   => []
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'fields'    => [
+                        'firstField'    => [
+                            'name'      => 'firstField',
+                            'getter'    => ['name' => 'getterName'],
+                        ],
+                        'secondField'    => [
+                            'name'      => 'secondField',
+                            'getter'    => ['prefix' => 'is'],
+                        ],
+                        'fieldOne'  => [
+                            'name'                       => 'FirstField',
+                            'type'                       => 'string',
+                            'class'                      => 'stdClass',
+                            'readConverter'              => 'readConvertFirstField',
+                            'writeConverter'             => 'writeConvertFirstField',
+                            'fieldMappingExtensionClass' => 'ExtensionClass',
+                        ],
+                        'fieldTwo'  => [
+                            'name'                       => 'SecondField',
+                            'type'                       => 'integer',
+                            'class'                      => '\DateTime',
+                            'readDateConverter'          => 'readDateConvertSecondField',
+                            'writeDateConverter'         => 'writeDateConvertSecondField',
+                            'fieldMappingExtensionClass' => 'ExtensionClass',
+                            'defaultValue'               => 12
+                        ],
+                        'dateField' => [
+                            'name'                       => 'DateField',
+                            'type'                       => 'date'
+                        ]
+                    ],
+                    'include' => [
+                        'includedField'
+                    ],
+                    'exclude' => [
+                        'excludedField'
+                    ],
+                    'refDefaultSource' => 'refDefaultSourceId',
+                    'listeners' => [
+                        'preHydrate' => ['class' => 'SomeClass', 'method' => 'preHydrateMethodName'],                
+                        'postHydrate' => 
+                        [
+                            ['class' => 'SomeClass', 'method' => 'postHydrateMethodName'],
+                            ['class' => 'SomeClassB', 'method' => 'postHydrateMethodName'],
+                        ], 
+                        'preExtract' => ['class' => 'SomeClass', 'method' => 'preExtractMethodName', 'args' => 'foo'],
+                        'postExtract' => ['class' => 'SomeClass', 'method' => 'postExtractMethodName', 'args' => ['foo', '#bar']],
+                    ],
+                    'objectListeners'   => ['SomeListenerAClass', 'SomeListenerBClass'],
+                    'config' => [
+                        'firstField'    => [
+                            'class' => '\ValueObjectClass',
+                            'mappingResourceName' => 'valueObjectResourceName',
+                            'mappingResourcePath' => 'valueObjectResourcePath',
+                            'mappingResourceType' => 'valueObjectResourceType'
+                        ]
+                    ],
+                    'valueObject' => [
+                        'firstField'    => [
+                            'class' => '\ValueObjectClass',
+                            'mappingResourceName' => 'valueObjectResourceName',
+                            'mappingResourcePath' => 'valueObjectResourcePath',
+                            'mappingResourceType' => 'valueObjectResourceType'
+                        ]
+                    ],
+                    'id'      => 'firstField',
+                    'idComposite'   => ['firstField', 'secondField'],
+                    'transient' => ['firstField'],
+                    'version'   => 'firstField',
+                ]
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Ensure that Annotation, Yaml and Php loaders have the same behaviour.

That is to say:
- [X] For Yaml and Php loaders, allows not to specify key config instead of specified them with value null.
- [X] Ensure that key config defaults values are the same for each loaders.
- [X] Ensure that all key config are handled by each loaders.
- [X] Ensure that all loaders have tests for each key config.
- [x] Ensure that all loaders have documentation for each key config.