### PR TITLE
PR #7: Retro documentation: Implement PSR-11 interface and registry pattern for LazyLoader

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,9 +3,11 @@ FROM php:8.2-cli
 # Outils de base utiles en dev (rien de spécifique au projet)
 RUN apt-get update && apt-get install -y \
     git \
+    git-lfs \
     unzip \
     zip \
     ca-certificates \
+    && git lfs install \
     && rm -rf /var/lib/apt/lists/*
 
 # Installer Composer (officiel, stable)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.2-cli
+
+# Outils de base utiles en dev (rien de spécifique au projet)
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    zip \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Installer Composer (officiel, stable)
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Dossier de travail utilisé par Codespaces
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "PHP 8.2 Devcontainer",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "root",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client"
+      ]
+    }
+  },
+  "postCreateCommand": "php -v && composer --version"
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        php-version: ['8.0', '8.1', '8.2', '8.3']
+    
+    name: PHP ${{ matrix.php-version }}
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+      
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+      
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+      
+      - name: Run test suite
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     
+    permissions:
+      contents: read
+    
     strategy:
       matrix:
         php-version: ['8.0', '8.1', '8.2', '8.3']

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/composer.lock
+/.phpunit.cache/
+/.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /.phpunit.cache/
 /.phpunit.result.cache
+/example.php

--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,0 +1,90 @@
+# Library Name
+
+A general-purpose data access and mapping library designed to handle
+multiple heterogeneous data sources with a consistent programming model.
+
+## Overview
+
+Library Name is an open-source library that provides a unified approach to:
+
+- managing multiple data sources (SQL, NoSQL, APIs, files, etc.)
+- mapping data to domain models
+- controlling hydration strategies
+- reducing coupling between data storage and application logic
+
+The library focuses on technical concerns only and does not embed
+business or domain-specific logic.
+
+## Origin
+
+This project was initiated as a personal open-source initiative,
+developed independently and outside of any professional assignment.
+
+It is not affiliated with, nor owned by, any organization.
+
+[Project background and philosophy](./ABOUT.md)
+
+## Core Concepts
+
+- **Source abstraction**  
+  Access heterogeneous data sources through a common interface.
+
+- **Explicit mapping**  
+  Mapping rules are explicit, configurable, and decoupled from storage concerns.
+
+- **Controlled hydration**  
+  Fine-grained control over when and how objects are hydrated.
+
+- **Composable architecture**  
+  Components can be combined or replaced to fit different application needs.
+
+## Typical Use Cases
+
+- applications with multiple data sources
+- gradual migration between storage technologies
+- read/write model separation
+- systems requiring fine control over data loading
+- platform or infrastructure-level tooling
+
+## Non-Goals
+
+Library Name does not aim to:
+
+- provide business or industry-specific features
+- enforce a specific architectural style
+- replace full-featured ORMs in all scenarios
+- embed domain or application logic
+
+## Installation
+
+(installation instructions here)
+
+## Basic Usage
+
+(basic usage examples here)
+
+## License & Authorship
+
+Library Name is authored and maintained by **Kassko**.
+
+It is released under the **[License Name]** license.  
+See the [LICENSE](./LICENSE) file for details.
+
+Unless explicitly stated otherwise, no rights are granted beyond those
+defined by the license.
+
+## Contributions
+
+Contributions are welcome.
+
+By contributing, you agree that your contributions are licensed under
+the same terms as the project.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
+
+## Disclaimer
+
+This project is provided "as is", without warranty of any kind.
+
+Any references to systems, organizations, or use cases are purely
+illustrative and do not imply any formal relationship.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Thank you for your interest in contributing to this project.
+
+Contribution guidelines are not yet finalized and will be added soon.
+In the meantime, feel free to open issues to discuss ideas or report bugs.
+
+Thank you for your patience.

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,338 @@
+# DataMapper - New Features Examples
+
+This document demonstrates the new features added to the data-mapper library.
+
+## 1. DataSourcesStore Attribute
+
+Group multiple DataSource definitions in one place at the class level:
+
+```php
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+#[DataSourcesStore([
+    new DataSource(
+        id: 'personSource',
+        class: PersonDataSource::class,
+        method: 'getData',
+        args: ['#id'],
+        supplySeveralFields: true
+    ),
+    new DataSource(
+        id: 'carSource',
+        class: CarRepository::class,
+        method: 'find',
+        args: ["expr(source('personSource')['car_id'])"]
+    )
+])]
+class Person
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $name = null;
+
+    #[DataSourceRef(id: 'carSource')]
+    private ?Car $car = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): ?string
+    {
+        $this->loadProperty('name');
+        return $this->name;
+    }
+
+    public function getCar(): ?Car
+    {
+        $this->loadProperty('car');
+        return $this->car;
+    }
+}
+```
+
+## 2. DataSourceRef Attribute
+
+Reference a DataSource by its id from the store:
+
+```php
+#[DataSourceRef(id: 'personSource')]
+private ?string $name = null;
+```
+
+Instead of repeating the DataSource configuration on each property, you define it once in the store and reference it by id.
+
+## 3. Field Attribute
+
+Map a property to a different key name in the returned data:
+
+```php
+use Kassko\DataMapper\Attribute\Field;
+
+#[DataSourceRef(id: 'personSource')]
+#[Field(name: 'first_name')]
+private ?string $firstName = null;
+```
+
+When PersonDataSource returns `['first_name' => 'John', ...]`, the value 'John' will be mapped to the `$firstName` property.
+
+## 4. supplySeveralFields Option
+
+Control how DataSources hydrate properties:
+
+### supplySeveralFields = false (default)
+
+Each property triggers a separate call, or properties with identical signatures share a single call:
+
+```php
+class PersonDataSource
+{
+    public function getData(int $id): array
+    {
+        return ['name' => 'John', 'email' => 'john@example.com'];
+    }
+}
+
+class Person
+{
+    #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+    private ?string $name = null;
+
+    #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+    private ?string $email = null;
+}
+```
+
+Both properties have the same signature, so only ONE call to `getData()` is made, and both are hydrated.
+
+### supplySeveralFields = true
+
+ALL properties with `#[DataSourceRef]` pointing to this source are hydrated in a SINGLE call:
+
+```php
+#[DataSourcesStore([
+    new DataSource(
+        id: 'personSource',
+        class: PersonDataSource::class,
+        method: 'getData',
+        args: ['#id'],
+        supplySeveralFields: true  // ← Key difference
+    )
+])]
+class Person
+{
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $name = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    #[Field(name: 'first_name')]
+    private ?string $firstName = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $email = null;
+
+    // This property is NOT hydrated (no DataSourceRef)
+    private ?int $age = null;
+}
+```
+
+When ANY of the properties with `DataSourceRef(id: 'personSource')` is accessed, the DataSource is called ONCE, and ALL three properties are hydrated simultaneously.
+
+## 5. Expression Language
+
+### Simple Property References
+
+Use `#propertyName` to reference property values:
+
+```php
+new DataSource(
+    id: 'personSource',
+    class: PersonDataSource::class,
+    method: 'getData',
+    args: ['#id']  // Passes the value of $this->id
+)
+```
+
+### Advanced Expressions with expr()
+
+Use `expr(source('id')['key'])` to execute a DataSource and extract values:
+
+```php
+new DataSource(
+    id: 'carSource',
+    class: CarRepository::class,
+    method: 'find',
+    args: ["expr(source('personSource')['car_id'])"]
+    // 1. Executes personSource DataSource
+    // 2. Extracts the 'car_id' key from the result
+    // 3. Passes it to CarRepository::find()
+)
+```
+
+### Dependency Chain Resolution
+
+The expression language automatically resolves dependencies:
+
+```php
+$person = new Person(1);
+$dataMapper->prepare($person);
+
+// Accessing car triggers:
+// 1. personSource is executed (because car expression depends on it)
+// 2. car_id is extracted from personSource result
+// 3. carSource is executed with car_id
+// 4. Car is loaded and returned
+$car = $person->getCar();
+
+// Now accessing name doesn't trigger another call
+// because personSource was already loaded when resolving car
+$name = $person->getName();
+```
+
+### Result Caching
+
+DataSource results are automatically cached per object to avoid duplicate executions:
+
+```php
+$person = new Person(1);
+$dataMapper->prepare($person);
+
+$car = $person->getCar();        // Loads personSource + carSource
+$name = $person->getName();      // Uses cached personSource result
+$firstName = $person->getFirstName();  // Uses cached personSource result
+```
+
+## Complete Example
+
+```php
+<?php
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\Field;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+// Data Sources
+class PersonDataSource
+{
+    public function getData(int $id): array
+    {
+        return [
+            'name' => 'John Doe',
+            'first_name' => 'John',
+            'email' => 'john@example.com',
+            'car_id' => 100
+        ];
+    }
+}
+
+class CarRepository
+{
+    public function find(int $id): ?Car
+    {
+        return new Car(100, 'Toyota', 'Camry');
+    }
+}
+
+class Car
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $brand,
+        public readonly string $model
+    ) {}
+}
+
+// Entity with DataSourcesStore
+#[DataSourcesStore([
+    new DataSource(
+        id: 'personSource',
+        class: PersonDataSource::class,
+        method: 'getData',
+        args: ['#id'],
+        supplySeveralFields: true
+    ),
+    new DataSource(
+        id: 'carSource',
+        class: CarRepository::class,
+        method: 'find',
+        args: ["expr(source('personSource')['car_id'])"]
+    )
+])]
+class Person
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSourceRef(id: 'personSource')]
+    #[Field(name: 'first_name')]
+    private ?string $firstName = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $name = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $email = null;
+
+    #[DataSourceRef(id: 'carSource')]
+    private ?Car $car = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getFirstName(): ?string
+    {
+        $this->loadProperty('firstName');
+        return $this->firstName;
+    }
+
+    public function getName(): ?string
+    {
+        $this->loadProperty('name');
+        return $this->name;
+    }
+
+    public function getEmail(): ?string
+    {
+        $this->loadProperty('email');
+        return $this->email;
+    }
+
+    public function getCar(): ?Car
+    {
+        $this->loadProperty('car');
+        return $this->car;
+    }
+}
+
+// Usage
+$dataMapper = new DataMapper();
+$person = new Person(1);
+$dataMapper->prepare($person);
+
+echo $person->getFirstName(); // "John" (loaded from 'first_name' key)
+echo $person->getName();      // "John Doe"
+echo $person->getEmail();     // "john@example.com"
+$car = $person->getCar();     // Car object with Toyota Camry
+```
+
+## Key Benefits
+
+1. **Cleaner Code**: Define DataSources once, reference by id
+2. **Performance**: supplySeveralFields reduces database calls
+3. **Flexibility**: Field mapping allows adapting to different data formats
+4. **Power**: Expression language enables complex dependency chains
+5. **Efficiency**: Automatic caching prevents duplicate executions
+6. **Backward Compatible**: All existing code continues to work

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,170 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License.
+      Subject to the terms and conditions of this License, each Contributor
+      hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+      royalty-free, irrevocable copyright license to reproduce, prepare
+      Derivative Works of, publicly display, publicly perform, sublicense,
+      and distribute the Work and such Derivative Works in Source or Object
+      form.
+
+   3. Grant of Patent License.
+      Subject to the terms and conditions of this License, each Contributor
+      hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+      royalty-free, irrevocable (except as stated in this section) patent
+      license to make, have made, use, offer to sell, sell, import, and
+      otherwise transfer the Work, where such license applies only to those
+      patent claims licensable by such Contributor that are necessarily
+      infringed by their Contribution(s) alone or by combination of their
+      Contribution(s) with the Work to which such Contribution(s) was
+      submitted. If You institute patent litigation against any entity
+      (including a cross-claim or counterclaim in a lawsuit) alleging that
+      the Work or a Contribution incorporated within the Work constitutes
+      direct or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate as of
+      the date such litigation is filed.
+
+   4. Redistribution.
+      You may reproduce and distribute copies of the Work or Derivative
+      Works thereof in any medium, with or without modifications, and in
+      Source or Object form, provided that You meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+   5. Submission of Contributions.
+      Unless You explicitly state otherwise, any Contribution intentionally
+      submitted for inclusion in the Work by You to the Licensor shall be
+      under the terms and conditions of this License, without any additional
+      terms or conditions.
+
+   6. Trademarks.
+      This License does not grant permission to use the trade names,
+      trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty.
+      Unless required by applicable law or agreed to in writing, Licensor
+      provides the Work (and each Contributor provides its Contributions)
+      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+      either express or implied, including, without limitation, any
+      warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY,
+      or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for
+      determining the appropriateness of using or redistributing the Work
+      and assume any risks associated with Your exercise of permissions
+      under this License.
+
+   8. Limitation of Liability.
+      In no event and under no legal theory, whether in tort (including
+      negligence), contract, or otherwise, unless required by applicable law
+      (such as deliberate and grossly negligent acts) or agreed to in writing,
+      shall any Contributor be liable to You for damages, including any
+      direct, indirect, special, incidental, or consequential damages of any
+      character arising as a result of this License or out of the use or
+      inability to use the Work (including but not limited to damages for
+      loss of goodwill, work stoppage, computer failure or malfunction, or
+      any and all other commercial damages or losses), even if such
+      Contributor has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability.
+      While redistributing the Work or Derivative Works thereof, You may
+      choose to offer, and charge a fee for, acceptance of support, warranty,
+      indemnity, or other liability obligations and/or rights consistent with
+      this License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify, defend, and
+      hold each Contributor harmless for any liability incurred by, or claims
+      asserted against, such Contributor by reason of your accepting any such
+      warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,6 @@
+Library Name
+
+Copyright (c) 2025 Kassko
+
+This project is an independent open-source initiative.
+It is not affiliated with or owned by any organization.

--- a/README.md
+++ b/README.md
@@ -150,4 +150,4 @@ vendor/bin/phpunit
 
 ## License
 
-MIT
+Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,145 @@
-# data-mapper-experimental
+# PHP 8 Data Mapper Library
+
+A minimal PHP 8 data-mapper library with lazy loading, attributes, and PSR-11 container integration.
+
+## Features
+
+- **PHP 8 Attributes**: Use native PHP 8 attributes for metadata (no external annotation library)
+- **Lazy Loading**: Properties are loaded on-demand when accessed
+- **Single Call Optimization**: Properties sharing the same DataSource configuration are loaded together in one call
+- **Service Locator Pattern**: Resolve DataSources via PSR-11 ContainerInterface or direct instantiation
+- **WeakMap Registry**: Efficient memory management with PHP 8's WeakMap for tracking loaded properties
+
+## Requirements
+
+- PHP >= 8.0
+- PSR-11 Container Interface
+
+## Installation
+
+```bash
+composer require kassko/data-mapper-experimental
+```
+
+## Usage
+
+### Basic Example
+
+```php
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Kassko\DataMapper\DataMapper;
+
+// Define your entity
+class Person
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+    private ?string $name = null;
+
+    #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+    private ?string $email = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        $this->loadProperty('name');
+        return $this->name;
+    }
+
+    public function getEmail(): ?string
+    {
+        $this->loadProperty('email');
+        return $this->email;
+    }
+}
+
+// Define your data source
+class PersonDataSource
+{
+    public function getData(int $id): array
+    {
+        return match($id) {
+            1 => ['name' => 'foo', 'email' => 'foo@aaa.com'],
+            2 => ['name' => 'bar', 'email' => 'bar@bbb.com'],
+            default => ['name' => 'baz', 'email' => 'baz@ccc.com'],
+        };
+    }
+}
+
+// Use the data mapper
+$dataMapper = new DataMapper();
+$person = new Person(1);
+$dataMapper->prepare($person);
+
+echo $person->getName();  // Output: foo (loads both name and email in one call)
+echo $person->getEmail(); // Output: foo@aaa.com (already loaded, no additional call)
+```
+
+### Service Locator Pattern
+
+You can use the `@` prefix to resolve DataSources from a PSR-11 container:
+
+```php
+use Psr\Container\ContainerInterface;
+
+// Configure your container
+$container = /* your PSR-11 container */;
+
+// Use service identifier in the attribute
+class Person
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSource(class: '@person.data_source', method: 'getData', args: ['#id'])]
+    private ?string $name = null;
+
+    // ... rest of the class
+}
+
+// Pass container to DataMapper
+$dataMapper = new DataMapper($container);
+$person = new Person(1);
+$dataMapper->prepare($person);
+```
+
+### Property References
+
+The `args` parameter in the `#[DataSource]` attribute can reference object properties using the `#` prefix:
+
+```php
+#[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id', 'some-static-value'])]
+private ?string $name = null;
+```
+
+## How It Works
+
+1. **Selective Hydration**: Only properties with the `#[DataSource]` attribute are hydrated
+2. **Lazy Loading**: Properties are loaded when `loadProperty()` is called (typically in getters)
+3. **Single Call Optimization**: Properties with identical DataSource signatures (class + method + resolved args) are loaded together
+4. **Registry**: A WeakMap tracks which properties have been loaded to avoid duplicate calls
+
+## Testing
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A minimal PHP 8 data-mapper library with lazy loading, attributes, and PSR-11 container integration.
 
+## Origin
+
+This project was initiated as a personal open-source initiative, developed independently and outside of any professional assignment.
+
+It is not affiliated with, nor owned by, any organization.
+
+[Read more about the project background](./ABOUT.md)
+
 ## Features
 
 - **PHP 8 Attributes**: Use native PHP 8 attributes for metadata (no external annotation library)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "kassko/data-mapper-experimental",
     "description": "A minimal PHP 8 data-mapper library with attributes and lazy loading",
     "type": "library",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "require": {
         "php": ">=8.0",
         "psr/container": "^1.1|^2.0"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "kassko/data-mapper-experimental",
+    "description": "A minimal PHP 8 data-mapper library with attributes and lazy loading",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.0",
+        "psr/container": "^1.1|^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Kassko\\DataMapper\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Kassko\\DataMapper\\Tests\\": "tests/",
+            "Kassko\\Sample\\": "tests/Fixtures/"
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/ArrayServiceLocator.php
+++ b/src/ArrayServiceLocator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper;
+
+final class ArrayServiceLocator implements ServiceLocatorInterface
+{
+    /**
+     * @param array<string, string> $map Keys to service IDs or class names
+     */
+    public function __construct(
+        private array $map
+    ) {}
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->map);
+    }
+
+    public function get(string $key): string
+    {
+        if (!$this->has($key)) {
+            throw new \InvalidArgumentException(sprintf('Key "%s" not found in locator', $key));
+        }
+        return $this->map[$key];
+    }
+}

--- a/src/ArrayServiceLocator.php
+++ b/src/ArrayServiceLocator.php
@@ -4,25 +4,27 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper;
 
+use Psr\Container\NotFoundExceptionInterface;
+
 final class ArrayServiceLocator implements ServiceLocatorInterface
 {
     /**
      * @param array<string, string> $map Keys to service IDs or class names
      */
     public function __construct(
-        private array $map
+        private array $map = []
     ) {}
 
-    public function has(string $key): bool
+    public function has(string $id): bool
     {
-        return array_key_exists($key, $this->map);
+        return array_key_exists($id, $this->map);
     }
 
-    public function get(string $key): string
+    public function get(string $id): mixed
     {
-        if (!$this->has($key)) {
-            throw new \InvalidArgumentException(sprintf('Key "%s" not found in locator', $key));
+        if (!$this->has($id)) {
+            throw new class("Key \"$id\" not found in locator") extends \Exception implements NotFoundExceptionInterface {};
         }
-        return $this->map[$key];
+        return $this->map[$id];
     }
 }

--- a/src/ArrayServiceLocator.php
+++ b/src/ArrayServiceLocator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper;
 
-use Psr\Container\NotFoundExceptionInterface;
+use Kassko\DataMapper\Exception\NotFoundException;
 
 final class ArrayServiceLocator implements ServiceLocatorInterface
 {
@@ -23,8 +23,9 @@ final class ArrayServiceLocator implements ServiceLocatorInterface
     public function get(string $id): mixed
     {
         if (!$this->has($id)) {
-            throw new class("Key \"$id\" not found in locator") extends \Exception implements NotFoundExceptionInterface {};
+            throw new NotFoundException("Key \"$id\" not found in locator");
         }
         return $this->map[$id];
     }
 }
+

--- a/src/Attribute/DataSource.php
+++ b/src/Attribute/DataSource.php
@@ -10,14 +10,18 @@ use Attribute;
 class DataSource
 {
     /**
+     * @param string|null $id Optional identifier for referencing from DataSourcesStore
      * @param string $class The DataSource class name or service identifier (prefixed with @)
      * @param string $method The method to call on the DataSource
      * @param array $args Arguments to pass to the method (can include property references like #propertyName)
+     * @param bool $supplySeveralFields Whether this DataSource returns an associative array for multiple fields (default: false)
      */
     public function __construct(
         public readonly string $class,
         public readonly string $method,
-        public readonly array $args = []
+        public readonly array $args = [],
+        public readonly ?string $id = null,
+        public readonly bool $supplySeveralFields = false
     ) {
     }
 }

--- a/src/Attribute/DataSource.php
+++ b/src/Attribute/DataSource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class DataSource
+{
+    /**
+     * @param string $class The DataSource class name or service identifier (prefixed with @)
+     * @param string $method The method to call on the DataSource
+     * @param array $args Arguments to pass to the method (can include property references like #propertyName)
+     */
+    public function __construct(
+        public readonly string $class,
+        public readonly string $method,
+        public readonly array $args = []
+    ) {
+    }
+}

--- a/src/Attribute/DataSourceRef.php
+++ b/src/Attribute/DataSourceRef.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class DataSourceRef
+{
+    public readonly string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Attribute/DataSourcesStore.php
+++ b/src/Attribute/DataSourcesStore.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class DataSourcesStore
+{
+    /** @var DataSource[] */
+    public readonly array $sources;
+
+    public function __construct(array $sources = [])
+    {
+        $this->sources = $sources;
+    }
+}

--- a/src/Attribute/Field.php
+++ b/src/Attribute/Field.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Field
+{
+    public readonly ?string $name;
+
+    public function __construct(?string $name = null)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper;
+
+use Kassko\DataMapper\LazyLoader\LazyLoader;
+use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Psr\Container\ContainerInterface;
+
+class DataMapper
+{
+    private LazyLoaderInterface $lazyLoader;
+
+    public function __construct(?ContainerInterface $container = null)
+    {
+        $this->lazyLoader = new LazyLoader($container);
+    }
+
+    /**
+     * Prepare an object for lazy loading by injecting the loader
+     *
+     * @param object $object The object to prepare (must use LoadableTrait)
+     */
+    public function prepare(object $object): void
+    {
+        // Check if object uses LoadableTrait
+        if (!method_exists($object, 'setDataMapperLoader')) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Object of class %s must use %s to support lazy loading',
+                    get_class($object),
+                    LoadableTrait::class
+                )
+            );
+        }
+        
+        $object->setDataMapperLoader($this->lazyLoader);
+    }
+}

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Kassko\DataMapper;
 
 use Kassko\DataMapper\LazyLoader\LazyLoader;
-use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
-use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Psr\Container\ContainerInterface;
 
 final class DataMapper
 {
-    private LazyLoaderInterface $lazyLoader;
+    private ServiceResolver $serviceResolver;
 
     /**
      * @param ServiceResolver|ContainerInterface|null $serviceResolverOrContainer
@@ -20,43 +19,24 @@ final class DataMapper
     {
         // Support backward compatibility: allow ContainerInterface or null
         if ($serviceResolverOrContainer instanceof ServiceResolver) {
-            $serviceResolver = $serviceResolverOrContainer;
+            $this->serviceResolver = $serviceResolverOrContainer;
         } elseif ($serviceResolverOrContainer instanceof ContainerInterface || $serviceResolverOrContainer === null) {
             // Backward compatibility: create a ServiceResolver with just the container
-            $serviceResolver = new ServiceResolver($serviceResolverOrContainer, []);
+            $this->serviceResolver = new ServiceResolver($serviceResolverOrContainer, []);
         } else {
             throw new \InvalidArgumentException(
                 'Argument must be ServiceResolver, ContainerInterface, or null'
             );
         }
         
-        $this->lazyLoader = new LazyLoader($serviceResolver);
+        // Register LazyLoader in the registry for backward compatibility
+        $lazyLoader = new LazyLoader($this->serviceResolver);
+        LazyLoaderRegistry::set($lazyLoader);
     }
 
     public function getServiceResolver(): ServiceResolver
     {
-        return $this->lazyLoader->getServiceResolver();
-    }
-
-    /**
-     * Prepare an object for lazy loading by injecting the loader
-     *
-     * @param object $object The object to prepare (must use LoadableTrait)
-     */
-    public function prepare(object $object): void
-    {
-        // Check if object uses LoadableTrait
-        if (!method_exists($object, 'setDataMapperLoader')) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Object of class %s must use %s to support lazy loading',
-                    get_class($object),
-                    LoadableTrait::class
-                )
-            );
-        }
-        
-        $object->setDataMapperLoader($this->lazyLoader);
+        return $this->serviceResolver;
     }
 }
 

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -9,13 +9,33 @@ use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
 use Kassko\DataMapper\ObjectExtension\LoadableTrait;
 use Psr\Container\ContainerInterface;
 
-class DataMapper
+final class DataMapper
 {
     private LazyLoaderInterface $lazyLoader;
 
-    public function __construct(?ContainerInterface $container = null)
+    /**
+     * @param ServiceResolver|ContainerInterface|null $serviceResolverOrContainer
+     */
+    public function __construct(ServiceResolver|ContainerInterface|null $serviceResolverOrContainer = null)
     {
-        $this->lazyLoader = new LazyLoader($container);
+        // Support backward compatibility: allow ContainerInterface or null
+        if ($serviceResolverOrContainer instanceof ServiceResolver) {
+            $serviceResolver = $serviceResolverOrContainer;
+        } elseif ($serviceResolverOrContainer instanceof ContainerInterface || $serviceResolverOrContainer === null) {
+            // Backward compatibility: create a ServiceResolver with just the container
+            $serviceResolver = new ServiceResolver($serviceResolverOrContainer, []);
+        } else {
+            throw new \InvalidArgumentException(
+                'Argument must be ServiceResolver, ContainerInterface, or null'
+            );
+        }
+        
+        $this->lazyLoader = new LazyLoader($serviceResolver);
+    }
+
+    public function getServiceResolver(): ServiceResolver
+    {
+        return $this->lazyLoader->getServiceResolver();
     }
 
     /**
@@ -39,3 +59,4 @@ class DataMapper
         $object->setDataMapperLoader($this->lazyLoader);
     }
 }
+

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -39,4 +39,3 @@ final class DataMapper
         return $this->serviceResolver;
     }
 }
-

--- a/src/DataMapperBuilder.php
+++ b/src/DataMapperBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper;
+
+use Psr\Container\ContainerInterface;
+
+final class DataMapperBuilder
+{
+    private ?ContainerInterface $container = null;
+    
+    /** @var ServiceLocatorInterface[] */
+    private array $locators = [];
+
+    public function setContainer(ContainerInterface $container): self
+    {
+        $this->container = $container;
+        return $this;
+    }
+
+    public function addLocator(ServiceLocatorInterface $locator): self
+    {
+        $this->locators[] = $locator;
+        return $this;
+    }
+
+    public function build(): DataMapper
+    {
+        $serviceResolver = new ServiceResolver($this->container, $this->locators);
+        return new DataMapper($serviceResolver);
+    }
+}

--- a/src/DataMapperBuilder.php
+++ b/src/DataMapperBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper;
 
+use Kassko\DataMapper\LazyLoader\LazyLoader;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Psr\Container\ContainerInterface;
 
 final class DataMapperBuilder
@@ -28,6 +30,11 @@ final class DataMapperBuilder
     public function build(): DataMapper
     {
         $serviceResolver = new ServiceResolver($this->container, $this->locators);
+        $lazyLoader = new LazyLoader($serviceResolver);
+        
+        // Register the LazyLoader globally
+        LazyLoaderRegistry::set($lazyLoader);
+        
         return new DataMapper($serviceResolver);
     }
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Exception;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+class NotFoundException extends \Exception implements NotFoundExceptionInterface
+{
+}

--- a/src/Expression/ExpressionParser.php
+++ b/src/Expression/ExpressionParser.php
@@ -98,7 +98,7 @@ class ExpressionParser
     private function evaluateExpression(string $expression, object $object, callable $propertyLoader)
     {
         // Parse source('id')['key'] or source('id')
-        if (preg_match("/source\('([^']+)'\)(?:\['([^']+)'\])?/", $expression, $matches)) {
+        if (preg_match("/source\('([a-zA-Z0-9_-]+)'\)(?:\['([^']+)'\])?/", $expression, $matches)) {
             $sourceId = $matches[1];
             $key = $matches[2] ?? null;
             

--- a/src/Expression/ExpressionParser.php
+++ b/src/Expression/ExpressionParser.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Expression;
+
+use ReflectionClass;
+
+class ExpressionParser
+{
+    private SourceFunctionProvider $sourceFunctionProvider;
+
+    public function __construct(SourceFunctionProvider $sourceFunctionProvider)
+    {
+        $this->sourceFunctionProvider = $sourceFunctionProvider;
+    }
+
+    /**
+     * Resolve arguments, replacing property references and expressions with actual values
+     *
+     * @param array $args
+     * @param object $object
+     * @param callable $propertyLoader Callback to load a property if needed: function(string $propertyName): void
+     * @return array
+     */
+    public function resolveArgs(array $args, object $object, callable $propertyLoader): array
+    {
+        $resolved = [];
+        
+        foreach ($args as $arg) {
+            $resolved[] = $this->resolveArg($arg, $object, $propertyLoader);
+        }
+        
+        return $resolved;
+    }
+
+    /**
+     * Resolve a single argument
+     *
+     * @param mixed $arg
+     * @param object $object
+     * @param callable $propertyLoader
+     * @return mixed
+     */
+    private function resolveArg($arg, object $object, callable $propertyLoader)
+    {
+        if (!is_string($arg)) {
+            return $arg;
+        }
+
+        // Handle #property syntax
+        if (str_starts_with($arg, '#')) {
+            return $this->resolvePropertyReference($arg, $object, $propertyLoader);
+        }
+
+        // Handle expr(...) syntax
+        if (preg_match('/^expr\((.+)\)$/s', $arg, $matches)) {
+            return $this->evaluateExpression($matches[1], $object, $propertyLoader);
+        }
+
+        // Plain value
+        return $arg;
+    }
+
+    /**
+     * Resolve a property reference like #propertyName
+     *
+     * @param string $reference
+     * @param object $object
+     * @param callable $propertyLoader
+     * @return mixed
+     */
+    private function resolvePropertyReference(string $reference, object $object, callable $propertyLoader)
+    {
+        $propertyName = substr($reference, 1);
+        
+        // Try to load the property first if it needs loading
+        $propertyLoader($propertyName);
+        
+        $reflectionClass = new ReflectionClass($object);
+        
+        if ($reflectionClass->hasProperty($propertyName)) {
+            $property = $reflectionClass->getProperty($propertyName);
+            return $property->getValue($object);
+        }
+        
+        return null;
+    }
+
+    /**
+     * Evaluate an expression like source('personSource')['car_id']
+     *
+     * @param string $expression
+     * @param object $object
+     * @param callable $propertyLoader
+     * @return mixed
+     */
+    private function evaluateExpression(string $expression, object $object, callable $propertyLoader)
+    {
+        // Parse source('id')['key'] or source('id')
+        if (preg_match("/source\('([^']+)'\)(?:\['([^']+)'\])?/", $expression, $matches)) {
+            $sourceId = $matches[1];
+            $key = $matches[2] ?? null;
+            
+            $result = $this->sourceFunctionProvider->getSourceResult($sourceId);
+            
+            if ($key !== null && is_array($result)) {
+                return $result[$key] ?? null;
+            }
+            
+            return $result;
+        }
+        
+        // If we can't parse it, return the original expression
+        return $expression;
+    }
+}

--- a/src/Expression/SourceFunctionProvider.php
+++ b/src/Expression/SourceFunctionProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Expression;
+
+class SourceFunctionProvider
+{
+    /** @var array<string, mixed> Cache of DataSource results by source id */
+    private array $cache = [];
+    
+    /** @var callable Callback to execute a DataSource by id: function(string $sourceId): mixed */
+    private $dataSourceExecutor;
+
+    /**
+     * @param callable $dataSourceExecutor Callback to execute a DataSource: function(string $sourceId): mixed
+     */
+    public function __construct(callable $dataSourceExecutor)
+    {
+        $this->dataSourceExecutor = $dataSourceExecutor;
+    }
+
+    /**
+     * Get the result of a DataSource by its id
+     * Results are cached to avoid duplicate executions
+     *
+     * @param string $sourceId
+     * @return mixed
+     */
+    public function getSourceResult(string $sourceId)
+    {
+        if (!isset($this->cache[$sourceId])) {
+            $this->cache[$sourceId] = ($this->dataSourceExecutor)($sourceId);
+        }
+        
+        return $this->cache[$sourceId];
+    }
+
+    /**
+     * Clear the cache (useful for testing or when processing a new object)
+     */
+    public function clearCache(): void
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * Check if a source has been cached
+     *
+     * @param string $sourceId
+     * @return bool
+     */
+    public function isCached(string $sourceId): bool
+    {
+        return isset($this->cache[$sourceId]);
+    }
+}

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -322,8 +322,10 @@ class LazyLoader implements LazyLoaderInterface
         $dataSourceMap = $this->attributeReader->getDataSourceMap($object);
         
         if (!isset($dataSourceMap[$sourceId])) {
+            // Sanitize sourceId for error message to prevent log injection
+            $sanitizedId = preg_replace('/[^a-zA-Z0-9_-]/', '', $sourceId);
             throw new \RuntimeException(
-                sprintf('DataSource with id "%s" not found in DataSourcesStore', $sourceId)
+                sprintf('DataSource with id "%s" not found in DataSourcesStore', $sanitizedId)
             );
         }
         

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\LazyLoader;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Metadata\AttributeReader;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionProperty;
+use WeakMap;
+
+class LazyLoader implements LazyLoaderInterface
+{
+    /** @var WeakMap<object, array<string, bool>> */
+    private WeakMap $loadedProperties;
+    
+    private AttributeReader $attributeReader;
+    private ?ContainerInterface $container;
+
+    public function __construct(?ContainerInterface $container = null)
+    {
+        $this->loadedProperties = new WeakMap();
+        $this->attributeReader = new AttributeReader();
+        $this->container = $container;
+    }
+
+    /**
+     * Load a property on the given object
+     *
+     * @param object $object The object containing the property
+     * @param string $propertyName The name of the property to load
+     */
+    public function loadProperty(object $object, string $propertyName): void
+    {
+        // Initialize loaded properties registry for this object if needed
+        if (!isset($this->loadedProperties[$object])) {
+            $this->loadedProperties[$object] = [];
+        }
+        
+        // Check if property is already loaded
+        if (isset($this->loadedProperties[$object][$propertyName])) {
+            return;
+        }
+        
+        // Get the property's DataSource attribute
+        $reflectionClass = new ReflectionClass($object);
+        
+        if (!$reflectionClass->hasProperty($propertyName)) {
+            return;
+        }
+        
+        $property = $reflectionClass->getProperty($propertyName);
+        $dataSource = $this->attributeReader->readDataSource($property);
+        
+        if ($dataSource === null) {
+            return;
+        }
+        
+        // Find all properties that share the same DataSource signature
+        $signature = $this->createSignature($dataSource, $object);
+        $propertiesToHydrate = $this->findPropertiesWithSameSignature($object, $signature);
+        
+        // Load data from DataSource
+        $data = $this->loadDataFromSource($dataSource, $object);
+        
+        // Hydrate all properties with the same signature
+        foreach ($propertiesToHydrate as $propName) {
+            $this->hydrateProperty($object, $propName, $data);
+            $this->loadedProperties[$object][$propName] = true;
+        }
+    }
+
+    /**
+     * Create a unique signature for a DataSource configuration
+     *
+     * @param DataSource $dataSource
+     * @param object $object
+     * @return string
+     */
+    private function createSignature(DataSource $dataSource, object $object): string
+    {
+        $resolvedArgs = $this->resolveArgs($dataSource->args, $object);
+        return md5(serialize([
+            'class' => $dataSource->class,
+            'method' => $dataSource->method,
+            'args' => $resolvedArgs
+        ]));
+    }
+
+    /**
+     * Find all properties that share the same DataSource signature
+     *
+     * @param object $object
+     * @param string $signature
+     * @return array<string>
+     */
+    private function findPropertiesWithSameSignature(object $object, string $signature): array
+    {
+        $properties = [];
+        $allProperties = $this->attributeReader->getPropertiesWithDataSource($object);
+        
+        foreach ($allProperties as $propName => $dataSource) {
+            $propSignature = $this->createSignature($dataSource, $object);
+            if ($propSignature === $signature) {
+                $properties[] = $propName;
+            }
+        }
+        
+        return $properties;
+    }
+
+    /**
+     * Load data from the DataSource
+     *
+     * @param DataSource $dataSource
+     * @param object $object
+     * @return array
+     */
+    private function loadDataFromSource(DataSource $dataSource, object $object): array
+    {
+        $dataSourceInstance = $this->resolveDataSource($dataSource->class);
+        $resolvedArgs = $this->resolveArgs($dataSource->args, $object);
+        
+        $result = call_user_func_array(
+            [$dataSourceInstance, $dataSource->method],
+            $resolvedArgs
+        );
+        
+        return is_array($result) ? $result : [];
+    }
+
+    /**
+     * Resolve a DataSource class (either instantiate or get from container)
+     *
+     * @param string $class
+     * @return object
+     */
+    private function resolveDataSource(string $class): object
+    {
+        // Check if it's a service identifier (prefixed with @)
+        if (str_starts_with($class, '@')) {
+            if ($this->container === null) {
+                throw new \RuntimeException(
+                    "Cannot resolve service identifier '{$class}' without a container"
+                );
+            }
+            
+            $serviceId = substr($class, 1);
+            return $this->container->get($serviceId);
+        }
+        
+        // Direct instantiation
+        return new $class();
+    }
+
+    /**
+     * Resolve arguments, replacing property references with actual values
+     *
+     * @param array $args
+     * @param object $object
+     * @return array
+     */
+    private function resolveArgs(array $args, object $object): array
+    {
+        $resolved = [];
+        $reflectionClass = new ReflectionClass($object);
+        
+        foreach ($args as $arg) {
+            if (is_string($arg) && str_starts_with($arg, '#')) {
+                // Property reference - extract the value
+                $propertyName = substr($arg, 1);
+                
+                if ($reflectionClass->hasProperty($propertyName)) {
+                    $property = $reflectionClass->getProperty($propertyName);
+                    $property->setAccessible(true);
+                    $resolved[] = $property->getValue($object);
+                } else {
+                    $resolved[] = null;
+                }
+            } else {
+                // Plain value
+                $resolved[] = $arg;
+            }
+        }
+        
+        return $resolved;
+    }
+
+    /**
+     * Hydrate a property with data
+     *
+     * @param object $object
+     * @param string $propertyName
+     * @param array $data
+     */
+    private function hydrateProperty(object $object, string $propertyName, array $data): void
+    {
+        if (!isset($data[$propertyName])) {
+            return;
+        }
+        
+        $reflectionClass = new ReflectionClass($object);
+        
+        if (!$reflectionClass->hasProperty($propertyName)) {
+            return;
+        }
+        
+        $property = $reflectionClass->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $data[$propertyName]);
+    }
+}

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -8,6 +8,7 @@ use Kassko\DataMapper\Attribute\DataSource;
 use Kassko\DataMapper\Expression\ExpressionParser;
 use Kassko\DataMapper\Expression\SourceFunctionProvider;
 use Kassko\DataMapper\Metadata\AttributeReader;
+use Kassko\DataMapper\ServiceResolver;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionProperty;
@@ -22,14 +23,33 @@ class LazyLoader implements LazyLoaderInterface
     private WeakMap $sourceFunctionProviders;
     
     private AttributeReader $attributeReader;
-    private ?ContainerInterface $container;
+    private ServiceResolver $serviceResolver;
 
-    public function __construct(?ContainerInterface $container = null)
+    /**
+     * @param ServiceResolver|ContainerInterface|null $serviceResolverOrContainer
+     */
+    public function __construct(ServiceResolver|ContainerInterface|null $serviceResolverOrContainer = null)
     {
         $this->loadedProperties = new WeakMap();
         $this->sourceFunctionProviders = new WeakMap();
         $this->attributeReader = new AttributeReader();
-        $this->container = $container;
+        
+        // Support backward compatibility: allow ContainerInterface or null
+        if ($serviceResolverOrContainer instanceof ServiceResolver) {
+            $this->serviceResolver = $serviceResolverOrContainer;
+        } elseif ($serviceResolverOrContainer instanceof ContainerInterface || $serviceResolverOrContainer === null) {
+            // Backward compatibility: create a ServiceResolver with just the container
+            $this->serviceResolver = new ServiceResolver($serviceResolverOrContainer, []);
+        } else {
+            throw new \InvalidArgumentException(
+                'Argument must be ServiceResolver, ContainerInterface, or null'
+            );
+        }
+    }
+
+    public function getServiceResolver(): ServiceResolver
+    {
+        return $this->serviceResolver;
     }
 
     /**
@@ -264,33 +284,7 @@ class LazyLoader implements LazyLoaderInterface
      */
     private function resolveDataSource(string $class): object
     {
-        // Check if it's a service identifier (prefixed with @)
-        if (str_starts_with($class, '@')) {
-            if ($this->container === null) {
-                throw new \RuntimeException(
-                    "Cannot resolve service identifier '{$class}' without a container"
-                );
-            }
-            
-            $serviceId = substr($class, 1);
-            return $this->container->get($serviceId);
-        }
-        
-        // Validate class exists and is instantiable before direct instantiation
-        if (!class_exists($class)) {
-            throw new \RuntimeException(
-                "DataSource class '{$class}' does not exist"
-            );
-        }
-        
-        $reflectionClass = new ReflectionClass($class);
-        if (!$reflectionClass->isInstantiable()) {
-            throw new \RuntimeException(
-                "DataSource class '{$class}' is not instantiable"
-            );
-        }
-        
-        return new $class();
+        return $this->serviceResolver->resolve($class);
     }
 
     /**

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -81,12 +81,20 @@ class LazyLoader implements LazyLoaderInterface
             $propertiesToHydrate = $this->findPropertiesWithSameSignature($object, $signature);
             
             // Load data from DataSource
-            $data = $this->loadDataFromSource($dataSource, $object);
+            $result = $this->executeDataSource($dataSource, $object);
             
-            // Hydrate all properties with the same signature
-            foreach ($propertiesToHydrate as $propName) {
-                $this->hydrateProperty($object, $propName, $data);
-                $this->loadedProperties[$object][$propName] = true;
+            // If result is an array, use array-based hydration
+            // Otherwise, directly set the value to all matching properties
+            if (is_array($result)) {
+                foreach ($propertiesToHydrate as $propName) {
+                    $this->hydrateProperty($object, $propName, $result);
+                    $this->loadedProperties[$object][$propName] = true;
+                }
+            } else {
+                foreach ($propertiesToHydrate as $propName) {
+                    $this->hydratePropertyWithValue($object, $propName, $result);
+                    $this->loadedProperties[$object][$propName] = true;
+                }
             }
         }
     }
@@ -187,12 +195,19 @@ class LazyLoader implements LazyLoaderInterface
     private function findPropertiesWithSameSignature(object $object, string $signature): array
     {
         $properties = [];
-        $allProperties = $this->attributeReader->getPropertiesWithDataSource($object);
+        $reflectionClass = new ReflectionClass($object);
         
-        foreach ($allProperties as $propName => $dataSource) {
+        // Check all properties for matching DataSource signature
+        foreach ($reflectionClass->getProperties() as $property) {
+            $dataSource = $this->resolveDataSourceForProperty($property, $object);
+            
+            if ($dataSource === null) {
+                continue;
+            }
+            
             $propSignature = $this->createSignature($dataSource, $object);
             if ($propSignature === $signature) {
-                $properties[] = $propName;
+                $properties[] = $property->getName();
             }
         }
         
@@ -200,13 +215,26 @@ class LazyLoader implements LazyLoaderInterface
     }
 
     /**
-     * Load data from the DataSource
+     * Load data from the DataSource (expects array result for supplySeveralFields)
      *
      * @param DataSource $dataSource
      * @param object $object
      * @return array
      */
     private function loadDataFromSource(DataSource $dataSource, object $object): array
+    {
+        $result = $this->executeDataSource($dataSource, $object);
+        return is_array($result) ? $result : [];
+    }
+
+    /**
+     * Execute a DataSource and return the result
+     *
+     * @param DataSource $dataSource
+     * @param object $object
+     * @return mixed
+     */
+    private function executeDataSource(DataSource $dataSource, object $object)
     {
         $dataSourceInstance = $this->resolveDataSource($dataSource->class);
         $resolvedArgs = $this->resolveArgs($dataSource->args, $object);
@@ -222,12 +250,10 @@ class LazyLoader implements LazyLoaderInterface
             );
         }
         
-        $result = call_user_func_array(
+        return call_user_func_array(
             [$dataSourceInstance, $dataSource->method],
             $resolvedArgs
         );
-        
-        return is_array($result) ? $result : [];
     }
 
     /**
@@ -303,8 +329,8 @@ class LazyLoader implements LazyLoaderInterface
         
         $dataSource = $dataSourceMap[$sourceId];
         
-        // Load the data from the source
-        $result = $this->loadDataFromSource($dataSource, $object);
+        // Execute the data source
+        $result = $this->executeDataSource($dataSource, $object);
         
         // If supplySeveralFields, also hydrate all related properties
         if ($dataSource->supplySeveralFields && is_array($result)) {
@@ -315,7 +341,7 @@ class LazyLoader implements LazyLoaderInterface
     }
 
     /**
-     * Hydrate a property with data
+     * Hydrate a property with data from an array
      *
      * @param object $object
      * @param string $propertyName
@@ -340,5 +366,24 @@ class LazyLoader implements LazyLoaderInterface
         }
         
         $property->setValue($object, $data[$fieldName]);
+    }
+
+    /**
+     * Hydrate a property with a single value
+     *
+     * @param object $object
+     * @param string $propertyName
+     * @param mixed $value
+     */
+    private function hydratePropertyWithValue(object $object, string $propertyName, $value): void
+    {
+        $reflectionClass = new ReflectionClass($object);
+        
+        if (!$reflectionClass->hasProperty($propertyName)) {
+            return;
+        }
+        
+        $property = $reflectionClass->getProperty($propertyName);
+        $property->setValue($object, $value);
     }
 }

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\LazyLoader;
 
 use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Expression\ExpressionParser;
+use Kassko\DataMapper\Expression\SourceFunctionProvider;
 use Kassko\DataMapper\Metadata\AttributeReader;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
@@ -16,12 +18,16 @@ class LazyLoader implements LazyLoaderInterface
     /** @var WeakMap<object, array<string, bool>> */
     private WeakMap $loadedProperties;
     
+    /** @var WeakMap<object, SourceFunctionProvider> */
+    private WeakMap $sourceFunctionProviders;
+    
     private AttributeReader $attributeReader;
     private ?ContainerInterface $container;
 
     public function __construct(?ContainerInterface $container = null)
     {
         $this->loadedProperties = new WeakMap();
+        $this->sourceFunctionProviders = new WeakMap();
         $this->attributeReader = new AttributeReader();
         $this->container = $container;
     }
@@ -39,12 +45,19 @@ class LazyLoader implements LazyLoaderInterface
             $this->loadedProperties[$object] = [];
         }
         
+        // Initialize source function provider for this object if needed
+        if (!isset($this->sourceFunctionProviders[$object])) {
+            $this->sourceFunctionProviders[$object] = new SourceFunctionProvider(
+                fn(string $sourceId) => $this->executeDataSourceById($object, $sourceId)
+            );
+        }
+        
         // Check if property is already loaded
         if (isset($this->loadedProperties[$object][$propertyName])) {
             return;
         }
         
-        // Get the property's DataSource attribute
+        // Get the property's DataSource
         $reflectionClass = new ReflectionClass($object);
         
         if (!$reflectionClass->hasProperty($propertyName)) {
@@ -52,23 +65,98 @@ class LazyLoader implements LazyLoaderInterface
         }
         
         $property = $reflectionClass->getProperty($propertyName);
-        $dataSource = $this->attributeReader->readDataSource($property);
+        $dataSource = $this->resolveDataSourceForProperty($property, $object);
         
         if ($dataSource === null) {
             return;
         }
         
-        // Find all properties that share the same DataSource signature
-        $signature = $this->createSignature($dataSource, $object);
-        $propertiesToHydrate = $this->findPropertiesWithSameSignature($object, $signature);
+        // Handle supplySeveralFields
+        if ($dataSource->supplySeveralFields) {
+            // Load all properties that reference this DataSource
+            $this->loadPropertiesForDataSource($object, $dataSource);
+        } else {
+            // Old behavior: find properties with same signature
+            $signature = $this->createSignature($dataSource, $object);
+            $propertiesToHydrate = $this->findPropertiesWithSameSignature($object, $signature);
+            
+            // Load data from DataSource
+            $data = $this->loadDataFromSource($dataSource, $object);
+            
+            // Hydrate all properties with the same signature
+            foreach ($propertiesToHydrate as $propName) {
+                $this->hydrateProperty($object, $propName, $data);
+                $this->loadedProperties[$object][$propName] = true;
+            }
+        }
+    }
+
+    /**
+     * Resolve the DataSource for a property (either from attribute or from store via ref)
+     *
+     * @param ReflectionProperty $property
+     * @param object $object
+     * @return DataSource|null
+     */
+    private function resolveDataSourceForProperty(ReflectionProperty $property, object $object): ?DataSource
+    {
+        // First check for direct DataSource attribute
+        $dataSource = $this->attributeReader->readDataSource($property);
+        if ($dataSource !== null) {
+            return $dataSource;
+        }
         
-        // Load data from DataSource
+        // Check for DataSourceRef attribute
+        $dataSourceRef = $this->attributeReader->readDataSourceRef($property);
+        if ($dataSourceRef !== null) {
+            $dataSourceMap = $this->attributeReader->getDataSourceMap($object);
+            return $dataSourceMap[$dataSourceRef->id] ?? null;
+        }
+        
+        return null;
+    }
+
+    /**
+     * Load all properties that reference a DataSource with supplySeveralFields
+     *
+     * @param object $object
+     * @param DataSource $dataSource
+     */
+    private function loadPropertiesForDataSource(object $object, DataSource $dataSource): void
+    {
+        // Load data from DataSource once
         $data = $this->loadDataFromSource($dataSource, $object);
         
-        // Hydrate all properties with the same signature
-        foreach ($propertiesToHydrate as $propName) {
-            $this->hydrateProperty($object, $propName, $data);
-            $this->loadedProperties[$object][$propName] = true;
+        if (!is_array($data)) {
+            return;
+        }
+        
+        // Find all properties that reference this DataSource
+        $reflectionClass = new ReflectionClass($object);
+        
+        foreach ($reflectionClass->getProperties() as $property) {
+            $propDataSource = $this->resolveDataSourceForProperty($property, $object);
+            
+            // Check if this property uses the same DataSource (by id)
+            if ($propDataSource === null || $propDataSource->id === null || $propDataSource->id !== $dataSource->id) {
+                continue;
+            }
+            
+            // Check if already loaded
+            $propName = $property->getName();
+            if (isset($this->loadedProperties[$object][$propName])) {
+                continue;
+            }
+            
+            // Get the field name mapping
+            $fieldAttr = $this->attributeReader->readField($property);
+            $fieldName = $fieldAttr !== null && $fieldAttr->name !== null ? $fieldAttr->name : $propName;
+            
+            // Hydrate if the field exists in the data
+            if (array_key_exists($fieldName, $data)) {
+                $property->setValue($object, $data[$fieldName]);
+                $this->loadedProperties[$object][$propName] = true;
+            }
         }
     }
 
@@ -180,7 +268,7 @@ class LazyLoader implements LazyLoaderInterface
     }
 
     /**
-     * Resolve arguments, replacing property references with actual values
+     * Resolve arguments, replacing property references and expressions with actual values
      *
      * @param array $args
      * @param object $object
@@ -188,28 +276,42 @@ class LazyLoader implements LazyLoaderInterface
      */
     private function resolveArgs(array $args, object $object): array
     {
-        $resolved = [];
-        $reflectionClass = new ReflectionClass($object);
+        $sourceFunctionProvider = $this->sourceFunctionProviders[$object];
+        $expressionParser = new ExpressionParser($sourceFunctionProvider);
         
-        foreach ($args as $arg) {
-            if (is_string($arg) && str_starts_with($arg, '#')) {
-                // Property reference - extract the value
-                $propertyName = substr($arg, 1);
-                
-                if ($reflectionClass->hasProperty($propertyName)) {
-                    $property = $reflectionClass->getProperty($propertyName);
-                    // $property->setAccessible(true);
-                    $resolved[] = $property->getValue($object);
-                } else {
-                    $resolved[] = null;
-                }
-            } else {
-                // Plain value
-                $resolved[] = $arg;
-            }
+        return $expressionParser->resolveArgs($args, $object, function(string $propertyName) use ($object) {
+            $this->loadProperty($object, $propertyName);
+        });
+    }
+
+    /**
+     * Execute a DataSource by its id from the store
+     *
+     * @param object $object
+     * @param string $sourceId
+     * @return mixed
+     */
+    private function executeDataSourceById(object $object, string $sourceId)
+    {
+        $dataSourceMap = $this->attributeReader->getDataSourceMap($object);
+        
+        if (!isset($dataSourceMap[$sourceId])) {
+            throw new \RuntimeException(
+                sprintf('DataSource with id "%s" not found in DataSourcesStore', $sourceId)
+            );
         }
         
-        return $resolved;
+        $dataSource = $dataSourceMap[$sourceId];
+        
+        // Load the data from the source
+        $result = $this->loadDataFromSource($dataSource, $object);
+        
+        // If supplySeveralFields, also hydrate all related properties
+        if ($dataSource->supplySeveralFields && is_array($result)) {
+            $this->loadPropertiesForDataSource($object, $dataSource);
+        }
+        
+        return $result;
     }
 
     /**
@@ -221,10 +323,6 @@ class LazyLoader implements LazyLoaderInterface
      */
     private function hydrateProperty(object $object, string $propertyName, array $data): void
     {
-        if (!isset($data[$propertyName])) {
-            return;
-        }
-        
         $reflectionClass = new ReflectionClass($object);
         
         if (!$reflectionClass->hasProperty($propertyName)) {
@@ -232,7 +330,15 @@ class LazyLoader implements LazyLoaderInterface
         }
         
         $property = $reflectionClass->getProperty($propertyName);
-        // $property->setAccessible(true);
-        $property->setValue($object, $data[$propertyName]);
+        
+        // Get the field name mapping
+        $fieldAttr = $this->attributeReader->readField($property);
+        $fieldName = $fieldAttr !== null && $fieldAttr->name !== null ? $fieldAttr->name : $propertyName;
+        
+        if (!array_key_exists($fieldName, $data)) {
+            return;
+        }
+        
+        $property->setValue($object, $data[$fieldName]);
     }
 }

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -123,6 +123,17 @@ class LazyLoader implements LazyLoaderInterface
         $dataSourceInstance = $this->resolveDataSource($dataSource->class);
         $resolvedArgs = $this->resolveArgs($dataSource->args, $object);
         
+        // Validate method exists before calling
+        if (!method_exists($dataSourceInstance, $dataSource->method)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Method %s does not exist on DataSource class %s',
+                    $dataSource->method,
+                    get_class($dataSourceInstance)
+                )
+            );
+        }
+        
         $result = call_user_func_array(
             [$dataSourceInstance, $dataSource->method],
             $resolvedArgs
@@ -151,7 +162,20 @@ class LazyLoader implements LazyLoaderInterface
             return $this->container->get($serviceId);
         }
         
-        // Direct instantiation
+        // Validate class exists and is instantiable before direct instantiation
+        if (!class_exists($class)) {
+            throw new \RuntimeException(
+                "DataSource class '{$class}' does not exist"
+            );
+        }
+        
+        $reflectionClass = new ReflectionClass($class);
+        if (!$reflectionClass->isInstantiable()) {
+            throw new \RuntimeException(
+                "DataSource class '{$class}' is not instantiable"
+            );
+        }
+        
         return new $class();
     }
 

--- a/src/LazyLoader/LazyLoader.php
+++ b/src/LazyLoader/LazyLoader.php
@@ -198,7 +198,7 @@ class LazyLoader implements LazyLoaderInterface
                 
                 if ($reflectionClass->hasProperty($propertyName)) {
                     $property = $reflectionClass->getProperty($propertyName);
-                    $property->setAccessible(true);
+                    // $property->setAccessible(true);
                     $resolved[] = $property->getValue($object);
                 } else {
                     $resolved[] = null;
@@ -232,7 +232,7 @@ class LazyLoader implements LazyLoaderInterface
         }
         
         $property = $reflectionClass->getProperty($propertyName);
-        $property->setAccessible(true);
+        // $property->setAccessible(true);
         $property->setValue($object, $data[$propertyName]);
     }
 }

--- a/src/LazyLoader/LazyLoaderInterface.php
+++ b/src/LazyLoader/LazyLoaderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\LazyLoader;
+
+interface LazyLoaderInterface
+{
+    /**
+     * Load a property on the given object
+     *
+     * @param object $object The object containing the property
+     * @param string $propertyName The name of the property to load
+     */
+    public function loadProperty(object $object, string $propertyName): void;
+}

--- a/src/Metadata/AttributeReader.php
+++ b/src/Metadata/AttributeReader.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Metadata;
 
 use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\Field;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -25,6 +28,82 @@ class AttributeReader
         }
         
         return $attributes[0]->newInstance();
+    }
+
+    /**
+     * Read DataSourceRef attribute from a property
+     *
+     * @param ReflectionProperty $property
+     * @return DataSourceRef|null
+     */
+    public function readDataSourceRef(ReflectionProperty $property): ?DataSourceRef
+    {
+        $attributes = $property->getAttributes(DataSourceRef::class);
+        
+        if (empty($attributes)) {
+            return null;
+        }
+        
+        return $attributes[0]->newInstance();
+    }
+
+    /**
+     * Read Field attribute from a property
+     *
+     * @param ReflectionProperty $property
+     * @return Field|null
+     */
+    public function readField(ReflectionProperty $property): ?Field
+    {
+        $attributes = $property->getAttributes(Field::class);
+        
+        if (empty($attributes)) {
+            return null;
+        }
+        
+        return $attributes[0]->newInstance();
+    }
+
+    /**
+     * Read DataSourcesStore attribute from a class
+     *
+     * @param ReflectionClass $reflectionClass
+     * @return DataSourcesStore|null
+     */
+    public function readDataSourcesStore(ReflectionClass $reflectionClass): ?DataSourcesStore
+    {
+        $attributes = $reflectionClass->getAttributes(DataSourcesStore::class);
+        
+        if (empty($attributes)) {
+            return null;
+        }
+        
+        return $attributes[0]->newInstance();
+    }
+
+    /**
+     * Build a map of DataSource id => DataSource from DataSourcesStore
+     *
+     * @param object $object
+     * @return array<string, DataSource>
+     */
+    public function getDataSourceMap(object $object): array
+    {
+        $reflectionClass = new ReflectionClass($object);
+        $store = $this->readDataSourcesStore($reflectionClass);
+        
+        if ($store === null) {
+            return [];
+        }
+        
+        $map = [];
+        foreach ($store->sources as $source) {
+            if ($source->id !== null) {
+                $map[$source->id] = $source;
+            }
+        }
+        
+        return $map;
     }
 
     /**

--- a/src/Metadata/AttributeReader.php
+++ b/src/Metadata/AttributeReader.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Metadata;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use ReflectionClass;
+use ReflectionProperty;
+
+class AttributeReader
+{
+    /**
+     * Read DataSource attribute from a property
+     *
+     * @param ReflectionProperty $property
+     * @return DataSource|null
+     */
+    public function readDataSource(ReflectionProperty $property): ?DataSource
+    {
+        $attributes = $property->getAttributes(DataSource::class);
+        
+        if (empty($attributes)) {
+            return null;
+        }
+        
+        return $attributes[0]->newInstance();
+    }
+
+    /**
+     * Get all properties with DataSource attributes from an object
+     *
+     * @param object $object
+     * @return array<string, DataSource> Array of property name => DataSource
+     */
+    public function getPropertiesWithDataSource(object $object): array
+    {
+        $reflectionClass = new ReflectionClass($object);
+        $properties = [];
+        
+        foreach ($reflectionClass->getProperties() as $property) {
+            $dataSource = $this->readDataSource($property);
+            if ($dataSource !== null) {
+                $properties[$property->getName()] = $dataSource;
+            }
+        }
+        
+        return $properties;
+    }
+}

--- a/src/ObjectExtension/LoadableTrait.php
+++ b/src/ObjectExtension/LoadableTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\ObjectExtension;
+
+use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
+
+trait LoadableTrait
+{
+    private ?LazyLoaderInterface $dataMapperLoader = null;
+
+    /**
+     * Set the lazy loader for this object
+     *
+     * @param LazyLoaderInterface $loader
+     */
+    public function setDataMapperLoader(LazyLoaderInterface $loader): void
+    {
+        $this->dataMapperLoader = $loader;
+    }
+
+    /**
+     * Load a property lazily using the configured loader
+     *
+     * @param string $propertyName The name of the property to load
+     */
+    protected function loadProperty(string $propertyName): void
+    {
+        if ($this->dataMapperLoader !== null) {
+            $this->dataMapperLoader->loadProperty($this, $propertyName);
+        }
+    }
+}

--- a/src/ObjectExtension/LoadableTrait.php
+++ b/src/ObjectExtension/LoadableTrait.php
@@ -4,31 +4,23 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper\ObjectExtension;
 
-use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 
 trait LoadableTrait
 {
-    private ?LazyLoaderInterface $dataMapperLoader = null;
-
     /**
-     * Set the lazy loader for this object
-     *
-     * @param LazyLoaderInterface $loader
-     */
-    public function setDataMapperLoader(LazyLoaderInterface $loader): void
-    {
-        $this->dataMapperLoader = $loader;
-    }
-
-    /**
-     * Load a property lazily using the configured loader
-     *
-     * @param string $propertyName The name of the property to load
+     * Load a property on-demand using the global LazyLoader.
      */
     protected function loadProperty(string $propertyName): void
     {
-        if ($this->dataMapperLoader !== null) {
-            $this->dataMapperLoader->loadProperty($this, $propertyName);
+        $lazyLoader = LazyLoaderRegistry::get();
+        
+        if ($lazyLoader === null) {
+            // No DataMapper configured - silently skip
+            // This allows objects to work even without DataMapper
+            return;
         }
+
+        $lazyLoader->loadProperty($this, $propertyName);
     }
 }

--- a/src/Registry/LazyLoaderRegistry.php
+++ b/src/Registry/LazyLoaderRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Registry;
+
+use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
+
+final class LazyLoaderRegistry
+{
+    private static ?LazyLoaderInterface $lazyLoader = null;
+
+    /**
+     * Set the global LazyLoader instance.
+     * Called by DataMapperBuilder::build()
+     */
+    public static function set(LazyLoaderInterface $lazyLoader): void
+    {
+        self::$lazyLoader = $lazyLoader;
+    }
+
+    /**
+     * Get the global LazyLoader instance.
+     * Called by LoadableTrait::loadProperty()
+     */
+    public static function get(): ?LazyLoaderInterface
+    {
+        return self::$lazyLoader;
+    }
+
+    /**
+     * Check if a LazyLoader has been registered.
+     */
+    public static function has(): bool
+    {
+        return self::$lazyLoader !== null;
+    }
+
+    /**
+     * Clear the registry (useful for tests).
+     */
+    public static function clear(): void
+    {
+        self::$lazyLoader = null;
+    }
+}

--- a/src/ServiceLocatorInterface.php
+++ b/src/ServiceLocatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper;
+
+interface ServiceLocatorInterface
+{
+    /**
+     * Check if this locator has a mapping for the given key.
+     */
+    public function has(string $key): bool;
+
+    /**
+     * Get the mapped value for the given key.
+     * Returns the service ID (with @) or class name.
+     */
+    public function get(string $key): string;
+}

--- a/src/ServiceLocatorInterface.php
+++ b/src/ServiceLocatorInterface.php
@@ -4,16 +4,24 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper;
 
-interface ServiceLocatorInterface
+use Psr\Container\ContainerInterface;
+
+interface ServiceLocatorInterface extends ContainerInterface
 {
     /**
      * Check if this locator has a mapping for the given key.
+     * 
+     * @param string $id
+     * @return bool
      */
-    public function has(string $key): bool;
+    public function has(string $id): bool;
 
     /**
      * Get the mapped value for the given key.
      * Returns the service ID (with @) or class name.
+     * 
+     * @param string $id
+     * @return mixed
      */
-    public function get(string $key): string;
+    public function get(string $id): mixed;
 }

--- a/src/ServiceResolver.php
+++ b/src/ServiceResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper;
+
+use Psr\Container\ContainerInterface;
+
+final class ServiceResolver
+{
+    /**
+     * @param ServiceLocatorInterface[] $locators
+     */
+    public function __construct(
+        private ?ContainerInterface $container,
+        private array $locators
+    ) {}
+
+    /**
+     * Resolve a class/service identifier to an actual instance.
+     */
+    public function resolve(string $classOrId): object
+    {
+        // Case 1: Starts with "@" - direct container lookup
+        if (str_starts_with($classOrId, '@')) {
+            $serviceId = substr($classOrId, 1);
+            return $this->resolveFromContainer($serviceId);
+        }
+
+        // Case 2: Check locators
+        foreach ($this->locators as $locator) {
+            if ($locator->has($classOrId)) {
+                $resolved = $locator->get($classOrId);
+                
+                // Recursively resolve (in case locator returns @serviceId)
+                return $this->resolve($resolved);
+            }
+        }
+
+        // Case 3: Try to instantiate directly
+        return $this->instantiate($classOrId);
+    }
+
+    private function resolveFromContainer(string $serviceId): object
+    {
+        if ($this->container === null) {
+            throw new \RuntimeException(
+                "Cannot resolve service identifier '@{$serviceId}' without a container"
+            );
+        }
+
+        if (!$this->container->has($serviceId)) {
+            throw new \RuntimeException(sprintf(
+                'Service "%s" not found in container',
+                $serviceId
+            ));
+        }
+
+        return $this->container->get($serviceId);
+    }
+
+    private function instantiate(string $className): object
+    {
+        if (!class_exists($className)) {
+            throw new \RuntimeException(
+                "DataSource class '{$className}' does not exist"
+            );
+        }
+
+        $reflection = new \ReflectionClass($className);
+        
+        if (!$reflection->isInstantiable()) {
+            throw new \RuntimeException(
+                "DataSource class '{$className}' is not instantiable"
+            );
+        }
+
+        return new $className();
+    }
+}

--- a/src/ServiceResolver.php
+++ b/src/ServiceResolver.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
 final class ServiceResolver
 {
     /**
-     * @param ServiceLocatorInterface[] $locators
+     * @param ServiceLocatorInterface[] $locators Locators are checked in order; first match wins
      */
     public function __construct(
         private ?ContainerInterface $container,
@@ -45,7 +45,7 @@ final class ServiceResolver
     {
         if ($this->container === null) {
             throw new \RuntimeException(
-                "Cannot resolve service identifier '@{$serviceId}' without a container"
+                "Cannot resolve service identifier '{$serviceId}' without a container"
             );
         }
 

--- a/tests/Fixtures/Car.php
+++ b/tests/Fixtures/Car.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\Sample;
+
+class Car
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $brand,
+        public readonly string $model
+    ) {
+    }
+}

--- a/tests/Fixtures/CarRepository.php
+++ b/tests/Fixtures/CarRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\Sample;
+
+class CarRepository
+{
+    public function find(int $id): ?Car
+    {
+        return match($id) {
+            100 => new Car(100, 'Toyota', 'Camry'),
+            200 => new Car(200, 'Honda', 'Accord'),
+            300 => new Car(300, 'Ford', 'Mustang'),
+            default => null,
+        };
+    }
+}

--- a/tests/Fixtures/Person.php
+++ b/tests/Fixtures/Person.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\Sample;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+class Person
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+    private ?string $name = null;
+
+    #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+    private ?string $email = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        $this->loadProperty('name');
+        return $this->name;
+    }
+
+    public function getEmail(): ?string
+    {
+        $this->loadProperty('email');
+        return $this->email;
+    }
+}

--- a/tests/Fixtures/PersonDataSource.php
+++ b/tests/Fixtures/PersonDataSource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\Sample;
+
+class PersonDataSource
+{
+    public function getData(int $id): array
+    {
+        return match($id) {
+            1 => ['name' => 'foo', 'email' => 'foo@aaa.com'],
+            2 => ['name' => 'bar', 'email' => 'bar@bbb.com'],
+            default => ['name' => 'baz', 'email' => 'baz@ccc.com'],
+        };
+    }
+}

--- a/tests/Fixtures/PersonDataSource.php
+++ b/tests/Fixtures/PersonDataSource.php
@@ -9,9 +9,9 @@ class PersonDataSource
     public function getData(int $id): array
     {
         return match($id) {
-            1 => ['name' => 'foo', 'email' => 'foo@aaa.com'],
-            2 => ['name' => 'bar', 'email' => 'bar@bbb.com'],
-            default => ['name' => 'baz', 'email' => 'baz@ccc.com'],
+            1 => ['name' => 'foo', 'email' => 'foo@aaa.com', 'first_name' => 'Foo', 'car_id' => 100],
+            2 => ['name' => 'bar', 'email' => 'bar@bbb.com', 'first_name' => 'Bar', 'car_id' => 200],
+            default => ['name' => 'baz', 'email' => 'baz@ccc.com', 'first_name' => 'Baz', 'car_id' => 300],
         };
     }
 }

--- a/tests/Fixtures/PersonWithCar.php
+++ b/tests/Fixtures/PersonWithCar.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\Sample;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\Field;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+#[DataSourcesStore([
+    new DataSource(
+        id: 'personSource',
+        class: PersonDataSource::class,
+        method: 'getData',
+        args: ['#id'],
+        supplySeveralFields: true
+    ),
+    new DataSource(
+        id: 'carSource',
+        class: CarRepository::class,
+        method: 'find',
+        args: ["expr(source('personSource')['car_id'])"]
+    )
+])]
+class PersonWithCar
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSourceRef(id: 'personSource')]
+    #[Field(name: 'first_name')]
+    private ?string $firstName = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $name = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $email = null;
+
+    #[DataSourceRef(id: 'carSource')]
+    private ?Car $car = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): ?string
+    {
+        $this->loadProperty('firstName');
+        return $this->firstName;
+    }
+
+    public function getName(): ?string
+    {
+        $this->loadProperty('name');
+        return $this->name;
+    }
+
+    public function getEmail(): ?string
+    {
+        $this->loadProperty('email');
+        return $this->email;
+    }
+
+    public function getCar(): ?Car
+    {
+        $this->loadProperty('car');
+        return $this->car;
+    }
+}

--- a/tests/Fixtures/PersonWithStore.php
+++ b/tests/Fixtures/PersonWithStore.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\Sample;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\Field;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+#[DataSourcesStore([
+    new DataSource(
+        id: 'personSource',
+        class: PersonDataSource::class,
+        method: 'getData',
+        args: ['#id'],
+        supplySeveralFields: true
+    )
+])]
+class PersonWithStore
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[DataSourceRef(id: 'personSource')]
+    #[Field(name: 'first_name')]
+    private ?string $firstName = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $name = null;
+
+    #[DataSourceRef(id: 'personSource')]
+    private ?string $email = null;
+
+    // This property should NOT be hydrated (no DataSourceRef)
+    private ?int $age = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): ?string
+    {
+        $this->loadProperty('firstName');
+        return $this->firstName;
+    }
+
+    public function getName(): ?string
+    {
+        $this->loadProperty('name');
+        return $this->name;
+    }
+
+    public function getEmail(): ?string
+    {
+        $this->loadProperty('email');
+        return $this->email;
+    }
+
+    public function getAge(): ?int
+    {
+        $this->loadProperty('age');
+        return $this->age;
+    }
+}

--- a/tests/Integration/DataMapperTest.php
+++ b/tests/Integration/DataMapperTest.php
@@ -5,29 +5,31 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Tests\Integration;
 
 use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Kassko\Sample\Person;
 use PHPUnit\Framework\TestCase;
 
 class DataMapperTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
+
     public function testDataMapperPreparesObjectForLazyLoading(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper(); // Registers LazyLoader automatically
         $person = new Person(1);
 
-        $dataMapper->prepare($person);
-
-        // Access properties - they should be lazy loaded
+        // Access properties - they should be lazy loaded (no prepare() needed!)
         $this->assertEquals('foo', $person->getName());
         $this->assertEquals('foo@aaa.com', $person->getEmail());
     }
 
     public function testSingleCallOptimization(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper(); // Registers LazyLoader automatically
         $person = new Person(1);
-
-        $dataMapper->prepare($person);
 
         // First call to getName() should load both name and email
         $name = $person->getName();
@@ -41,15 +43,11 @@ class DataMapperTest extends TestCase
 
     public function testMultiplePersonsWithDifferentIds(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper(); // Registers LazyLoader automatically
         
         $person1 = new Person(1);
         $person2 = new Person(2);
         $person3 = new Person(3);
-
-        $dataMapper->prepare($person1);
-        $dataMapper->prepare($person2);
-        $dataMapper->prepare($person3);
 
         $this->assertEquals('foo', $person1->getName());
         $this->assertEquals('foo@aaa.com', $person1->getEmail());
@@ -59,16 +57,5 @@ class DataMapperTest extends TestCase
 
         $this->assertEquals('baz', $person3->getName());
         $this->assertEquals('baz@ccc.com', $person3->getEmail());
-    }
-
-    public function testPrepareThrowsExceptionForObjectWithoutLoadableTrait(): void
-    {
-        $dataMapper = new DataMapper();
-        $object = new \stdClass();
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/must use.*LoadableTrait/');
-
-        $dataMapper->prepare($object);
     }
 }

--- a/tests/Integration/DataMapperTest.php
+++ b/tests/Integration/DataMapperTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapper;
+use Kassko\Sample\Person;
+use PHPUnit\Framework\TestCase;
+
+class DataMapperTest extends TestCase
+{
+    public function testDataMapperPreparesObjectForLazyLoading(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new Person(1);
+
+        $dataMapper->prepare($person);
+
+        // Access properties - they should be lazy loaded
+        $this->assertEquals('foo', $person->getName());
+        $this->assertEquals('foo@aaa.com', $person->getEmail());
+    }
+
+    public function testSingleCallOptimization(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new Person(1);
+
+        $dataMapper->prepare($person);
+
+        // First call to getName() should load both name and email
+        $name = $person->getName();
+        $this->assertEquals('foo', $name);
+
+        // Second call to getEmail() should NOT trigger another DataSource call
+        // (this is verified by the fact that we only have one DataSource mock call)
+        $email = $person->getEmail();
+        $this->assertEquals('foo@aaa.com', $email);
+    }
+
+    public function testMultiplePersonsWithDifferentIds(): void
+    {
+        $dataMapper = new DataMapper();
+        
+        $person1 = new Person(1);
+        $person2 = new Person(2);
+        $person3 = new Person(3);
+
+        $dataMapper->prepare($person1);
+        $dataMapper->prepare($person2);
+        $dataMapper->prepare($person3);
+
+        $this->assertEquals('foo', $person1->getName());
+        $this->assertEquals('foo@aaa.com', $person1->getEmail());
+
+        $this->assertEquals('bar', $person2->getName());
+        $this->assertEquals('bar@bbb.com', $person2->getEmail());
+
+        $this->assertEquals('baz', $person3->getName());
+        $this->assertEquals('baz@ccc.com', $person3->getEmail());
+    }
+
+    public function testPrepareThrowsExceptionForObjectWithoutLoadableTrait(): void
+    {
+        $dataMapper = new DataMapper();
+        $object = new \stdClass();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/must use.*LoadableTrait/');
+
+        $dataMapper->prepare($object);
+    }
+}

--- a/tests/Integration/DataSourcesStoreTest.php
+++ b/tests/Integration/DataSourcesStoreTest.php
@@ -5,17 +5,21 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Tests\Integration;
 
 use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Kassko\Sample\PersonWithStore;
 use PHPUnit\Framework\TestCase;
 
 class DataSourcesStoreTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
+
     public function testDataSourcesStoreWithSupplySeveralFields(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithStore(1);
-
-        $dataMapper->prepare($person);
 
         // Access firstName with Field mapping
         $this->assertEquals('Foo', $person->getFirstName());
@@ -32,10 +36,8 @@ class DataSourcesStoreTest extends TestCase
 
     public function testSupplySeveralFieldsLoadsAllPropertiesInSingleCall(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithStore(2);
-
-        $dataMapper->prepare($person);
 
         // Trigger loading by accessing one property
         $name = $person->getName();
@@ -48,10 +50,8 @@ class DataSourcesStoreTest extends TestCase
 
     public function testFieldAttributeMapsPropertyToDifferentKey(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithStore(3);
-
-        $dataMapper->prepare($person);
 
         // firstName property should be mapped to 'first_name' key in data
         $this->assertEquals('Baz', $person->getFirstName());
@@ -59,10 +59,8 @@ class DataSourcesStoreTest extends TestCase
 
     public function testPropertiesWithoutDataSourceRefAreNotHydrated(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithStore(1);
-
-        $dataMapper->prepare($person);
 
         // Load some properties
         $person->getName();

--- a/tests/Integration/DataSourcesStoreTest.php
+++ b/tests/Integration/DataSourcesStoreTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapper;
+use Kassko\Sample\PersonWithStore;
+use PHPUnit\Framework\TestCase;
+
+class DataSourcesStoreTest extends TestCase
+{
+    public function testDataSourcesStoreWithSupplySeveralFields(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithStore(1);
+
+        $dataMapper->prepare($person);
+
+        // Access firstName with Field mapping
+        $this->assertEquals('Foo', $person->getFirstName());
+        
+        // Access name directly
+        $this->assertEquals('foo', $person->getName());
+        
+        // Access email directly
+        $this->assertEquals('foo@aaa.com', $person->getEmail());
+        
+        // Age should remain null (no DataSourceRef)
+        $this->assertNull($person->getAge());
+    }
+
+    public function testSupplySeveralFieldsLoadsAllPropertiesInSingleCall(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithStore(2);
+
+        $dataMapper->prepare($person);
+
+        // Trigger loading by accessing one property
+        $name = $person->getName();
+        $this->assertEquals('bar', $name);
+
+        // Other properties with same DataSourceRef should already be loaded
+        $this->assertEquals('Bar', $person->getFirstName());
+        $this->assertEquals('bar@bbb.com', $person->getEmail());
+    }
+
+    public function testFieldAttributeMapsPropertyToDifferentKey(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithStore(3);
+
+        $dataMapper->prepare($person);
+
+        // firstName property should be mapped to 'first_name' key in data
+        $this->assertEquals('Baz', $person->getFirstName());
+    }
+
+    public function testPropertiesWithoutDataSourceRefAreNotHydrated(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithStore(1);
+
+        $dataMapper->prepare($person);
+
+        // Load some properties
+        $person->getName();
+
+        // Age has no DataSourceRef, should remain null even if key exists in data
+        $this->assertNull($person->getAge());
+    }
+}

--- a/tests/Integration/DifferentSignaturesTest.php
+++ b/tests/Integration/DifferentSignaturesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use PHPUnit\Framework\TestCase;
+
+class DifferentSignaturesTest extends TestCase
+{
+    public function testPropertiesWithDifferentArgsAreLoadedSeparately(): void
+    {
+        // Create a data source that returns different data based on the type parameter
+        $dataSource = new class {
+            public int $callCount = 0;
+
+            public function getData(string $type): array
+            {
+                $this->callCount++;
+                
+                return match($type) {
+                    'profile' => ['profileData' => 'Profile Info'],
+                    'settings' => ['settingsData' => 'Settings Info'],
+                    default => [],
+                };
+            }
+        };
+
+        // Create an entity with properties that have different signatures
+        $entity = new class($dataSource) {
+            use LoadableTrait;
+
+            private object $dataSource;
+
+            #[DataSource(class: self::class . 'DataSource', method: 'getData', args: ['profile'])]
+            private ?string $profileData = null;
+
+            #[DataSource(class: self::class . 'DataSource', method: 'getData', args: ['settings'])]
+            private ?string $settingsData = null;
+
+            public function __construct(object $dataSource)
+            {
+                $this->dataSource = $dataSource;
+            }
+
+            public function getProfileData(): ?string
+            {
+                $this->loadProperty('profileData');
+                return $this->profileData;
+            }
+
+            public function getSettingsData(): ?string
+            {
+                $this->loadProperty('settingsData');
+                return $this->settingsData;
+            }
+
+            public function getDataSource(): object
+            {
+                return $this->dataSource;
+            }
+        };
+
+        // Since we can't easily use the DataSource from the entity in attributes,
+        // let's test the basic scenario with a more straightforward approach
+        
+        $this->markTestSkipped('This test demonstrates the concept but requires more complex setup');
+    }
+
+    public function testPropertiesWithSameClassAndMethodButDifferentArgs(): void
+    {
+        // Create an entity with properties that reference different IDs
+        // This means they have different signatures and should be loaded separately
+        $entity = new class(1, 2) {
+            use LoadableTrait;
+
+            private int $id1;
+            private int $id2;
+
+            #[DataSource(class: 'Kassko\Sample\PersonDataSource', method: 'getData', args: ['#id1'])]
+            private ?string $name = null;
+
+            #[DataSource(class: 'Kassko\Sample\PersonDataSource', method: 'getData', args: ['#id2'])]
+            private ?string $email = null;
+
+            public function __construct(int $id1, int $id2)
+            {
+                $this->id1 = $id1;
+                $this->id2 = $id2;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+
+            public function getEmail(): ?string
+            {
+                $this->loadProperty('email');
+                return $this->email;
+            }
+        };
+
+        $dataMapper = new DataMapper();
+        $dataMapper->prepare($entity);
+
+        // Load name (should use id1=1, which returns ['name' => 'foo', 'email' => 'foo@aaa.com'])
+        $name = $entity->getName();
+        $this->assertEquals('foo', $name);
+
+        // Load email (should use id2=2, which returns ['name' => 'bar', 'email' => 'bar@bbb.com'])
+        // The email property will be hydrated with 'bar@bbb.com'
+        $email = $entity->getEmail();
+        $this->assertEquals('bar@bbb.com', $email);
+    }
+}

--- a/tests/Integration/DifferentSignaturesTest.php
+++ b/tests/Integration/DifferentSignaturesTest.php
@@ -105,8 +105,7 @@ class DifferentSignaturesTest extends TestCase
             }
         };
 
-        $dataMapper = new DataMapper();
-        $dataMapper->prepare($entity);
+        new DataMapper();
 
         // Load name (should use id1=1, which returns ['name' => 'foo', 'email' => 'foo@aaa.com'])
         $name = $entity->getName();
@@ -116,5 +115,7 @@ class DifferentSignaturesTest extends TestCase
         // The email property will be hydrated with 'bar@bbb.com'
         $email = $entity->getEmail();
         $this->assertEquals('bar@bbb.com', $email);
+        
+        \Kassko\DataMapper\Registry\LazyLoaderRegistry::clear();
     }
 }

--- a/tests/Integration/ExpressionLanguageTest.php
+++ b/tests/Integration/ExpressionLanguageTest.php
@@ -5,17 +5,21 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Tests\Integration;
 
 use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Kassko\Sample\PersonWithCar;
 use PHPUnit\Framework\TestCase;
 
 class ExpressionLanguageTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
+
     public function testSimplePropertyReferenceExpression(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithCar(1);
-
-        $dataMapper->prepare($person);
 
         // The personSource uses #id which references $id property
         $name = $person->getName();
@@ -24,10 +28,8 @@ class ExpressionLanguageTest extends TestCase
 
     public function testExprWithSourceFunction(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithCar(1);
-
-        $dataMapper->prepare($person);
 
         // The carSource uses expr(source('personSource')['car_id'])
         // This should load personSource, extract car_id, and use it to load the car
@@ -41,10 +43,8 @@ class ExpressionLanguageTest extends TestCase
 
     public function testDependencyChainResolution(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithCar(2);
-
-        $dataMapper->prepare($person);
 
         // Loading car requires loading personSource first (dependency)
         $car = $person->getCar();
@@ -60,10 +60,8 @@ class ExpressionLanguageTest extends TestCase
 
     public function testSourceResultIsCached(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithCar(3);
-
-        $dataMapper->prepare($person);
 
         // Load car first (which loads personSource internally)
         $car = $person->getCar();
@@ -81,13 +79,10 @@ class ExpressionLanguageTest extends TestCase
 
     public function testMultipleExpressionEvaluations(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         
         $person1 = new PersonWithCar(1);
         $person2 = new PersonWithCar(2);
-        
-        $dataMapper->prepare($person1);
-        $dataMapper->prepare($person2);
         
         $car1 = $person1->getCar();
         $car2 = $person2->getCar();

--- a/tests/Integration/ExpressionLanguageTest.php
+++ b/tests/Integration/ExpressionLanguageTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapper;
+use Kassko\Sample\PersonWithCar;
+use PHPUnit\Framework\TestCase;
+
+class ExpressionLanguageTest extends TestCase
+{
+    public function testSimplePropertyReferenceExpression(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithCar(1);
+
+        $dataMapper->prepare($person);
+
+        // The personSource uses #id which references $id property
+        $name = $person->getName();
+        $this->assertEquals('foo', $name);
+    }
+
+    public function testExprWithSourceFunction(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithCar(1);
+
+        $dataMapper->prepare($person);
+
+        // The carSource uses expr(source('personSource')['car_id'])
+        // This should load personSource, extract car_id, and use it to load the car
+        $car = $person->getCar();
+        
+        $this->assertNotNull($car);
+        $this->assertEquals(100, $car->id);
+        $this->assertEquals('Toyota', $car->brand);
+        $this->assertEquals('Camry', $car->model);
+    }
+
+    public function testDependencyChainResolution(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithCar(2);
+
+        $dataMapper->prepare($person);
+
+        // Loading car requires loading personSource first (dependency)
+        $car = $person->getCar();
+        
+        $this->assertNotNull($car);
+        $this->assertEquals(200, $car->id);
+        $this->assertEquals('Honda', $car->brand);
+        
+        // PersonSource should also have been loaded
+        $this->assertEquals('bar', $person->getName());
+        $this->assertEquals('Bar', $person->getFirstName());
+    }
+
+    public function testSourceResultIsCached(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithCar(3);
+
+        $dataMapper->prepare($person);
+
+        // Load car first (which loads personSource internally)
+        $car = $person->getCar();
+        $this->assertNotNull($car);
+        $this->assertEquals(300, $car->id);
+        
+        // Now accessing name should not trigger another personSource call
+        // because it was already loaded when resolving car
+        $name = $person->getName();
+        $this->assertEquals('baz', $name);
+        
+        $firstName = $person->getFirstName();
+        $this->assertEquals('Baz', $firstName);
+    }
+
+    public function testMultipleExpressionEvaluations(): void
+    {
+        $dataMapper = new DataMapper();
+        
+        $person1 = new PersonWithCar(1);
+        $person2 = new PersonWithCar(2);
+        
+        $dataMapper->prepare($person1);
+        $dataMapper->prepare($person2);
+        
+        $car1 = $person1->getCar();
+        $car2 = $person2->getCar();
+        
+        $this->assertEquals('Toyota', $car1->brand);
+        $this->assertEquals('Honda', $car2->brand);
+    }
+}

--- a/tests/Integration/FieldMappingTest.php
+++ b/tests/Integration/FieldMappingTest.php
@@ -5,17 +5,21 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Tests\Integration;
 
 use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Kassko\Sample\PersonWithStore;
 use PHPUnit\Framework\TestCase;
 
 class FieldMappingTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
+
     public function testFieldAttributeMapsKeyToProperty(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithStore(1);
-
-        $dataMapper->prepare($person);
 
         // firstName property should use 'first_name' key from data
         $firstName = $person->getFirstName();
@@ -24,15 +28,11 @@ class FieldMappingTest extends TestCase
 
     public function testFieldMappingWithMultipleIds(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         
         $person1 = new PersonWithStore(1);
         $person2 = new PersonWithStore(2);
         $person3 = new PersonWithStore(3);
-
-        $dataMapper->prepare($person1);
-        $dataMapper->prepare($person2);
-        $dataMapper->prepare($person3);
 
         $this->assertEquals('Foo', $person1->getFirstName());
         $this->assertEquals('Bar', $person2->getFirstName());
@@ -41,10 +41,8 @@ class FieldMappingTest extends TestCase
 
     public function testPropertiesWithoutFieldAttributeUsePropertyName(): void
     {
-        $dataMapper = new DataMapper();
+        new DataMapper();
         $person = new PersonWithStore(1);
-
-        $dataMapper->prepare($person);
 
         // name and email properties don't have Field attribute
         // so they should use their property name as the key

--- a/tests/Integration/FieldMappingTest.php
+++ b/tests/Integration/FieldMappingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapper;
+use Kassko\Sample\PersonWithStore;
+use PHPUnit\Framework\TestCase;
+
+class FieldMappingTest extends TestCase
+{
+    public function testFieldAttributeMapsKeyToProperty(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithStore(1);
+
+        $dataMapper->prepare($person);
+
+        // firstName property should use 'first_name' key from data
+        $firstName = $person->getFirstName();
+        $this->assertEquals('Foo', $firstName);
+    }
+
+    public function testFieldMappingWithMultipleIds(): void
+    {
+        $dataMapper = new DataMapper();
+        
+        $person1 = new PersonWithStore(1);
+        $person2 = new PersonWithStore(2);
+        $person3 = new PersonWithStore(3);
+
+        $dataMapper->prepare($person1);
+        $dataMapper->prepare($person2);
+        $dataMapper->prepare($person3);
+
+        $this->assertEquals('Foo', $person1->getFirstName());
+        $this->assertEquals('Bar', $person2->getFirstName());
+        $this->assertEquals('Baz', $person3->getFirstName());
+    }
+
+    public function testPropertiesWithoutFieldAttributeUsePropertyName(): void
+    {
+        $dataMapper = new DataMapper();
+        $person = new PersonWithStore(1);
+
+        $dataMapper->prepare($person);
+
+        // name and email properties don't have Field attribute
+        // so they should use their property name as the key
+        $this->assertEquals('foo', $person->getName());
+        $this->assertEquals('foo@aaa.com', $person->getEmail());
+    }
+}

--- a/tests/Integration/RegistryIntegrationTest.php
+++ b/tests/Integration/RegistryIntegrationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
+use Kassko\Sample\Person;
+use PHPUnit\Framework\TestCase;
+
+final class RegistryIntegrationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
+
+    public function testLazyLoadingWorksWithoutPrepare(): void
+    {
+        // Build DataMapper once
+        (new DataMapperBuilder())->build();
+        
+        // Create object - NO prepare() call!
+        $person = new Person(1);
+        
+        // Lazy loading should work
+        $name = $person->getName();
+        
+        $this->assertNotNull($name);
+        $this->assertEquals('foo', $name);
+    }
+
+    public function testObjectIsSerializable(): void
+    {
+        (new DataMapperBuilder())->build();
+        
+        $person = new Person(1);
+        
+        // Object should be serializable (no service in properties)
+        $serialized = serialize($person);
+        $unserialized = unserialize($serialized);
+        
+        $this->assertInstanceOf(Person::class, $unserialized);
+    }
+
+    public function testMultipleObjects(): void
+    {
+        (new DataMapperBuilder())->build();
+        
+        $person1 = new Person(1);
+        $person2 = new Person(2);
+        
+        $this->assertEquals('foo', $person1->getName());
+        $this->assertEquals('bar', $person2->getName());
+    }
+
+    public function testWithoutDataMapperGracefulDegradation(): void
+    {
+        // Don't build DataMapper - objects should still work but properties won't load
+        LazyLoaderRegistry::clear();
+        
+        $person = new Person(1);
+        
+        // Accessing properties should not throw - just return null
+        $name = $person->getName();
+        
+        $this->assertNull($name);
+    }
+}

--- a/tests/Integration/ServiceLocatorIntegrationTest.php
+++ b/tests/Integration/ServiceLocatorIntegrationTest.php
@@ -159,12 +159,20 @@ final class ServiceLocatorIntegrationTest extends TestCase
         ]);
 
         // Create a mock container
-        $container = new class implements ContainerInterface {
+        $personService = new PersonDataSource();
+        $carService = new CarRepository();
+        
+        $container = new class($personService, $carService) implements ContainerInterface {
+            public function __construct(
+                private PersonDataSource $personService,
+                private CarRepository $carService
+            ) {}
+            
             public function get(string $id): object
             {
                 return match($id) {
-                    'person.data_source' => new PersonDataSource(),
-                    'car.repository' => new CarRepository(),
+                    'person.data_source' => $this->personService,
+                    'car.repository' => $this->carService,
                     default => throw new \RuntimeException("Service not found: {$id}")
                 };
             }

--- a/tests/Integration/ServiceLocatorIntegrationTest.php
+++ b/tests/Integration/ServiceLocatorIntegrationTest.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\ArrayServiceLocator;
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Kassko\Sample\PersonDataSource;
+use Kassko\Sample\CarRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class ServiceLocatorIntegrationTest extends TestCase
+{
+    public function testDirectContainerResolution(): void
+    {
+        // Create a mock container
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                if ($id === 'person.datasource') {
+                    return new PersonDataSource();
+                }
+                throw new \RuntimeException("Service not found: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === 'person.datasource';
+            }
+        };
+
+        // Create an entity that uses @service.id pattern
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: '@person.datasource', method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $dataMapper = (new DataMapperBuilder())
+            ->setContainer($container)
+            ->build();
+
+        $dataMapper->prepare($entity);
+
+        $this->assertEquals('foo', $entity->getName());
+    }
+
+    public function testLocatorResolutionWithFQCN(): void
+    {
+        // Create locator mapping FQCN to service ID
+        $locator = new ArrayServiceLocator([
+            PersonDataSource::class => '@person.data_source',
+        ]);
+
+        // Create a mock container
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                if ($id === 'person.data_source') {
+                    return new PersonDataSource();
+                }
+                throw new \RuntimeException("Service not found: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === 'person.data_source';
+            }
+        };
+
+        // Create an entity using FQCN in DataSource
+        $entity = new class(2) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $dataMapper = (new DataMapperBuilder())
+            ->setContainer($container)
+            ->addLocator($locator)
+            ->build();
+
+        $dataMapper->prepare($entity);
+
+        $this->assertEquals('bar', $entity->getName());
+    }
+
+    public function testDirectInstantiationWithNoContainerOrLocator(): void
+    {
+        // Create an entity using direct class reference
+        $entity = new class(3) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        // Build without container or locators - should instantiate directly
+        $dataMapper = (new DataMapperBuilder())->build();
+
+        $dataMapper->prepare($entity);
+
+        $this->assertEquals('baz', $entity->getName());
+    }
+
+    public function testMultipleLocators(): void
+    {
+        $familyLocator = new ArrayServiceLocator([
+            PersonDataSource::class => '@person.data_source',
+        ]);
+
+        $vehicleLocator = new ArrayServiceLocator([
+            CarRepository::class => '@car.repository',
+        ]);
+
+        // Create a mock container
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                return match($id) {
+                    'person.data_source' => new PersonDataSource(),
+                    'car.repository' => new CarRepository(),
+                    default => throw new \RuntimeException("Service not found: {$id}")
+                };
+            }
+
+            public function has(string $id): bool
+            {
+                return in_array($id, ['person.data_source', 'car.repository']);
+            }
+        };
+
+        // Create an entity using PersonDataSource
+        $person = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: PersonDataSource::class, method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $dataMapper = (new DataMapperBuilder())
+            ->setContainer($container)
+            ->addLocator($familyLocator)
+            ->addLocator($vehicleLocator)
+            ->build();
+
+        $dataMapper->prepare($person);
+
+        $this->assertEquals('foo', $person->getName());
+    }
+
+    public function testSemanticKeyResolution(): void
+    {
+        // Create locator with semantic keys
+        $proofLocator = new ArrayServiceLocator([
+            'DIPLOMA' => PersonDataSource::class,  // Maps to a class that will be instantiated
+        ]);
+
+        // Create an entity using semantic key
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: 'DIPLOMA', method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $dataMapper = (new DataMapperBuilder())
+            ->addLocator($proofLocator)
+            ->build();
+
+        $dataMapper->prepare($entity);
+
+        $this->assertEquals('foo', $entity->getName());
+    }
+
+    public function testLocatorPriorityOrder(): void
+    {
+        // First locator
+        $locator1 = new ArrayServiceLocator([
+            'TEST_KEY' => PersonDataSource::class,
+        ]);
+
+        // Second locator with same key (should not be used)
+        $locator2 = new ArrayServiceLocator([
+            'TEST_KEY' => CarRepository::class,
+        ]);
+
+        // Create an entity
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: 'TEST_KEY', method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        // First locator should take priority
+        $dataMapper = (new DataMapperBuilder())
+            ->addLocator($locator1)
+            ->addLocator($locator2)
+            ->build();
+
+        $dataMapper->prepare($entity);
+
+        $this->assertEquals('foo', $entity->getName());
+    }
+
+    public function testRecursiveResolution(): void
+    {
+        // Locator maps semantic key to service ID
+        $locator = new ArrayServiceLocator([
+            'MY_DATASOURCE' => '@person.data_source',
+        ]);
+
+        // Container resolves service ID
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                if ($id === 'person.data_source') {
+                    return new PersonDataSource();
+                }
+                throw new \RuntimeException("Service not found: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === 'person.data_source';
+            }
+        };
+
+        // Create an entity using semantic key
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: 'MY_DATASOURCE', method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $dataMapper = (new DataMapperBuilder())
+            ->setContainer($container)
+            ->addLocator($locator)
+            ->build();
+
+        $dataMapper->prepare($entity);
+
+        // Should resolve: MY_DATASOURCE -> @person.data_source -> PersonDataSource instance
+        $this->assertEquals('foo', $entity->getName());
+    }
+}

--- a/tests/Integration/ServiceLocatorIntegrationTest.php
+++ b/tests/Integration/ServiceLocatorIntegrationTest.php
@@ -8,6 +8,7 @@ use Kassko\DataMapper\DataMapperBuilder;
 use Kassko\DataMapper\ArrayServiceLocator;
 use Kassko\DataMapper\Attribute\DataSource;
 use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use Kassko\Sample\PersonDataSource;
 use Kassko\Sample\CarRepository;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,10 @@ use Psr\Container\ContainerInterface;
 
 final class ServiceLocatorIntegrationTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
     public function testDirectContainerResolution(): void
     {
         // Create a mock container
@@ -58,7 +63,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
             ->setContainer($container)
             ->build();
 
-        $dataMapper->prepare($entity);
 
         $this->assertEquals('foo', $entity->getName());
     }
@@ -112,7 +116,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
             ->addLocator($locator)
             ->build();
 
-        $dataMapper->prepare($entity);
 
         $this->assertEquals('bar', $entity->getName());
     }
@@ -143,7 +146,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
         // Build without container or locators - should instantiate directly
         $dataMapper = (new DataMapperBuilder())->build();
 
-        $dataMapper->prepare($entity);
 
         $this->assertEquals('baz', $entity->getName());
     }
@@ -210,7 +212,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
             ->addLocator($vehicleLocator)
             ->build();
 
-        $dataMapper->prepare($person);
 
         $this->assertEquals('foo', $person->getName());
     }
@@ -247,7 +248,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
             ->addLocator($proofLocator)
             ->build();
 
-        $dataMapper->prepare($entity);
 
         $this->assertEquals('foo', $entity->getName());
     }
@@ -291,7 +291,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
             ->addLocator($locator2)
             ->build();
 
-        $dataMapper->prepare($entity);
 
         $this->assertEquals('foo', $entity->getName());
     }
@@ -345,7 +344,6 @@ final class ServiceLocatorIntegrationTest extends TestCase
             ->addLocator($locator)
             ->build();
 
-        $dataMapper->prepare($entity);
 
         // Should resolve: MY_DATASOURCE -> @person.data_source -> PersonDataSource instance
         $this->assertEquals('foo', $entity->getName());

--- a/tests/Integration/ServiceLocatorTest.php
+++ b/tests/Integration/ServiceLocatorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Kassko\Sample\PersonDataSource;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ServiceLocatorTest extends TestCase
+{
+    public function testServiceLocatorWithContainerPrefix(): void
+    {
+        // Create a mock container
+        $container = new class implements ContainerInterface {
+            public function get(string $id): object
+            {
+                if ($id === 'person.data_source') {
+                    return new PersonDataSource();
+                }
+                throw new \RuntimeException("Service not found: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === 'person.data_source';
+            }
+        };
+
+        // Create an entity that uses service locator pattern
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: '@person.data_source', method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            #[DataSource(class: '@person.data_source', method: 'getData', args: ['#id'])]
+            private ?string $email = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+
+            public function getEmail(): ?string
+            {
+                $this->loadProperty('email');
+                return $this->email;
+            }
+        };
+
+        $dataMapper = new DataMapper($container);
+        $dataMapper->prepare($entity);
+
+        $this->assertEquals('foo', $entity->getName());
+        $this->assertEquals('foo@aaa.com', $entity->getEmail());
+    }
+
+    public function testServiceLocatorThrowsExceptionWithoutContainer(): void
+    {
+        // Create an entity that uses service locator pattern
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: '@person.data_source', method: 'getData', args: ['#id'])]
+            private ?string $name = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $dataMapper = new DataMapper(); // No container provided
+        $dataMapper->prepare($entity);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot resolve service identifier');
+
+        $entity->getName();
+    }
+}

--- a/tests/Integration/ServiceLocatorTest.php
+++ b/tests/Integration/ServiceLocatorTest.php
@@ -61,11 +61,12 @@ class ServiceLocatorTest extends TestCase
             }
         };
 
-        $dataMapper = new DataMapper($container);
-        $dataMapper->prepare($entity);
+        new DataMapper($container);
 
         $this->assertEquals('foo', $entity->getName());
         $this->assertEquals('foo@aaa.com', $entity->getEmail());
+        
+        \Kassko\DataMapper\Registry\LazyLoaderRegistry::clear();
     }
 
     public function testServiceLocatorThrowsExceptionWithoutContainer(): void
@@ -91,12 +92,13 @@ class ServiceLocatorTest extends TestCase
             }
         };
 
-        $dataMapper = new DataMapper(); // No container provided
-        $dataMapper->prepare($entity);
+        new DataMapper(); // No container provided
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot resolve service identifier');
 
         $entity->getName();
+        
+        \Kassko\DataMapper\Registry\LazyLoaderRegistry::clear();
     }
 }

--- a/tests/Unit/ArrayServiceLocatorTest.php
+++ b/tests/Unit/ArrayServiceLocatorTest.php
@@ -47,7 +47,7 @@ final class ArrayServiceLocatorTest extends TestCase
             'key1' => 'value1',
         ]);
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\Psr\Container\NotFoundExceptionInterface::class);
         $this->expectExceptionMessage('Key "nonexistent" not found in locator');
 
         $locator->get('nonexistent');

--- a/tests/Unit/ArrayServiceLocatorTest.php
+++ b/tests/Unit/ArrayServiceLocatorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit;
+
+use Kassko\DataMapper\ArrayServiceLocator;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayServiceLocatorTest extends TestCase
+{
+    public function testHasReturnsTrueForExistingKey(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ]);
+
+        $this->assertTrue($locator->has('key1'));
+        $this->assertTrue($locator->has('key2'));
+    }
+
+    public function testHasReturnsFalseForNonExistingKey(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'key1' => 'value1',
+        ]);
+
+        $this->assertFalse($locator->has('key2'));
+        $this->assertFalse($locator->has('nonexistent'));
+    }
+
+    public function testGetReturnsValueForExistingKey(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'PersonDataSource' => '@person.data_source',
+            'CarRepository' => '@car.repository',
+        ]);
+
+        $this->assertEquals('@person.data_source', $locator->get('PersonDataSource'));
+        $this->assertEquals('@car.repository', $locator->get('CarRepository'));
+    }
+
+    public function testGetThrowsExceptionForNonExistingKey(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'key1' => 'value1',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Key "nonexistent" not found in locator');
+
+        $locator->get('nonexistent');
+    }
+
+    public function testEmptyLocator(): void
+    {
+        $locator = new ArrayServiceLocator([]);
+
+        $this->assertFalse($locator->has('anything'));
+    }
+
+    public function testLocatorWithServiceIds(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'Kassko\Sample\PersonDataSource' => '@person.data_source',
+            'Kassko\Sample\PetDataSource' => '@pet.data_source',
+        ]);
+
+        $this->assertTrue($locator->has('Kassko\Sample\PersonDataSource'));
+        $this->assertEquals('@person.data_source', $locator->get('Kassko\Sample\PersonDataSource'));
+    }
+
+    public function testLocatorWithClassNames(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'DIPLOMA' => 'Kassko\Sample\DiplomaProof',
+            'CERTIFICATION' => 'Kassko\Sample\CertificationProof',
+        ]);
+
+        $this->assertTrue($locator->has('DIPLOMA'));
+        $this->assertEquals('Kassko\Sample\DiplomaProof', $locator->get('DIPLOMA'));
+    }
+}

--- a/tests/Unit/AttributeReaderTest.php
+++ b/tests/Unit/AttributeReaderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Metadata\AttributeReader;
+use Kassko\Sample\Person;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class AttributeReaderTest extends TestCase
+{
+    private AttributeReader $reader;
+
+    protected function setUp(): void
+    {
+        $this->reader = new AttributeReader();
+    }
+
+    public function testReadDataSourceFromProperty(): void
+    {
+        $person = new Person(1);
+        $reflectionClass = new ReflectionClass($person);
+        $property = $reflectionClass->getProperty('name');
+
+        $dataSource = $this->reader->readDataSource($property);
+
+        $this->assertInstanceOf(DataSource::class, $dataSource);
+        $this->assertStringContainsString('PersonDataSource', $dataSource->class);
+        $this->assertEquals('getData', $dataSource->method);
+        $this->assertEquals(['#id'], $dataSource->args);
+    }
+
+    public function testReadDataSourceReturnsNullForPropertyWithoutAttribute(): void
+    {
+        $person = new Person(1);
+        $reflectionClass = new ReflectionClass($person);
+        $property = $reflectionClass->getProperty('id');
+
+        $dataSource = $this->reader->readDataSource($property);
+
+        $this->assertNull($dataSource);
+    }
+
+    public function testGetPropertiesWithDataSource(): void
+    {
+        $person = new Person(1);
+        $properties = $this->reader->getPropertiesWithDataSource($person);
+
+        $this->assertCount(2, $properties);
+        $this->assertArrayHasKey('name', $properties);
+        $this->assertArrayHasKey('email', $properties);
+        $this->assertInstanceOf(DataSource::class, $properties['name']);
+        $this->assertInstanceOf(DataSource::class, $properties['email']);
+    }
+}

--- a/tests/Unit/DataMapperBuilderTest.php
+++ b/tests/Unit/DataMapperBuilderTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit;
+
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\ArrayServiceLocator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class DataMapperBuilderTest extends TestCase
+{
+    public function testBuildReturnsDataMapper(): void
+    {
+        $builder = new DataMapperBuilder();
+        $dataMapper = $builder->build();
+
+        $this->assertInstanceOf(DataMapper::class, $dataMapper);
+    }
+
+    public function testBuildWithContainer(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        
+        $builder = new DataMapperBuilder();
+        $dataMapper = $builder
+            ->setContainer($container)
+            ->build();
+
+        $this->assertInstanceOf(DataMapper::class, $dataMapper);
+    }
+
+    public function testBuildWithLocators(): void
+    {
+        $locator1 = new ArrayServiceLocator(['key1' => 'value1']);
+        $locator2 = new ArrayServiceLocator(['key2' => 'value2']);
+        
+        $builder = new DataMapperBuilder();
+        $dataMapper = $builder
+            ->addLocator($locator1)
+            ->addLocator($locator2)
+            ->build();
+
+        $this->assertInstanceOf(DataMapper::class, $dataMapper);
+    }
+
+    public function testBuildWithContainerAndLocators(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $locator = new ArrayServiceLocator(['key1' => 'value1']);
+        
+        $builder = new DataMapperBuilder();
+        $dataMapper = $builder
+            ->setContainer($container)
+            ->addLocator($locator)
+            ->build();
+
+        $this->assertInstanceOf(DataMapper::class, $dataMapper);
+    }
+
+    public function testBuilderIsReusable(): void
+    {
+        $builder = new DataMapperBuilder();
+        
+        $dataMapper1 = $builder->build();
+        $dataMapper2 = $builder->build();
+
+        $this->assertInstanceOf(DataMapper::class, $dataMapper1);
+        $this->assertInstanceOf(DataMapper::class, $dataMapper2);
+        $this->assertNotSame($dataMapper1, $dataMapper2);
+    }
+
+    public function testBuilderFluentInterface(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $locator1 = new ArrayServiceLocator(['key1' => 'value1']);
+        $locator2 = new ArrayServiceLocator(['key2' => 'value2']);
+        
+        $builder = new DataMapperBuilder();
+        
+        // Test that methods return builder instance for chaining
+        $result = $builder->setContainer($container);
+        $this->assertSame($builder, $result);
+        
+        $result = $builder->addLocator($locator1);
+        $this->assertSame($builder, $result);
+        
+        $result = $builder->addLocator($locator2);
+        $this->assertSame($builder, $result);
+    }
+
+    public function testMultipleLocatorsCanBeAdded(): void
+    {
+        $locators = [
+            new ArrayServiceLocator(['person' => '@person.service']),
+            new ArrayServiceLocator(['car' => '@car.service']),
+            new ArrayServiceLocator(['pet' => '@pet.service']),
+        ];
+        
+        $builder = new DataMapperBuilder();
+        
+        foreach ($locators as $locator) {
+            $builder->addLocator($locator);
+        }
+        
+        $dataMapper = $builder->build();
+        
+        $this->assertInstanceOf(DataMapper::class, $dataMapper);
+    }
+}

--- a/tests/Unit/LazyLoaderTest.php
+++ b/tests/Unit/LazyLoaderTest.php
@@ -19,7 +19,6 @@ class LazyLoaderTest extends TestCase
         // Verify property is null before loading
         $reflection = new ReflectionClass($person);
         $nameProperty = $reflection->getProperty('name');
-        $nameProperty->setAccessible(true);
         $this->assertNull($nameProperty->getValue($person));
 
         // Load the property
@@ -41,11 +40,9 @@ class LazyLoaderTest extends TestCase
         $reflection = new ReflectionClass($person);
         
         $nameProperty = $reflection->getProperty('name');
-        $nameProperty->setAccessible(true);
         $this->assertEquals('foo', $nameProperty->getValue($person));
 
         $emailProperty = $reflection->getProperty('email');
-        $emailProperty->setAccessible(true);
         $this->assertEquals('foo@aaa.com', $emailProperty->getValue($person));
     }
 
@@ -60,7 +57,6 @@ class LazyLoaderTest extends TestCase
         // Get the value
         $reflection = new ReflectionClass($person);
         $nameProperty = $reflection->getProperty('name');
-        $nameProperty->setAccessible(true);
         $firstValue = $nameProperty->getValue($person);
 
         // Manually change the value
@@ -85,11 +81,9 @@ class LazyLoaderTest extends TestCase
         $reflection = new ReflectionClass($person1);
         
         $person1Name = $reflection->getProperty('name');
-        $person1Name->setAccessible(true);
         $this->assertEquals('foo', $person1Name->getValue($person1));
 
         $person2Name = $reflection->getProperty('name');
-        $person2Name->setAccessible(true);
         $this->assertEquals('bar', $person2Name->getValue($person2));
     }
 }

--- a/tests/Unit/LazyLoaderTest.php
+++ b/tests/Unit/LazyLoaderTest.php
@@ -19,6 +19,7 @@ class LazyLoaderTest extends TestCase
         // Verify property is null before loading
         $reflection = new ReflectionClass($person);
         $nameProperty = $reflection->getProperty('name');
+        $nameProperty->setAccessible(true);
         $this->assertNull($nameProperty->getValue($person));
 
         // Load the property
@@ -40,9 +41,11 @@ class LazyLoaderTest extends TestCase
         $reflection = new ReflectionClass($person);
         
         $nameProperty = $reflection->getProperty('name');
+        $nameProperty->setAccessible(true);
         $this->assertEquals('foo', $nameProperty->getValue($person));
 
         $emailProperty = $reflection->getProperty('email');
+        $emailProperty->setAccessible(true);
         $this->assertEquals('foo@aaa.com', $emailProperty->getValue($person));
     }
 
@@ -57,6 +60,7 @@ class LazyLoaderTest extends TestCase
         // Get the value
         $reflection = new ReflectionClass($person);
         $nameProperty = $reflection->getProperty('name');
+        $nameProperty->setAccessible(true);
         $firstValue = $nameProperty->getValue($person);
 
         // Manually change the value
@@ -81,9 +85,11 @@ class LazyLoaderTest extends TestCase
         $reflection = new ReflectionClass($person1);
         
         $person1Name = $reflection->getProperty('name');
+        $person1Name->setAccessible(true);
         $this->assertEquals('foo', $person1Name->getValue($person1));
 
         $person2Name = $reflection->getProperty('name');
+        $person2Name->setAccessible(true);
         $this->assertEquals('bar', $person2Name->getValue($person2));
     }
 }

--- a/tests/Unit/LazyLoaderTest.php
+++ b/tests/Unit/LazyLoaderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit;
+
+use Kassko\DataMapper\LazyLoader\LazyLoader;
+use Kassko\Sample\Person;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class LazyLoaderTest extends TestCase
+{
+    public function testLoadPropertyHydratesProperty(): void
+    {
+        $loader = new LazyLoader();
+        $person = new Person(1);
+
+        // Verify property is null before loading
+        $reflection = new ReflectionClass($person);
+        $nameProperty = $reflection->getProperty('name');
+        $nameProperty->setAccessible(true);
+        $this->assertNull($nameProperty->getValue($person));
+
+        // Load the property
+        $loader->loadProperty($person, 'name');
+
+        // Verify property is hydrated
+        $this->assertEquals('foo', $nameProperty->getValue($person));
+    }
+
+    public function testLoadPropertyHydratesAllPropertiesWithSameSignature(): void
+    {
+        $loader = new LazyLoader();
+        $person = new Person(1);
+
+        // Load only 'name' property
+        $loader->loadProperty($person, 'name');
+
+        // Verify both 'name' and 'email' are hydrated (same signature)
+        $reflection = new ReflectionClass($person);
+        
+        $nameProperty = $reflection->getProperty('name');
+        $nameProperty->setAccessible(true);
+        $this->assertEquals('foo', $nameProperty->getValue($person));
+
+        $emailProperty = $reflection->getProperty('email');
+        $emailProperty->setAccessible(true);
+        $this->assertEquals('foo@aaa.com', $emailProperty->getValue($person));
+    }
+
+    public function testLoadPropertyDoesNotReloadAlreadyLoadedProperty(): void
+    {
+        $loader = new LazyLoader();
+        $person = new Person(1);
+
+        // Load the property once
+        $loader->loadProperty($person, 'name');
+
+        // Get the value
+        $reflection = new ReflectionClass($person);
+        $nameProperty = $reflection->getProperty('name');
+        $nameProperty->setAccessible(true);
+        $firstValue = $nameProperty->getValue($person);
+
+        // Manually change the value
+        $nameProperty->setValue($person, 'modified');
+
+        // Try to load again
+        $loader->loadProperty($person, 'name');
+
+        // Verify it wasn't reloaded (value should still be 'modified')
+        $this->assertEquals('modified', $nameProperty->getValue($person));
+    }
+
+    public function testDifferentObjectsAreLoadedIndependently(): void
+    {
+        $loader = new LazyLoader();
+        $person1 = new Person(1);
+        $person2 = new Person(2);
+
+        $loader->loadProperty($person1, 'name');
+        $loader->loadProperty($person2, 'name');
+
+        $reflection = new ReflectionClass($person1);
+        
+        $person1Name = $reflection->getProperty('name');
+        $person1Name->setAccessible(true);
+        $this->assertEquals('foo', $person1Name->getValue($person1));
+
+        $person2Name = $reflection->getProperty('name');
+        $person2Name->setAccessible(true);
+        $this->assertEquals('bar', $person2Name->getValue($person2));
+    }
+}

--- a/tests/Unit/LazyLoaderValidationTest.php
+++ b/tests/Unit/LazyLoaderValidationTest.php
@@ -7,10 +7,15 @@ namespace Kassko\DataMapper\Tests\Unit;
 use Kassko\DataMapper\Attribute\DataSource;
 use Kassko\DataMapper\DataMapper;
 use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
 use PHPUnit\Framework\TestCase;
 
 class LazyLoaderValidationTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
     public function testThrowsExceptionForNonExistentClass(): void
     {
         $entity = new class(1) {
@@ -34,7 +39,6 @@ class LazyLoaderValidationTest extends TestCase
         };
 
         $dataMapper = new DataMapper();
-        $dataMapper->prepare($entity);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage("DataSource class 'NonExistentClass' does not exist");
@@ -65,7 +69,6 @@ class LazyLoaderValidationTest extends TestCase
         };
 
         $dataMapper = new DataMapper();
-        $dataMapper->prepare($entity);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Method nonExistentMethod does not exist');

--- a/tests/Unit/LazyLoaderValidationTest.php
+++ b/tests/Unit/LazyLoaderValidationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit;
+
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+use PHPUnit\Framework\TestCase;
+
+class LazyLoaderValidationTest extends TestCase
+{
+    public function testThrowsExceptionForNonExistentClass(): void
+    {
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: 'NonExistentClass', method: 'getData', args: ['#id'])]
+            private ?string $data = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getData(): ?string
+            {
+                $this->loadProperty('data');
+                return $this->data;
+            }
+        };
+
+        $dataMapper = new DataMapper();
+        $dataMapper->prepare($entity);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("DataSource class 'NonExistentClass' does not exist");
+
+        $entity->getData();
+    }
+
+    public function testThrowsExceptionForNonExistentMethod(): void
+    {
+        $entity = new class(1) {
+            use LoadableTrait;
+
+            private int $id;
+
+            #[DataSource(class: 'Kassko\Sample\PersonDataSource', method: 'nonExistentMethod', args: ['#id'])]
+            private ?string $data = null;
+
+            public function __construct(int $id)
+            {
+                $this->id = $id;
+            }
+
+            public function getData(): ?string
+            {
+                $this->loadProperty('data');
+                return $this->data;
+            }
+        };
+
+        $dataMapper = new DataMapper();
+        $dataMapper->prepare($entity);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Method nonExistentMethod does not exist');
+
+        $entity->getData();
+    }
+
+    public function testThrowsExceptionForAbstractClass(): void
+    {
+        // Create an abstract class for testing
+        $abstractClassName = 'AbstractDataSource_' . uniqid();
+        eval("
+            abstract class {$abstractClassName} {
+                abstract public function getData(int \$id): array;
+            }
+        ");
+
+        $entity = new class($abstractClassName, 1) {
+            use LoadableTrait;
+
+            private string $className;
+            private int $id;
+
+            public function __construct(string $className, int $id)
+            {
+                $this->className = $className;
+                $this->id = $id;
+            }
+
+            public function getData(): ?string
+            {
+                $this->loadProperty('data');
+                return 'test';
+            }
+        };
+
+        // We can't easily test this with attributes since the class name needs to be known at compile time
+        // This test demonstrates the concept but we'll skip it
+        $this->markTestSkipped('Cannot easily test abstract class validation with attributes');
+    }
+}

--- a/tests/Unit/Registry/LazyLoaderRegistryTest.php
+++ b/tests/Unit/Registry/LazyLoaderRegistryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit\Registry;
+
+use Kassko\DataMapper\Registry\LazyLoaderRegistry;
+use Kassko\DataMapper\LazyLoader\LazyLoaderInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LazyLoaderRegistryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        LazyLoaderRegistry::clear();
+    }
+
+    public function testSetAndGet(): void
+    {
+        $loader = $this->createMock(LazyLoaderInterface::class);
+        
+        LazyLoaderRegistry::set($loader);
+        
+        $this->assertSame($loader, LazyLoaderRegistry::get());
+    }
+
+    public function testHasReturnsFalseWhenEmpty(): void
+    {
+        $this->assertFalse(LazyLoaderRegistry::has());
+    }
+
+    public function testHasReturnsTrueWhenSet(): void
+    {
+        $loader = $this->createMock(LazyLoaderInterface::class);
+        LazyLoaderRegistry::set($loader);
+        
+        $this->assertTrue(LazyLoaderRegistry::has());
+    }
+
+    public function testClear(): void
+    {
+        $loader = $this->createMock(LazyLoaderInterface::class);
+        LazyLoaderRegistry::set($loader);
+        LazyLoaderRegistry::clear();
+        
+        $this->assertFalse(LazyLoaderRegistry::has());
+    }
+}

--- a/tests/Unit/ServiceResolverTest.php
+++ b/tests/Unit/ServiceResolverTest.php
@@ -98,7 +98,7 @@ final class ServiceResolverTest extends TestCase
         
         $container = $this->createMock(ContainerInterface::class);
         $container->method('has')->willReturnCallback(
-            fn($id) => in_array($id, ['person.data_source', 'car.repository'])
+            fn(string $id) => in_array($id, ['person.data_source', 'car.repository'])
         );
         $container->method('get')->willReturnCallback(function($id) use ($personService, $carService) {
             return match($id) {

--- a/tests/Unit/ServiceResolverTest.php
+++ b/tests/Unit/ServiceResolverTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit;
+
+use Kassko\DataMapper\ServiceResolver;
+use Kassko\DataMapper\ArrayServiceLocator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class ServiceResolverTest extends TestCase
+{
+    public function testResolveDirectContainerLookup(): void
+    {
+        $service = new \stdClass();
+        
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with('person.datasource')->willReturn(true);
+        $container->method('get')->with('person.datasource')->willReturn($service);
+
+        $resolver = new ServiceResolver($container, []);
+        
+        $this->assertSame($service, $resolver->resolve('@person.datasource'));
+    }
+
+    public function testResolveViaLocator(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'Kassko\Sample\PersonDataSource' => '@person.data_source',
+        ]);
+
+        $service = new \stdClass();
+        
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with('person.data_source')->willReturn(true);
+        $container->method('get')->with('person.data_source')->willReturn($service);
+
+        $resolver = new ServiceResolver($container, [$locator]);
+        
+        $this->assertSame($service, $resolver->resolve('Kassko\Sample\PersonDataSource'));
+    }
+
+    public function testResolveDirectInstantiation(): void
+    {
+        $resolver = new ServiceResolver(null, []);
+        
+        $instance = $resolver->resolve(\stdClass::class);
+        
+        $this->assertInstanceOf(\stdClass::class, $instance);
+    }
+
+    public function testThrowsWhenNoContainerForServiceId(): void
+    {
+        $resolver = new ServiceResolver(null, []);
+        
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot resolve service identifier');
+        
+        $resolver->resolve('@some.service');
+    }
+
+    public function testThrowsWhenClassDoesNotExist(): void
+    {
+        $resolver = new ServiceResolver(null, []);
+        
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("DataSource class 'NonExistentClass' does not exist");
+        
+        $resolver->resolve('NonExistentClass');
+    }
+
+    public function testThrowsWhenServiceNotFoundInContainer(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with('unknown.service')->willReturn(false);
+
+        $resolver = new ServiceResolver($container, []);
+        
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Service "unknown.service" not found in container');
+        
+        $resolver->resolve('@unknown.service');
+    }
+
+    public function testResolveViaMultipleLocators(): void
+    {
+        $familyLocator = new ArrayServiceLocator([
+            'Kassko\Sample\PersonDataSource' => '@person.data_source',
+        ]);
+
+        $vehicleLocator = new ArrayServiceLocator([
+            'Kassko\Sample\CarRepository' => '@car.repository',
+        ]);
+
+        $personService = new \stdClass();
+        $carService = new \stdClass();
+        
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturnCallback(
+            fn($id) => in_array($id, ['person.data_source', 'car.repository'])
+        );
+        $container->method('get')->willReturnCallback(function($id) use ($personService, $carService) {
+            return match($id) {
+                'person.data_source' => $personService,
+                'car.repository' => $carService,
+            };
+        });
+
+        $resolver = new ServiceResolver($container, [$familyLocator, $vehicleLocator]);
+        
+        $this->assertSame($personService, $resolver->resolve('Kassko\Sample\PersonDataSource'));
+        $this->assertSame($carService, $resolver->resolve('Kassko\Sample\CarRepository'));
+    }
+
+    public function testResolveLocatorReturnsClassName(): void
+    {
+        $locator = new ArrayServiceLocator([
+            'DIPLOMA' => \stdClass::class,
+        ]);
+
+        $resolver = new ServiceResolver(null, [$locator]);
+        
+        $instance = $resolver->resolve('DIPLOMA');
+        
+        $this->assertInstanceOf(\stdClass::class, $instance);
+    }
+}


### PR DESCRIPTION
# PR #7: Implement PSR-11 interface and registry pattern for LazyLoader

**Author:** Kassko  
**Created:** 2025-12-19  
**Merged:** 2025-12-19  

---

Makes `ServiceLocatorInterface` extend PSR-11 `ContainerInterface` and removes the need for `prepare()` calls via a static registry pattern, enabling automatic lazy loading and object serialization.

## Changes

**PSR-11 Interface Compliance**
- `ServiceLocatorInterface` extends `Psr\Container\ContainerInterface`
- Method signatures updated: `$key` → `$id`, return type `string` → `mixed`
- `ArrayServiceLocator` throws proper `NotFoundException` implementing `NotFoundExceptionInterface`
- Constructor default: `array $map = []`

**Registry Pattern**
- Added `LazyLoaderRegistry` with static `set()`/`get()`/`has()`/`clear()` methods
- `LoadableTrait` queries registry instead of storing injected loader
- `DataMapperBuilder::build()` registers LazyLoader globally
- `DataMapper` constructor auto-registers for backward compatibility
- Removed `prepare()` method and loader property injection

**Benefits**
- Objects serializable (no service dependencies)
- Graceful degradation when DataMapper unconfigured
- Simpler API surface

## Usage

**Before:**
```php
$dataMapper = new DataMapper();
$person = new Person(1);
$dataMapper->prepare($person);
$name = $person->getName();
```

**After:**
```php
(new DataMapperBuilder())->build();
$person = new Person(1);
$name = $person->getName();  // Just works
$serialized = serialize($person);  // Now possible
```

Backward compatible: existing `DataMapper` instantiation continues to work.
