### PR TITLE
Context Improvements, Property Locking Ignorance & Data Lineage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main, 2.0-alpha]
+    branches: [main, 2.0]
   pull_request:
-    branches: [main, 2.0-alpha]
+    branches: [main, 2.0]
 
 jobs:
   test:

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -694,3 +694,139 @@ All DataSource attributes now support priority (default: 0):
     priority: 10  // Higher priority overrides lower priority
 )]
 ```
+
+## Context
+
+### Hydration Context with Named Arguments
+
+Pass contextual information through the object hierarchy:
+
+```php
+use Kassko\DataMapper\Attribute\Context;
+
+class Company
+{
+    #[Context(
+        company_type: 'enterprise',
+        region: 'europe',
+        tier: 'premium'
+    )]
+    private Chief $chief;
+}
+
+class Chief
+{
+    // Access parent context in expressions
+    #[PropertyCandidates([
+        new PropertyCandidate(
+            discriminator: "expr(context('tier') === 'premium')",
+            property: new Property(class: PremiumOffice::class)
+        ),
+        new PropertyCandidate(
+            discriminator: "expr(contextKeyExists('region'))",
+            property: new Property(class: RegionalOffice::class)
+        )
+    ])]
+    private ?Office $office = null;
+    
+    // Override context for nested objects
+    #[Context(tier: 'standard')]  // Overrides 'premium' from parent
+    private ?Department $department = null;
+}
+```
+
+### Application Context
+
+Set context values from your application before hydration:
+
+```php
+use Kassko\DataMapper\DataMapper;
+
+$dataMapper = new DataMapper($serviceResolver);
+
+// Add feature flags, user info, environment variables
+$dataMapper->addToContext('new_api_enabled', $featureFlag->isEnabled());
+$dataMapper->addToContext('current_user_role', $user->getRole());
+
+// Or add multiple at once
+$dataMapper->addManyToContext([
+    'env' => 'production',
+    'debug' => false,
+    'api_version' => 'v2',
+]);
+
+// Access in entities
+class User
+{
+    #[SinglePropDataSource(
+        class: ProfileService::class,
+        method: 'getProfile',
+        args: "expr(context('new_api_enabled') ? ['v2', #id] : ['v1', #id])"
+    )]
+    private ?Profile $profile = null;
+}
+```
+
+## Data Lineage Collection
+
+Track data flow during hydration for debugging:
+
+```php
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\DataCollector\LineageEvent;
+
+$dataMapper = new DataMapper($serviceResolver);
+
+// Enable lineage collection
+$dataMapper->enableLineageCollection();
+
+// Perform hydration
+$user = new User(123);
+$user->getName();
+$user->getProfile();
+
+// Get lineage information
+$collector = $dataMapper->getLineageCollector();
+
+// Get all events
+$events = $collector->getEvents();
+foreach ($events as $event) {
+    echo sprintf(
+        "[%s] %s::%s - %s\n",
+        $event->type,
+        $event->objectClass,
+        $event->propertyName,
+        $event->reason ?? 'OK'
+    );
+}
+
+// Get summary
+$summary = $collector->getSummary();
+print_r($summary);
+// Output:
+// [
+//     'totalEvents' => 15,
+//     'eventsByType' => [
+//         'datasource_call' => 5,
+//         'property_hydration' => 8,
+//         'property_skipped' => 2,
+//     ],
+//     'skippedReasons' => ['locked' => 1, 'priority' => 1],
+//     'maxDepth' => 3,
+// ]
+
+// Get skipped properties
+$skipped = $collector->getEventsByType(LineageEvent::TYPE_PROPERTY_SKIPPED);
+foreach ($skipped as $event) {
+    echo sprintf(
+        "Skipped %s::%s - Reason: %s\n",
+        $event->objectClass,
+        $event->propertyName,
+        $event->reason
+    );
+}
+
+// Disable when done
+$dataMapper->disableLineageCollection();
+$collector->clear();
+```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,42 @@ $mapper = $builder->build();
 
 ### v2.0 New Features
 
+#### Application Context
+
+Set context values from your application before hydration:
+
+```php
+$dataMapper = new DataMapper($serviceResolver);
+
+// Add application-level context
+$dataMapper->addToContext('feature_enabled', $featureFlag->isEnabled());
+$dataMapper->addManyToContext([
+    'env' => 'production',
+    'user_role' => 'admin',
+]);
+
+// Use in expressions
+#[MultiPropDataSource(
+    args: "expr(context('feature_enabled') ? property('propA') : property('propB'))"
+)]
+```
+
+#### Data Lineage Collection
+
+Track data flow during hydration for debugging:
+
+```php
+$dataMapper->enableLineageCollection();
+
+// ... hydration happens ...
+
+$collector = $dataMapper->getLineageCollector();
+$events = $collector->getEvents();
+$summary = $collector->getSummary();
+```
+
+See [DataLineageCollector](docs/classes/DataLineageCollector.md) for details.
+
 #### Priority System
 
 All DataSource attributes now support a `priority` field (integer, default: 0). Higher priority sources can override values from lower priority sources:
@@ -435,12 +471,30 @@ class Person
 
 #### Context
 
-Set context variables:
+Add context variables for conditional hydration behavior:
 
 ```php
-#[Context(['shop_quality' => 'premium'])]
+#[Context(shop_quality: 'premium', region: 'europe')]
 private ?Shop $shop = null;
 ```
+
+Context values accumulate through nested objects and can be accessed in expressions:
+
+```php
+#[PropertyCandidates([
+    new PropertyCandidate(
+        discriminator: "expr(context('shop_quality') === 'premium')",
+        property: new Property(class: PremiumShop::class)
+    ),
+    new PropertyCandidate(
+        discriminator: "expr(contextKeyExists('region'))",
+        property: new Property(class: RegionalShop::class)
+    )
+])]
+private ?Shop $shop = null;
+```
+
+See [Context](docs/attributes/Context.md) for detailed usage.
 
 ### Expression Language
 
@@ -465,7 +519,8 @@ private ?Shop $shop = null;
 |----------|-------------|
 | `source('id')` | Get DataSource result |
 | `service('id')` | Resolve service |
-| `context('key')` | Get context value |
+| `context('key')` | Get context value (null if missing, logs warning) |
+| `contextKeyExists('key')` | Check if context key exists |
 | `envVar('KEY')` | Environment variable |
 | `object()` | Current object |
 | `parentObject()` | Parent object |

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Architecture — DataMapper (librairie PHP)
+
+## Vue d’ensemble
+
+Le projet est une librairie d’hydratation/lazy-loading orientée **attributs PHP 8** : l’objet métier déclare *quoi charger* et *comment* via des attributs (DataSource, DataSourceRef, Context, hooks…), et un **Loader** applique ces règles au moment opportun (lazy via getters ou eager via `Loading::TYPE_EAGER`).
+
+Le runtime est volontairement léger et découplé d’un framework : l’intégration Symfony se fait principalement via la conformité PSR (PSR-11 container, PSR-3 logger, PSR-16 cache) et un `ServiceResolver` qui sait résoudre des services depuis plusieurs sources.
+
+## Modules (packages) principaux
+
+### 1) Point d’entrée / configuration
+- **`DataMapperBuilder`** : assemble la stratégie de résolution de services (container, locators, factories…) et construit un `DataMapper`.
+- **`DataMapper`** : façade runtime.
+  - Instancie un `Loader` et l’enregistre globalement via `LoaderRegistry`.
+  - Gère le **contexte applicatif** (`addToContext`, `addManyToContext`), et l’activation de la **collecte de lineage** (`enableLineageCollection`).
+
+### 2) Hydratation / exécution
+- **`Loader`** : cœur de l’exécution.
+  - Déclenche l’hydratation d’une propriété (`loadProperty`) ou d’un groupe (`MultiPropDataSource`).
+  - Lit la “métadonnée attributs” via `Metadata\AttributeReader`.
+  - Résout et exécute les DataSources via `ServiceResolver`.
+  - Applique la récursivité (hydrater des objets imbriqués), la sélection par priorité, les hooks, la mise à jour du contexte et l’anti-écrasement via verrouillage.
+
+### 3) Déclaration (attributs)
+- **`Attribute/*`** : ensemble des attributs configurant la stratégie d’hydratation.
+  - `DataSourcesStore` (niveau classe) : registre local des sources.
+  - `DataSourceRef` (niveau propriété) : référence vers une source stockée.
+  - `SinglePropDataSource` / `MultiPropDataSource` : sources directes.
+  - `Context` : injection de valeurs contextuelles pendant l’hydratation.
+  - `Needs`, `Loading`, `PropertyCandidates`, hooks (`PropertySettingHook`, etc.).
+
+### 4) Métadonnées
+- **`Metadata\AttributeReader`** : encapsule Reflection + lecture des attributs et fournit un accès uniforme au Loader.
+
+### 5) Registres (état global, faible couplage)
+- **`LoaderRegistry`** : stockage global du Loader actif (permet à `LoadableTrait` de rester simple).
+- **`ContextRegistry`** : stocke deux sources de contexte :
+  - *application context* (persistant, défini via `DataMapper`),
+  - *hydration context* (défini via `#[Context]`, priorité sur l’application).
+- **`LockedPropertyRegistry`** : verrouillage de propriété via `WeakMap` (état externe à l’objet → évite la sérialisation involontaire).
+
+### 6) Expressions
+- **`Expression\ExpressionParser`** : résout des arguments "dynamiques" (références de propriétés `#prop`, expressions `expr(...)`, accès `context('k')`, `source('id')`, `service('id')`, etc.).
+- **`Expression\SourceFunctionProvider`** : exécute et éventuellement cache les résultats de sources `source('id')`.
+
+### 7) Observabilité
+- **`DataCollector\DataLineageCollector` + `LineageEvent`** : collecte optionnelle d’événements (calls DataSource, hydrations, skips, hooks, context set…). Le Loader appelle le collecteur si activé.
+
+## Flux de données (runtime)
+
+### Scénario "lazy load" typique
+1. Un getter côté objet métier appelle `loadProperty('x')` (via `LoadableTrait`).
+2. `LoadableTrait` récupère le `Loader` global via `LoaderRegistry`.
+3. `Loader::loadProperty()` :
+   - vérifie le verrouillage (`LockedPropertyRegistry` / `isPropertyLocked()`),
+   - vérifie si la propriété est déjà chargée,
+   - lit les attributs de la propriété (`AttributeReader`).
+4. Résolution de la source :
+   - `DataSourceRef` → lookup dans `DataSourcesStore` (niveau classe),
+   - ou source directe (Single/MultiProp) sur la propriété.
+5. Exécution de la source : le Loader utilise `ServiceResolver` pour instancier/récupérer la classe source puis appelle la méthode.
+   - Si des args sont présents, `ExpressionParser` peut évaluer `expr(...)`, `context(...)`, `source(...)`, etc.
+6. Hydratation : mapping éventuel, récursivité, hooks, mise à jour du contexte (`ContextRegistry`), puis écriture de la propriété (setter ou accès direct selon stratégie).
+7. Marquage “loaded” et, si activé, enregistrement des events dans `DataLineageCollector`.
+
+### Points clés de conception
+- **Découplage** via PSR et registres : le domaine n’a pas besoin de connaître le Loader concret.
+- **État externe** (locks via WeakMap) pour éviter la pollution des objets.
+- **Contexte à deux niveaux** (application vs hydration) pour permettre des expressions pilotées par l’environnement.
+- **Observabilité** intégrée sans impacter le chemin critique quand désactivée.

--- a/docs/architecture/class-packages.puml
+++ b/docs/architecture/class-packages.puml
@@ -1,0 +1,75 @@
+@startuml
+' DataMapper — Class / Package overview (high-level)
+
+skinparam packageStyle rectangle
+skinparam linetype ortho
+hide empty members
+
+package "Kassko\\DataMapper" as Root {
+  class DataMapper
+  class DataMapperBuilder
+  class ServiceResolver
+  class ArrayServiceLocator
+  interface ServiceLocatorInterface
+}
+
+package "Kassko\\DataMapper\\Loader" as LoaderPkg {
+  interface LoaderInterface
+  class Loader
+}
+
+package "Kassko\\DataMapper\\Metadata" as MetaPkg {
+  class AttributeReader
+}
+
+package "Kassko\\DataMapper\\Registry" as RegPkg {
+  class LoaderRegistry
+  class ContextRegistry
+  class LockedPropertyRegistry
+}
+
+package "Kassko\\DataMapper\\ObjectExtension" as ObjPkg {
+  class LoadableTrait <<trait>>
+  class LoadableInternalTrait <<trait>>
+}
+
+package "Kassko\\DataMapper\\Expression" as ExprPkg {
+  class ExpressionParser
+  class SourceFunctionProvider
+}
+
+package "Kassko\\DataMapper\\DataCollector" as CollectPkg {
+  class DataLineageCollector
+  class LineageEvent
+}
+
+' --- Core wiring
+DataMapperBuilder --> ServiceResolver : builds
+DataMapperBuilder --> DataMapper : creates
+
+DataMapper --> Loader : creates
+DataMapper --> LoaderRegistry : registers loader
+DataMapper --> ContextRegistry : sets logger/ctx
+DataMapper --> DataLineageCollector : owns
+
+Loader ..|> LoaderInterface
+Loader --> AttributeReader
+Loader --> ServiceResolver
+Loader --> ContextRegistry
+Loader --> LockedPropertyRegistry
+Loader --> ExpressionParser
+Loader --> SourceFunctionProvider
+Loader --> DataLineageCollector : records events
+
+LoadableTrait --> LoaderRegistry : get()
+LoadableTrait --> LockedPropertyRegistry : lock/unlock/isLocked
+LoadableInternalTrait --|> LoadableTrait
+
+ExpressionParser --> ContextRegistry
+ExpressionParser --> ServiceResolver : service('...')
+ExpressionParser --> SourceFunctionProvider : source('...')
+SourceFunctionProvider --> "PSR-16 CacheInterface" : optional
+
+DataLineageCollector --> LineageEvent
+
+@enduml

--- a/docs/architecture/components.c4like.mermaid.md
+++ b/docs/architecture/components.c4like.mermaid.md
@@ -1,0 +1,80 @@
+# Composants principaux — Vue C4-like (Mermaid)
+
+Cette vue reprend **exactement les mêmes composants** que la vue précédente, mais les organise en "boundaries" (groupes) pour se rapprocher d’une lecture C4 (Contexte/Conteneurs/Composants) tout en restant en Mermaid standard.
+
+## Diagramme (C4-like en `flowchart`)
+```mermaid
+flowchart LR
+  %% External actor
+  Caller[App / Caller]
+
+  %% Boundary: Domain model
+  subgraph B1[Domain Model]
+    Domain[Domain Object]
+    Loadable[LoadableTrait]
+  end
+
+  %% Boundary: DataMapper Runtime
+  subgraph B2[DataMapper Runtime]
+    Builder[DataMapperBuilder]
+    DM[DataMapper]
+    Loader[Loader]
+  end
+
+  %% Boundary: Metadata & Expression
+  subgraph B3[Metadata & Expression]
+    Attr[Metadata/AttributeReader]
+    Expr[ExpressionParser]
+    SourceFP[SourceFunctionProvider]
+  end
+
+  %% Boundary: Registries (global minimal state)
+  subgraph B4[Registries]
+    LoaderReg[Registry/LoaderRegistry]
+    CtxReg[Registry/ContextRegistry]
+    LockReg[Registry/LockedPropertyRegistry]
+  end
+
+  %% Boundary: Services resolution
+  subgraph B5[Services]
+    Resolver[ServiceResolver]
+  end
+
+  %% Boundary: Observability
+  subgraph B6[Observability]
+    Lineage[DataLineageCollector]
+  end
+
+  %% Main relationships
+  Caller -->|build + configure| Builder
+  Builder -->|build()| Resolver
+  Builder -->|build()| DM
+
+  DM -->|creates| Loader
+  DM -->|registers| LoaderReg
+  DM -->|owns/enables| Lineage
+
+  Caller -->|calls getters| Domain
+  Domain -->|uses| Loadable
+  Loadable -->|get()| LoaderReg
+  Loadable -->|loadProperty()| Loader
+  Loadable -->|lock/unlock/isLocked| LockReg
+
+  Loader -->|read attributes| Attr
+  Loader -->|resolve DS/services| Resolver
+  Loader -->|evaluate args| Expr
+  Loader -->|set/get hydration context| CtxReg
+  Loader -->|check locks| LockReg
+  Loader -->|record events| Lineage
+
+  Expr -->|context()| CtxReg
+  Expr -->|source('id')| SourceFP
+  Expr -->|service('id')| Resolver
+```
+
+## Lecture rapide (où regarder)
+- **Domain Model** : ne dépend pas directement du Loader concret; passe par `LoaderRegistry`.
+- **DataMapper Runtime** : construit/branche le Loader et expose la façade `DataMapper`.
+- **Registries** : état global volontairement minimal (Loader courant, context, locks).
+- **Metadata & Expression** : lecture des attributs + évaluation des expressions/arguments.
+- **Observability** : collecte d’événements, activable/désactivable.

--- a/docs/architecture/components.c4like.mermaid.md
+++ b/docs/architecture/components.c4like.mermaid.md
@@ -47,8 +47,8 @@ flowchart LR
 
   %% Main relationships
   Caller -->|build + configure| Builder
-  Builder -->|build()| Resolver
-  Builder -->|build()| DM
+  Builder -->|func_build| Resolver
+  Builder -->|func_build| DM
 
   DM -->|creates| Loader
   DM -->|registers| LoaderReg
@@ -56,8 +56,8 @@ flowchart LR
 
   Caller -->|calls getters| Domain
   Domain -->|uses| Loadable
-  Loadable -->|get()| LoaderReg
-  Loadable -->|loadProperty()| Loader
+  Loadable -->|func_get| LoaderReg
+  Loadable -->|func_loadProperty| Loader
   Loadable -->|lock/unlock/isLocked| LockReg
 
   Loader -->|read attributes| Attr
@@ -67,9 +67,9 @@ flowchart LR
   Loader -->|check locks| LockReg
   Loader -->|record events| Lineage
 
-  Expr -->|context()| CtxReg
-  Expr -->|source('id')| SourceFP
-  Expr -->|service('id')| Resolver
+  Expr -->|func_context| CtxReg
+  Expr -->|func_source_param_id| SourceFP
+  Expr -->|func_service_param_id| Resolver
 ```
 
 ## Lecture rapide (où regarder)

--- a/docs/architecture/components.mermaid.md
+++ b/docs/architecture/components.mermaid.md
@@ -58,15 +58,15 @@ flowchart LR
   Lineage[DataLineageCollector]
 
   %% Wiring
-  Builder -->|build()| Resolver
-  Builder -->|build()| DM
+  Builder -->|func_build| Resolver
+  Builder -->|func_build| DM
   DM -->|creates| Loader
   DM -->|registers| LoaderReg
   DM -->|owns/enables| Lineage
 
   Domain -->|uses| Loadable
-  Loadable -->|get()| LoaderReg
-  Loadable -->|loadProperty()| Loader
+  Loadable -->|func_get| LoaderReg
+  Loadable -->|func_loadProperty| Loader
   Loadable -->|lock/unlock/isLocked| LockReg
 
   Loader -->|read attributes| Attr
@@ -76,7 +76,7 @@ flowchart LR
   Loader -->|check locks| LockReg
   Loader -->|record events| Lineage
 
-  Expr -->|context()| CtxReg
-  Expr -->|source('id')| SourceFP
-  Expr -->|service('id')| Resolver
+  Expr -->|func_context| CtxReg
+  Expr -->|func_source_param_id| SourceFP
+  Expr -->|func_service_param_id| Resolver
 ```

--- a/docs/architecture/components.mermaid.md
+++ b/docs/architecture/components.mermaid.md
@@ -1,0 +1,82 @@
+# Composants principaux — DataMapper (Mermaid)
+
+## Rôles
+- **DataMapperBuilder** : assemble la résolution de services et construit le runtime.
+- **DataMapper** : façade; instancie le `Loader`, gère contexte applicatif + lineage.
+- **Loader** : exécute l’hydratation (lazy/eager), applique règles, hooks, contexte.
+- **AttributeReader** : lit les attributs PHP (métadonnées) via Reflection.
+- **ServiceResolver** : résout une DataSource/service (PSR-11, locators, factories…).
+- **ExpressionParser** : évalue `expr(...)`, `context(...)`, `source('id')`, `service('id')`.
+- **SourceFunctionProvider** : exécute (et optionnellement cache) `source('id')`.
+- **Registries** : état global minimal (Loader, Context, Locked properties).
+- **LoadableTrait** : côté domaine; déclenche le lazy-load en appelant le Loader global.
+- **DataLineageCollector** : collecte d’événements (si activée).
+
+## Explication des liens
+- **DataMapperBuilder → ServiceResolver** : construit la stratégie de résolution (container/locators/factories).
+- **DataMapperBuilder → DataMapper** : crée le runtime qui orchestre le reste.
+- **DataMapper → Loader** : instancie le cœur d’exécution (avec logger/cache/collector).
+- **DataMapper → LoaderRegistry** : enregistre le Loader global pour que les objets métiers puissent déclencher des chargements sans dépendance directe.
+- **LoadableTrait → LoaderRegistry** : récupère le Loader actif pour appeler `loadProperty(...)`.
+- **LoadableTrait → LockedPropertyRegistry** : verrouille/déverrouille des propriétés pour empêcher l’écrasement par hydratation.
+- **Loader → AttributeReader** : lit `DataSourceRef`, `Context`, `Needs`, hooks… pour décider comment hydrater.
+- **Loader → ServiceResolver** : obtient l’instance de DataSource/service à exécuter.
+- **Loader → ExpressionParser** : résout les arguments dynamiques (références propriétés, contexte, sources, services).
+- **ExpressionParser → ContextRegistry** : lit le contexte (applicatif + hydratation) utilisé dans les expressions.
+- **ExpressionParser → SourceFunctionProvider** : exécute/récupère le résultat `source('id')`.
+- **ExpressionParser → ServiceResolver** : résout `service('id')` lorsqu’une expression le demande.
+- **Loader → ContextRegistry** : écrit le contexte d’hydratation issu des attributs `#[Context]`.
+- **Loader → LockedPropertyRegistry** : vérifie le verrouillage avant toute hydratation (skip si verrouillé).
+- **Loader → DataLineageCollector** : enregistre les événements (calls DataSource, hydrations, skips…) si la collecte est activée.
+
+## Diagramme Mermaid
+```mermaid
+flowchart LR
+  %% Main facade
+  Builder[DataMapperBuilder]
+  DM[DataMapper]
+
+  %% Core execution
+  Loader[Loader]
+  Attr[Metadata/AttributeReader]
+  Resolver[ServiceResolver]
+
+  %% Domain integration
+  Domain[Domain Object]
+  Loadable[LoadableTrait]
+
+  %% Registries
+  LoaderReg[Registry/LoaderRegistry]
+  CtxReg[Registry/ContextRegistry]
+  LockReg[Registry/LockedPropertyRegistry]
+
+  %% Expressions
+  Expr[ExpressionParser]
+  SourceFP[SourceFunctionProvider]
+
+  %% Observability
+  Lineage[DataLineageCollector]
+
+  %% Wiring
+  Builder -->|build()| Resolver
+  Builder -->|build()| DM
+  DM -->|creates| Loader
+  DM -->|registers| LoaderReg
+  DM -->|owns/enables| Lineage
+
+  Domain -->|uses| Loadable
+  Loadable -->|get()| LoaderReg
+  Loadable -->|loadProperty()| Loader
+  Loadable -->|lock/unlock/isLocked| LockReg
+
+  Loader -->|read attributes| Attr
+  Loader -->|resolve DS/services| Resolver
+  Loader -->|evaluate args| Expr
+  Loader -->|set/get hydration context| CtxReg
+  Loader -->|check locks| LockReg
+  Loader -->|record events| Lineage
+
+  Expr -->|context()| CtxReg
+  Expr -->|source('id')| SourceFP
+  Expr -->|service('id')| Resolver
+```

--- a/docs/architecture/data-flow.puml
+++ b/docs/architecture/data-flow.puml
@@ -1,0 +1,56 @@
+@startuml
+' DataMapper — Data flow (lazy loading) as a sequence diagram
+
+skinparam linetype ortho
+hide footbox
+
+actor Caller
+participant "Domain Object\n(using LoadableTrait)" as Domain
+participant "LoadableTrait" as Trait
+participant "LoaderRegistry" as LoaderRegistry
+participant "Loader" as Loader
+participant "LockedPropertyRegistry" as LockReg
+participant "AttributeReader" as Attr
+participant "ServiceResolver" as Resolver
+participant "DataSource (service)" as DS
+participant "ExpressionParser" as Expr
+participant "ContextRegistry" as Ctx
+participant "DataLineageCollector" as Lineage
+
+Caller -> Domain : getX()
+Domain -> Trait : loadProperty('x')
+Trait -> LoaderRegistry : get()
+LoaderRegistry --> Trait : Loader
+Trait -> Loader : loadProperty(domain,'x')
+
+Loader -> LockReg : isLocked(domain,'x')
+alt property locked
+  Loader -> Lineage : recordPropertySkipped(..., reason=locked)
+  Loader --> Trait : return
+  Trait --> Domain
+  Domain --> Caller : current value
+else not locked
+  Loader -> Attr : read* attributes (DataSourceRef, ...)
+  Loader -> Resolver : resolve(DataSource class/id)
+  Resolver --> Loader : dataSource instance
+
+  opt args need evaluation
+    Loader -> Expr : resolveArgs(...)
+    Expr -> Ctx : context()/contextKeyExists()
+  end
+
+  Loader -> DS : method(...)
+  DS --> Loader : raw data
+
+  Loader -> Ctx : set hydration context (#[Context])
+  opt lineage enabled
+    Loader -> Lineage : recordDataSourceCall(...)
+    Loader -> Lineage : recordPropertyHydration(...)
+  end
+
+  Loader --> Trait : return
+  Trait --> Domain
+  Domain --> Caller : hydrated value
+end
+
+@enduml

--- a/docs/attributes/Context.md
+++ b/docs/attributes/Context.md
@@ -1,31 +1,123 @@
 # Context
 
-Stores hydrated data for later access.
+Adds key-value pairs to the hydration context, enabling conditional behavior based on parent object configuration.
+
+## Overview
+
+The `Context` attribute allows you to pass contextual information down through the object hierarchy during hydration. Context values accumulate as hydration descends into nested objects, and later values for the same key override earlier ones (last writer wins).
 
 ## Usage
+
+### Basic Usage with Named Arguments
 
 ```php
 use Kassko\DataMapper\Attribute\Context;
 
-class Entity
+class CompanyA
 {
-    #[Context]
-    private ?array $rawData = null;
+    #[Context(
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3'
+    )]
+    private Chief $chief;
     
-    // After hydration, $rawData will contain the original data
+    // Adds 3 variables to the context when chief is hydrated
 }
 ```
 
-## Parameters
+### Context Accumulation
 
-This attribute takes no parameters.
+Context values accumulate as you descend into nested objects:
 
-## Behavior
+```php
+class CompanyB
+{
+    #[Context(key3: 'value3')]
+    private Chief $chief;
+    // Adds 1 variable to the context
+}
 
-- Stores the raw data used to hydrate the property
-- Useful for debugging or accessing original values
-- Data is stored after hydration completes
+class Chief
+{
+    #[Context(
+        key2: 'new_value2',  // Overrides any previous key2 value
+        key4: 'value4'       // Adds new key
+    )]
+    private $prop;
+}
+```
+
+### Using Context in Expressions
+
+Access context values in expressions using `context()` and `contextKeyExists()`:
+
+```php
+class Chief
+{
+    #[Context(key2: 'new_value2', key4: 'value4')]
+    #[Property(
+        args: "expr(context('key1') === 'foo' ? property('propA') : property('propB'))"
+    )]
+    private $prop;
+}
+```
+
+### Using Context with PropertyCandidates
+
+```php
+class Chief
+{
+    #[Context(key2: 'new_value2', key4: 'value4')]
+    #[PropertyCandidates([
+        new PropertyCandidate(
+            discriminator: "expr(context('key1') === 'value1')",
+            property: new Property(class: TypeA::class)
+        ),
+        new PropertyCandidate(
+            discriminator: "expr(contextKeyExists('key3'))",
+            property: new Property(class: TypeB::class)
+        )
+    ])]
+    private $prop;
+}
+```
+
+## Application Context
+
+You can also set context values from your application before hydration:
+
+```php
+$dataMapper = new DataMapper($serviceResolver);
+
+// Add application-level context
+$dataMapper->addToContext('new_profile_api_feature', $featureFlag->isEnabled());
+$dataMapper->addToContext('current_user_role', 'admin');
+
+// Or add multiple at once
+$dataMapper->addManyToContext([
+    'env' => 'production',
+    'debug' => false,
+]);
+```
+
+Application context values are available during hydration and can be overridden by `#[Context]` attributes.
+
+## Expression Functions
+
+| Function | Description |
+|----------|-------------|
+| `context('key')` | Get context value (returns null if not found, logs warning) |
+| `contextKeyExists('key')` | Check if context key exists (returns boolean) |
+
+## Context Behavior
+
+1. **Accumulation**: Context values accumulate as hydration descends into nested objects
+2. **Override**: Later values for the same key override earlier ones (last writer wins)
+3. **Timing**: Context values are set AFTER the property is hydrated
+4. **Precedence**: Hydration context (`#[Context]`) takes precedence over application context
 
 ## See Also
 
 - [Property](Property.md)
+- [PropertyCandidates](PropertyCandidates.md)

--- a/docs/classes/DataLineageCollector.md
+++ b/docs/classes/DataLineageCollector.md
@@ -1,0 +1,145 @@
+# Data Lineage Collector
+
+Track how data flows and transforms during hydration for debugging and profiling purposes.
+
+## Overview
+
+The Data Lineage Collector is a debugging tool that records all data flow events during hydration:
+
+- DataSource calls and their results
+- Property hydrations and transformations
+- Decision points (where data is skipped due to priority, scope, lock, etc.)
+- Hook executions and their effects
+- Custom hydrator invocations
+- Context changes
+
+This is an **alpha feature** intended for debugging and can be used by tools like Symfony Profiler.
+
+## Usage
+
+### Enabling Collection
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+
+$builder = new DataMapperBuilder();
+$dataMapper = $builder->build();
+
+// Enable lineage collection
+$dataMapper->enableLineageCollection();
+
+// Your hydration code here...
+$object->loadProperties();
+
+// Get the collector
+$collector = $dataMapper->getLineageCollector();
+
+// Get all recorded events
+$events = $collector->getEvents();
+
+// Get a summary
+$summary = $collector->getSummary();
+```
+
+### Event Types
+
+| Type | Description |
+|------|-------------|
+| `datasource_call` | A DataSource method was called |
+| `property_hydration` | A property was hydrated with a value |
+| `property_skipped` | A property was skipped (locked, priority, scope, etc.) |
+| `property_transformed` | A property value was transformed (via hook) |
+| `hook_executed` | A lifecycle hook was executed |
+| `custom_hydrator` | A custom hydrator was invoked |
+| `context_set` | A context value was set |
+| `decision_point` | A decision affecting data flow was made |
+
+### Querying Events
+
+```php
+$collector = $dataMapper->getLineageCollector();
+
+// Get all events
+$allEvents = $collector->getEvents();
+
+// Get events by type
+$hydrations = $collector->getEventsByType(LineageEvent::TYPE_PROPERTY_HYDRATION);
+$skipped = $collector->getEventsByType(LineageEvent::TYPE_PROPERTY_SKIPPED);
+
+// Get events for a specific property
+$propertyEvents = $collector->getEventsForProperty('App\\Entity\\User', 'email');
+
+// Get summary statistics
+$summary = $collector->getSummary();
+// Returns:
+// [
+//     'totalEvents' => 42,
+//     'eventsByType' => ['property_hydration' => 30, 'property_skipped' => 5, ...],
+//     'skippedReasons' => ['locked' => 2, 'priority' => 3],
+//     'maxDepth' => 3,
+//     'totalDuration' => 0.0234,
+// ]
+```
+
+### Event Structure
+
+Each `LineageEvent` contains:
+
+```php
+class LineageEvent
+{
+    public readonly string $type;           // Event type
+    public readonly string $objectClass;    // Class being hydrated
+    public readonly ?string $propertyName;  // Property involved
+    public readonly ?string $source;        // DataSource or hook that produced the value
+    public readonly mixed $originalValue;   // Value before transformation
+    public readonly mixed $finalValue;      // Value after transformation
+    public readonly ?string $reason;        // Why (for skipped events)
+    public readonly array $metadata;        // Additional metadata
+    public readonly float $timestamp;       // Time since collection started
+    public readonly int $depth;             // Hydration depth level
+}
+```
+
+### Skipped Reasons
+
+When a property is skipped, the `reason` field indicates why:
+
+| Reason | Description |
+|--------|-------------|
+| `locked` | Property is locked via `lockProperty()` |
+| `priority` | A higher-priority source already hydrated the property |
+| `already_loaded` | Property was already loaded |
+| `scope` | Property excluded by loading scope configuration |
+
+## Integration with Symfony Profiler
+
+The Data Lineage Collector can be integrated with Symfony Profiler to visualize data flow:
+
+```php
+// In a Symfony data collector
+class DataMapperDataCollector extends DataCollector
+{
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    {
+        $collector = $this->dataMapper->getLineageCollector();
+        
+        $this->data = [
+            'events' => $collector->getEventsAsArrays(),
+            'summary' => $collector->getSummary(),
+        ];
+    }
+}
+```
+
+## Performance Considerations
+
+- Collection is **disabled by default**
+- Only enable for debugging/profiling
+- Call `$collector->clear()` between requests
+- Events use memory proportional to hydration complexity
+
+## See Also
+
+- [DataMapper](../classes/DataMapper.md)
+- [Context](Context.md)

--- a/docs/history/PR-2025_12_27_00_45_46.md
+++ b/docs/history/PR-2025_12_27_00_45_46.md
@@ -1,0 +1,202 @@
+# PR - 2025-12-27: Context Improvements, Property Locking & Data Lineage
+
+## Summary
+
+This PR introduces several major features and improvements to the DataMapper library:
+
+1. **Property Lock Registry Externalization**
+2. **Context Attribute Revision**
+3. **Application Context Support**
+4. **Data Lineage Collector**
+
+---
+
+## 1. Property Lock Registry Externalization
+
+### Problem
+Previously, locked properties were tracked inside the `LoadableTrait` using a `$lockedProperties` array. This meant the lock state was stored in the data object itself and could be accidentally serialized.
+
+### Solution
+Created a new `LockedPropertyRegistry` that uses a `WeakMap` to track locked properties externally. This prevents the lock state from being serialized with the object.
+
+### Files Changed
+- `src/Registry/LockedPropertyRegistry.php` (new)
+- `src/ObjectExtension/LoadableTrait.php` (updated)
+- `src/Loader/Loader.php` (updated to use registry)
+
+### Usage
+```php
+// The trait still works the same way for users
+class MyEntity {
+    use LoadableTrait;
+    
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+        $this->lockProperty('value'); // Now stored in registry, not in object
+    }
+}
+```
+
+---
+
+## 2. Context Attribute Revision
+
+### Problem
+The previous `#[Context]` attribute used an array parameter which was not intuitive.
+
+### Solution
+Changed to use named arguments for a cleaner syntax:
+
+```php
+// Before (old syntax - removed)
+#[Context(['key' => 'value'])]
+
+// After (new syntax)
+#[Context(key1: 'value1', key2: 'value2')]
+```
+
+### New Expression Function
+Added `contextKeyExists('key')` to check if a context key exists without triggering a warning.
+
+### Context Behavior
+- Context values accumulate as hydration descends into nested objects
+- Later values for the same key override earlier ones (last writer wins)
+- Context values are set AFTER the property is hydrated
+
+### Files Changed
+- `src/Attribute/Context.php` (updated)
+- `src/Registry/ContextRegistry.php` (updated)
+- `src/Expression/ExpressionParser.php` (added `contextKeyExists`)
+- `src/Loader/Loader.php` (updated `resolvePropertyCandidate`)
+- `src/Metadata/AttributeReader.php` (added `readAllContexts`)
+
+---
+
+## 3. Application Context Support
+
+### Problem
+Context was limited to values set during hydration via `#[Context]` attributes. Users needed to pass external values (like feature flags) into the hydration process.
+
+### Solution
+Added application context support via the `DataMapper` class:
+
+```php
+$dataMapper = new DataMapper($serviceResolver);
+
+// Add application context
+$dataMapper->addToContext('feature_enabled', $featureFlag->isEnabled());
+
+// Or add multiple at once
+$dataMapper->addManyToContext([
+    'env' => 'production',
+    'user_role' => 'admin',
+]);
+```
+
+Application context values are available in expressions:
+```php
+#[MultiPropDataSource(
+    args: "expr(context('feature_enabled') ? property('propA') : property('propB'))"
+)]
+```
+
+### Precedence
+Hydration context (`#[Context]`) takes precedence over application context.
+
+### Files Changed
+- `src/DataMapper.php` (added context methods)
+- `src/Registry/ContextRegistry.php` (split into application/hydration context)
+
+---
+
+## 4. Data Lineage Collector
+
+### Problem
+Debugging hydration issues was difficult without visibility into how data flows and transforms.
+
+### Solution
+Created a `DataLineageCollector` that records all data flow events during hydration:
+
+- DataSource calls and results
+- Property hydrations and transformations
+- Decision points (skipped due to priority, lock, scope, etc.)
+- Hook executions
+- Custom hydrator invocations
+- Context changes
+
+### Usage
+```php
+$dataMapper = new DataMapper($serviceResolver);
+$dataMapper->enableLineageCollection();
+
+// ... hydration happens ...
+
+$collector = $dataMapper->getLineageCollector();
+$events = $collector->getEvents();
+$summary = $collector->getSummary();
+```
+
+### Event Types
+- `datasource_call` - DataSource method called
+- `property_hydration` - Property hydrated
+- `property_skipped` - Property skipped (with reason)
+- `property_transformed` - Value transformed
+- `hook_executed` - Lifecycle hook executed
+- `custom_hydrator` - Custom hydrator invoked
+- `context_set` - Context value set
+
+### Files Changed
+- `src/DataCollector/LineageEvent.php` (new)
+- `src/DataCollector/DataLineageCollector.php` (new)
+- `src/DataMapper.php` (integrated collector)
+- `src/DataMapperBuilder.php` (updated)
+- `src/Loader/Loader.php` (added lineage recording)
+
+---
+
+## Breaking Changes
+
+⚠️ **This is an alpha version with breaking changes:**
+
+1. `#[Context]` syntax changed from array to named arguments
+2. `ContextRegistry` API updated (split application/hydration context)
+3. `LoadableTrait` no longer stores `$lockedProperties` in the object
+
+---
+
+## New Files
+
+- `src/Registry/LockedPropertyRegistry.php`
+- `src/DataCollector/LineageEvent.php`
+- `src/DataCollector/DataLineageCollector.php`
+- `docs/attributes/Context.md` (rewritten)
+- `docs/classes/DataLineageCollector.md`
+- `tests/Unit/Registry/LockedPropertyRegistryTest.php`
+- `tests/Unit/DataCollector/DataLineageCollectorTest.php`
+- `tests/Integration/ContextIntegrationTest.php`
+
+---
+
+## Documentation Updates
+
+- Updated `docs/attributes/Context.md` with new syntax and features
+- Created `docs/classes/DataLineageCollector.md`
+- This PR history file
+
+---
+
+## Testing
+
+Run tests with:
+```bash
+vendor/bin/phpunit
+```
+
+---
+
+## Future Work
+
+- Symfony Bundle integration for Profiler visualization
+- More detailed transformation tracking
+- Performance metrics in lineage events

--- a/src/Attribute/Context.php
+++ b/src/Attribute/Context.php
@@ -6,10 +6,38 @@ namespace Kassko\DataMapper\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
+/**
+ * Adds key-value pairs to the hydration context.
+ * 
+ * Context values accumulate as hydration descends into nested objects.
+ * Later values for the same key override earlier ones (last writer wins).
+ * Context values are set AFTER the property is hydrated but BEFORE 
+ * any PropertyCandidate discriminators are evaluated on child objects.
+ * 
+ * Usage:
+ * ```php
+ * #[Context(
+ *     key1: 'value1',
+ *     key2: 'value2',
+ * )]
+ * private Chief $chief;
+ * ```
+ * 
+ * Access in expressions:
+ * - `context('key1')` - returns the value or null if not found (logs warning)
+ * - `contextKeyExists('key1')` - returns true/false
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class Context
 {
-    public function __construct(
-        public readonly array $values = [],  // Key-value pairs
-    ) {}
+    /** @var array<string, mixed> Key-value pairs to add to context */
+    public readonly array $values;
+
+    /**
+     * @param mixed ...$values Named arguments become key-value pairs
+     */
+    public function __construct(mixed ...$values)
+    {
+        $this->values = $values;
+    }
 }

--- a/src/DataCollector/DataLineageCollector.php
+++ b/src/DataCollector/DataLineageCollector.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\DataCollector;
+
+/**
+ * Collector for data lineage and audit information.
+ * 
+ * This collector traces how data flows and transforms during hydration:
+ * - DataSource calls and their results
+ * - Property hydrations and transformations
+ * - Decision points (where data is skipped due to priority, scope, lock, etc.)
+ * - Hook executions and their effects
+ * - Custom hydrator invocations
+ * - Context changes
+ * 
+ * The collected data can be used by debugging tools (like Symfony Profiler)
+ * to visualize the data flow and help diagnose hydration issues.
+ * 
+ * @experimental This is an alpha feature
+ */
+final class DataLineageCollector
+{
+    /** @var LineageEvent[] */
+    private array $events = [];
+
+    /** @var bool */
+    private bool $enabled = false;
+
+    /** @var int Current hydration depth */
+    private int $currentDepth = 0;
+
+    /** @var float Start time of collection */
+    private float $startTime;
+
+    public function __construct()
+    {
+        $this->startTime = microtime(true);
+    }
+
+    /**
+     * Enable data collection.
+     */
+    public function enable(): void
+    {
+        $this->enabled = true;
+        $this->startTime = microtime(true);
+    }
+
+    /**
+     * Disable data collection.
+     */
+    public function disable(): void
+    {
+        $this->enabled = false;
+    }
+
+    /**
+     * Check if collection is enabled.
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Increment the current depth (when descending into nested objects).
+     */
+    public function incrementDepth(): void
+    {
+        $this->currentDepth++;
+    }
+
+    /**
+     * Decrement the current depth (when returning from nested objects).
+     */
+    public function decrementDepth(): void
+    {
+        if ($this->currentDepth > 0) {
+            $this->currentDepth--;
+        }
+    }
+
+    /**
+     * Get the current hydration depth.
+     */
+    public function getCurrentDepth(): int
+    {
+        return $this->currentDepth;
+    }
+
+    /**
+     * Record a DataSource call.
+     */
+    public function recordDataSourceCall(
+        string $objectClass,
+        string $sourceClass,
+        string $sourceMethod,
+        array $args,
+        mixed $result,
+        ?string $sourceId = null
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_DATASOURCE_CALL,
+            objectClass: $objectClass,
+            propertyName: null,
+            source: sprintf('%s::%s', $sourceClass, $sourceMethod),
+            originalValue: $args,
+            finalValue: $result,
+            reason: null,
+            metadata: [
+                'sourceId' => $sourceId,
+                'argsCount' => count($args),
+            ],
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a property hydration.
+     */
+    public function recordPropertyHydration(
+        string $objectClass,
+        string $propertyName,
+        mixed $originalValue,
+        mixed $finalValue,
+        string $source,
+        int $priority = 0
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_PROPERTY_HYDRATION,
+            objectClass: $objectClass,
+            propertyName: $propertyName,
+            source: $source,
+            originalValue: $originalValue,
+            finalValue: $finalValue,
+            reason: null,
+            metadata: [
+                'priority' => $priority,
+            ],
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a property being skipped (decision point).
+     */
+    public function recordPropertySkipped(
+        string $objectClass,
+        string $propertyName,
+        string $reason,
+        array $metadata = []
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_PROPERTY_SKIPPED,
+            objectClass: $objectClass,
+            propertyName: $propertyName,
+            source: null,
+            originalValue: null,
+            finalValue: null,
+            reason: $reason,
+            metadata: $metadata,
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a property transformation (e.g., via hook).
+     */
+    public function recordPropertyTransformation(
+        string $objectClass,
+        string $propertyName,
+        mixed $originalValue,
+        mixed $transformedValue,
+        string $transformer,
+        string $transformerType = 'hook'
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_PROPERTY_TRANSFORMED,
+            objectClass: $objectClass,
+            propertyName: $propertyName,
+            source: $transformer,
+            originalValue: $originalValue,
+            finalValue: $transformedValue,
+            reason: null,
+            metadata: [
+                'transformerType' => $transformerType,
+            ],
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a hook execution.
+     */
+    public function recordHookExecution(
+        string $objectClass,
+        string $hookType,
+        string $hookMethod,
+        ?string $hookClass,
+        array $args
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_HOOK_EXECUTED,
+            objectClass: $objectClass,
+            propertyName: null,
+            source: $hookClass ? sprintf('%s::%s', $hookClass, $hookMethod) : $hookMethod,
+            originalValue: $args,
+            finalValue: null,
+            reason: null,
+            metadata: [
+                'hookType' => $hookType,
+            ],
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a custom hydrator execution.
+     */
+    public function recordCustomHydrator(
+        string $objectClass,
+        string $propertyName,
+        string $hydratorKey,
+        mixed $result
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_CUSTOM_HYDRATOR,
+            objectClass: $objectClass,
+            propertyName: $propertyName,
+            source: $hydratorKey,
+            originalValue: null,
+            finalValue: $result,
+            reason: null,
+            metadata: [],
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a context value being set.
+     */
+    public function recordContextSet(
+        string $objectClass,
+        string $propertyName,
+        string $key,
+        mixed $value
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_CONTEXT_SET,
+            objectClass: $objectClass,
+            propertyName: $propertyName,
+            source: null,
+            originalValue: null,
+            finalValue: $value,
+            reason: null,
+            metadata: [
+                'contextKey' => $key,
+            ],
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Record a decision point (where data flow is affected by a condition).
+     */
+    public function recordDecisionPoint(
+        string $objectClass,
+        ?string $propertyName,
+        string $decisionType,
+        string $reason,
+        array $metadata = []
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new LineageEvent(
+            type: LineageEvent::TYPE_DECISION_POINT,
+            objectClass: $objectClass,
+            propertyName: $propertyName,
+            source: null,
+            originalValue: null,
+            finalValue: null,
+            reason: $reason,
+            metadata: array_merge(['decisionType' => $decisionType], $metadata),
+            timestamp: microtime(true) - $this->startTime,
+            depth: $this->currentDepth
+        );
+    }
+
+    /**
+     * Get all recorded events.
+     * 
+     * @return LineageEvent[]
+     */
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+
+    /**
+     * Get events as arrays (for serialization).
+     * 
+     * @return array
+     */
+    public function getEventsAsArrays(): array
+    {
+        return array_map(fn(LineageEvent $event) => $event->toArray(), $this->events);
+    }
+
+    /**
+     * Get events filtered by type.
+     * 
+     * @param string $type
+     * @return LineageEvent[]
+     */
+    public function getEventsByType(string $type): array
+    {
+        return array_filter($this->events, fn(LineageEvent $event) => $event->type === $type);
+    }
+
+    /**
+     * Get events for a specific property.
+     * 
+     * @param string $objectClass
+     * @param string $propertyName
+     * @return LineageEvent[]
+     */
+    public function getEventsForProperty(string $objectClass, string $propertyName): array
+    {
+        return array_filter(
+            $this->events, 
+            fn(LineageEvent $event) => 
+                $event->objectClass === $objectClass && $event->propertyName === $propertyName
+        );
+    }
+
+    /**
+     * Get a summary of the data lineage.
+     * 
+     * @return array
+     */
+    public function getSummary(): array
+    {
+        $eventsByType = [];
+        foreach ($this->events as $event) {
+            $eventsByType[$event->type] = ($eventsByType[$event->type] ?? 0) + 1;
+        }
+
+        $skippedReasons = [];
+        foreach ($this->getEventsByType(LineageEvent::TYPE_PROPERTY_SKIPPED) as $event) {
+            $reason = $event->reason ?? 'unknown';
+            $skippedReasons[$reason] = ($skippedReasons[$reason] ?? 0) + 1;
+        }
+
+        return [
+            'totalEvents' => count($this->events),
+            'eventsByType' => $eventsByType,
+            'skippedReasons' => $skippedReasons,
+            'maxDepth' => max(array_map(fn(LineageEvent $e) => $e->depth, $this->events) ?: [0]),
+            'totalDuration' => count($this->events) > 0 
+                ? $this->events[count($this->events) - 1]->timestamp 
+                : 0,
+        ];
+    }
+
+    /**
+     * Clear all recorded events.
+     */
+    public function clear(): void
+    {
+        $this->events = [];
+        $this->currentDepth = 0;
+        $this->startTime = microtime(true);
+    }
+
+    /**
+     * Reset the collector (clear events and reset state).
+     */
+    public function reset(): void
+    {
+        $this->clear();
+        $this->enabled = false;
+    }
+}

--- a/src/DataCollector/LineageEvent.php
+++ b/src/DataCollector/LineageEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\DataCollector;
+
+/**
+ * Represents a single event in the data lineage.
+ */
+final class LineageEvent
+{
+    public const TYPE_DATASOURCE_CALL = 'datasource_call';
+    public const TYPE_PROPERTY_HYDRATION = 'property_hydration';
+    public const TYPE_PROPERTY_SKIPPED = 'property_skipped';
+    public const TYPE_PROPERTY_TRANSFORMED = 'property_transformed';
+    public const TYPE_HOOK_EXECUTED = 'hook_executed';
+    public const TYPE_CUSTOM_HYDRATOR = 'custom_hydrator';
+    public const TYPE_CONTEXT_SET = 'context_set';
+    public const TYPE_DECISION_POINT = 'decision_point';
+
+    public function __construct(
+        public readonly string $type,
+        public readonly string $objectClass,
+        public readonly ?string $propertyName,
+        public readonly ?string $source,
+        public readonly mixed $originalValue,
+        public readonly mixed $finalValue,
+        public readonly ?string $reason,
+        public readonly array $metadata,
+        public readonly float $timestamp,
+        public readonly int $depth
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'objectClass' => $this->objectClass,
+            'propertyName' => $this->propertyName,
+            'source' => $this->source,
+            'originalValue' => $this->serializeValue($this->originalValue),
+            'finalValue' => $this->serializeValue($this->finalValue),
+            'reason' => $this->reason,
+            'metadata' => $this->metadata,
+            'timestamp' => $this->timestamp,
+            'depth' => $this->depth,
+        ];
+    }
+
+    private function serializeValue(mixed $value): mixed
+    {
+        if (is_object($value)) {
+            return sprintf('[object %s]', get_class($value));
+        }
+        if (is_array($value)) {
+            if (count($value) > 10) {
+                return sprintf('[array with %d items]', count($value));
+            }
+            return array_map(fn($v) => $this->serializeValue($v), $value);
+        }
+        return $value;
+    }
+}

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -4,29 +4,43 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper;
 
+use Kassko\DataMapper\DataCollector\DataLineageCollector;
 use Kassko\DataMapper\Loader\Loader;
+use Kassko\DataMapper\Registry\ContextRegistry;
 use Kassko\DataMapper\Registry\LoaderRegistry;
+use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 
 final class DataMapper
 {
     private ServiceResolver $serviceResolver;
     private ?CacheInterface $cache;
+    private ?LoggerInterface $logger;
+    private DataLineageCollector $lineageCollector;
 
     /**
      * @param ServiceResolver $serviceResolver
      * @param CacheInterface|null $cache PSR-16 cache interface
+     * @param LoggerInterface|null $logger PSR-3 logger interface
      */
     public function __construct(
         ServiceResolver $serviceResolver,
-        ?CacheInterface $cache = null
+        ?CacheInterface $cache = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->cache = $cache;
+        $this->logger = $logger;
         $this->serviceResolver = $serviceResolver;
+        $this->lineageCollector = new DataLineageCollector();
         
         // Register Loader in the registry
-        $loader = new Loader($this->serviceResolver);
+        $loader = new Loader($this->serviceResolver, $this->logger, [], $this->lineageCollector);
         LoaderRegistry::set($loader);
+        
+        // Set logger for context registry
+        if ($this->logger !== null) {
+            ContextRegistry::setLogger($this->logger);
+        }
     }
 
     public function getServiceResolver(): ServiceResolver
@@ -37,5 +51,102 @@ final class DataMapper
     public function getCache(): ?CacheInterface
     {
         return $this->cache;
+    }
+
+    /**
+     * Get the data lineage collector.
+     * 
+     * Use this to enable/disable data collection and retrieve lineage information.
+     */
+    public function getLineageCollector(): DataLineageCollector
+    {
+        return $this->lineageCollector;
+    }
+
+    /**
+     * Enable data lineage collection.
+     * 
+     * When enabled, the DataMapper will record all data flow events during hydration.
+     * This is useful for debugging and can be used by tools like Symfony Profiler.
+     * 
+     * @return self For method chaining
+     */
+    public function enableLineageCollection(): self
+    {
+        $this->lineageCollector->enable();
+        return $this;
+    }
+
+    /**
+     * Disable data lineage collection.
+     * 
+     * @return self For method chaining
+     */
+    public function disableLineageCollection(): self
+    {
+        $this->lineageCollector->disable();
+        return $this;
+    }
+
+    /**
+     * Add a value to the application context.
+     * 
+     * Application context values are available during hydration via context() expressions.
+     * They persist across hydration operations and can be overridden by #[Context] attributes.
+     * 
+     * @param string $key Context key
+     * @param mixed $value Context value (can be any type)
+     * @return self For method chaining
+     */
+    public function addToContext(string $key, mixed $value): self
+    {
+        ContextRegistry::addToApplicationContext($key, $value);
+        return $this;
+    }
+
+    /**
+     * Add multiple values to the application context at once.
+     * 
+     * @param array<string, mixed> $values Key-value pairs
+     * @return self For method chaining
+     */
+    public function addManyToContext(array $values): self
+    {
+        ContextRegistry::addManyToApplicationContext($values);
+        return $this;
+    }
+
+    /**
+     * Clear the application context.
+     * 
+     * @return self For method chaining
+     */
+    public function clearContext(): self
+    {
+        ContextRegistry::clearApplicationContext();
+        return $this;
+    }
+
+    /**
+     * Get a context value.
+     * 
+     * @param string $key Context key
+     * @param mixed $default Default value if key not found
+     * @return mixed
+     */
+    public function getContext(string $key, mixed $default = null): mixed
+    {
+        return ContextRegistry::get($key, $default, false);
+    }
+
+    /**
+     * Check if a context key exists.
+     * 
+     * @param string $key Context key
+     * @return bool
+     */
+    public function hasContext(string $key): bool
+    {
+        return ContextRegistry::has($key);
     }
 }

--- a/src/DataMapperBuilder.php
+++ b/src/DataMapperBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper;
 
+use Kassko\DataMapper\DataCollector\DataLineageCollector;
 use Kassko\DataMapper\Loader\Loader;
 use Kassko\DataMapper\Registry\LoaderRegistry;
 use Psr\Container\ContainerInterface;
@@ -122,11 +123,8 @@ final class DataMapperBuilder
             $this->staticFactories,
             $this->callables
         );
-        $loader = new Loader($serviceResolver, $this->logger, $this->customHydrators);
         
-        // Register the Loader globally
-        LoaderRegistry::set($loader);
-        
-        return new DataMapper($serviceResolver, $this->cache);
+        // Create the DataMapper which will create and register the Loader
+        return new DataMapper($serviceResolver, $this->cache, $this->logger);
     }
 }

--- a/src/Expression/ExpressionParser.php
+++ b/src/Expression/ExpressionParser.php
@@ -258,10 +258,15 @@ class ExpressionParser
             return $this->getPropertyValueDirect($this->currentObject, $propertyName);
         }
         
-        // Parse context('key')
+        // Parse contextKeyExists('key') - check if context key exists
+        if (preg_match("/contextKeyExists\('([^']+)'\)/", $expression, $matches)) {
+            $key = $matches[1];
+            return ContextRegistry::has($key);
+        }
+        
+        // Parse context('key') - returns null and logs warning if key doesn't exist
         if (preg_match("/context\('([^']+)'\)/", $expression, $matches)) {
             $key = $matches[1];
-            
             return ContextRegistry::get($key);
         }
         

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -527,6 +527,16 @@ class Loader implements LoaderInterface
         
         $data = $this->callDataSource($source, $object);
         
+        // Record the data source call for lineage
+        $this->lineageCollector?->recordDataSourceCall(
+            get_class($object),
+            $source->class ?? 'unknown',
+            $source->method,
+            $source->args,
+            $data,
+            $source->id ?? null
+        );
+        
         if (!is_array($data)) {
             return;
         }

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -14,10 +14,12 @@ use Kassko\DataMapper\Attribute\CustomHydrator;
 use Kassko\DataMapper\Attribute\PropertySettingHook;
 use Kassko\DataMapper\Attribute\PropertyInstantiatingHook;
 use Kassko\DataMapper\Attribute\PropertyHydratingHook;
+use Kassko\DataMapper\DataCollector\DataLineageCollector;
 use Kassko\DataMapper\Expression\ExpressionParser;
 use Kassko\DataMapper\Expression\SourceFunctionProvider;
 use Kassko\DataMapper\Metadata\AttributeReader;
 use Kassko\DataMapper\Registry\ContextRegistry;
+use Kassko\DataMapper\Registry\LockedPropertyRegistry;
 use Kassko\DataMapper\ServiceResolver;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -42,6 +44,7 @@ class Loader implements LoaderInterface
     private AttributeReader $attributeReader;
     private ServiceResolver $serviceResolver;
     private LoggerInterface $logger;
+    private ?DataLineageCollector $lineageCollector;
     
     /** @var array<string, callable> */
     private array $customHydrators;
@@ -50,11 +53,13 @@ class Loader implements LoaderInterface
      * @param ServiceResolver $serviceResolver
      * @param LoggerInterface|null $logger
      * @param array<string, callable> $customHydrators
+     * @param DataLineageCollector|null $lineageCollector
      */
     public function __construct(
         ServiceResolver $serviceResolver,
         ?LoggerInterface $logger = null,
-        array $customHydrators = []
+        array $customHydrators = [],
+        ?DataLineageCollector $lineageCollector = null
     ) {
         $this->loadedProperties = new WeakMap();
         $this->sourceFunctionProviders = new WeakMap();
@@ -64,11 +69,20 @@ class Loader implements LoaderInterface
         $this->logger = $logger ?? new NullLogger();
         $this->customHydrators = $customHydrators;
         $this->serviceResolver = $serviceResolver;
+        $this->lineageCollector = $lineageCollector;
     }
 
     public function getServiceResolver(): ServiceResolver
     {
         return $this->serviceResolver;
+    }
+
+    /**
+     * Get the data lineage collector.
+     */
+    public function getLineageCollector(): ?DataLineageCollector
+    {
+        return $this->lineageCollector;
     }
 
     /**
@@ -186,8 +200,20 @@ class Loader implements LoaderInterface
      */
     public function loadProperty(object $object, string $propertyName): void
     {
-        // Check if property is locked (prevent loading)
-        if (method_exists($object, 'isPropertyLocked') && $object->isPropertyLocked($propertyName)) {
+        // Check if property is locked (prevent loading) - use registry first, fallback to method
+        $isLocked = LockedPropertyRegistry::isLocked($object, $propertyName);
+        if (!$isLocked && method_exists($object, 'isPropertyLocked')) {
+            $isLocked = $object->isPropertyLocked($propertyName);
+        }
+        
+        if ($isLocked) {
+            // Record decision point for lineage
+            $this->lineageCollector?->recordPropertySkipped(
+                get_class($object),
+                $propertyName,
+                'locked',
+                ['reason' => 'Property is locked and cannot be modified']
+            );
             return; // Skip loading - property is locked
         }
         
@@ -424,18 +450,47 @@ class Loader implements LoaderInterface
                 'Skipping property hydration due to lower or equal priority',
                 ['property' => $propertyName, 'source' => $sourceSignature, 'priority' => $sourcePriority]
             );
+            
+            // Record decision point for lineage
+            $this->lineageCollector?->recordPropertySkipped(
+                get_class($object),
+                $propertyName,
+                'priority',
+                ['currentPriority' => $sourcePriority, 'source' => $sourceSignature]
+            );
             return;
         }
         
         $data = $this->callDataSource($source, $object);
         
+        // Record the data source call for lineage
+        $this->lineageCollector?->recordDataSourceCall(
+            get_class($object),
+            $source->class ?? 'unknown',
+            $source->method,
+            $source->args,
+            $data,
+            $source->id ?? null
+        );
+        
         // Apply recursive hydration if needed (handles PropertyCandidates, nested objects, etc.)
+        $originalData = $data;
         $data = $this->applyRecursiveHydration($property, $data, 0, $object);
         
         $this->setPropertyValue($object, $property, $data);
         $this->registerPropertyHydration($object, $propertyName, $sourcePriority, $sourceSignature);
         $this->loadedProperties[$object][$propertyName] = true;
         $this->handleContextAttribute($property, $data);
+        
+        // Record property hydration for lineage
+        $this->lineageCollector?->recordPropertyHydration(
+            get_class($object),
+            $propertyName,
+            $originalData,
+            $data,
+            $sourceSignature,
+            $sourcePriority
+        );
     }
 
     /**
@@ -484,6 +539,12 @@ class Loader implements LoaderInterface
             
             // Skip if already loaded
             if (isset($this->loadedProperties[$object][$propName])) {
+                $this->lineageCollector?->recordPropertySkipped(
+                    get_class($object),
+                    $propName,
+                    'already_loaded',
+                    ['source' => $sourceSignature]
+                );
                 continue;
             }
             
@@ -492,6 +553,12 @@ class Loader implements LoaderInterface
                 $this->logger->info(
                     'Skipping property hydration due to lower or equal priority',
                     ['property' => $propName, 'source' => $sourceSignature, 'priority' => $sourcePriority]
+                );
+                $this->lineageCollector?->recordPropertySkipped(
+                    get_class($object),
+                    $propName,
+                    'priority',
+                    ['currentPriority' => $sourcePriority, 'source' => $sourceSignature]
                 );
                 continue;
             }
@@ -978,11 +1045,17 @@ class Loader implements LoaderInterface
                     } else {
                         $result = (bool)$value;
                     }
+                } elseif (preg_match("/contextKeyExists\('([^']+)'\)/", $expression, $keyMatches)) {
+                    // Support contextKeyExists() expression
+                    $key = $keyMatches[1];
+                    $result = ContextRegistry::has($key);
                 } elseif (preg_match("/context\('([^']+)'\)/", $expression, $keyMatches)) {
                     $key = $keyMatches[1];
                     $contextValue = ContextRegistry::get($key);
-                    // Evaluate the full expression - for now handle simple equality
-                    if (preg_match("/context\('([^']+)'\)\s*==\s*'([^']+)'/", $expression, $eqMatches)) {
+                    // Evaluate the full expression - handle equality comparisons
+                    if (preg_match("/context\('([^']+)'\)\s*===\s*'([^']+)'/", $expression, $eqMatches)) {
+                        $result = ($contextValue === $eqMatches[2]);
+                    } elseif (preg_match("/context\('([^']+)'\)\s*==\s*'([^']+)'/", $expression, $eqMatches)) {
                         $result = ($contextValue == $eqMatches[2]);
                     } else {
                         $result = (bool)$contextValue;
@@ -1147,14 +1220,29 @@ class Loader implements LoaderInterface
      */
     private function handleContextAttribute(ReflectionProperty $property, mixed $value): void
     {
-        $context = $this->attributeReader->readContext($property);
+        $contexts = $this->attributeReader->readAllContexts($property);
         
-        if ($context === null) {
+        if (empty($contexts)) {
             return;
         }
         
-        // Set all context values
-        ContextRegistry::setMany($context->values);
+        $objectClass = $property->getDeclaringClass()->getName();
+        $propertyName = $property->getName();
+        
+        // Set all context values from all Context attributes
+        foreach ($contexts as $context) {
+            foreach ($context->values as $key => $contextValue) {
+                ContextRegistry::set($key, $contextValue);
+                
+                // Record context set for lineage
+                $this->lineageCollector?->recordContextSet(
+                    $objectClass,
+                    $propertyName,
+                    $key,
+                    $contextValue
+                );
+            }
+        }
     }
 
     /**
@@ -1282,6 +1370,15 @@ class Loader implements LoaderInterface
         
         // Call the hook method
         if (method_exists($target, $method)) {
+            // Record hook execution for lineage
+            $this->lineageCollector?->recordHookExecution(
+                get_class($object),
+                $property !== null ? 'property_setting' : ($includeObjectInArgs ? 'hydrating' : 'instantiating'),
+                $method,
+                $class,
+                $resolvedArgs
+            );
+            
             call_user_func_array([$target, $method], $resolvedArgs);
         }
     }
@@ -1487,6 +1584,14 @@ class Loader implements LoaderInterface
                 )
             );
         }
+        
+        // Record custom hydrator for lineage
+        $this->lineageCollector?->recordCustomHydrator(
+            get_class($object),
+            $property->getName(),
+            $customHydrator->key,
+            $result
+        );
         
         // Set the property value
         $this->setPropertyValue($object, $property, $result);

--- a/src/Metadata/AttributeReader.php
+++ b/src/Metadata/AttributeReader.php
@@ -137,6 +137,23 @@ class AttributeReader
     }
 
     /**
+     * Read all Context attributes from a property (supports IS_REPEATABLE)
+     *
+     * @param ReflectionProperty $property
+     * @return Context[]
+     */
+    public function readAllContexts(ReflectionProperty $property): array
+    {
+        $attributes = $property->getAttributes(Context::class);
+        
+        if (empty($attributes)) {
+            return [];
+        }
+        
+        return array_map(fn($attr) => $attr->newInstance(), $attributes);
+    }
+
+    /**
      * Read Getter attribute from a property
      *
      * @param ReflectionProperty $property

--- a/src/ObjectExtension/LoadableTrait.php
+++ b/src/ObjectExtension/LoadableTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\ObjectExtension;
 
 use Kassko\DataMapper\Registry\LoaderRegistry;
+use Kassko\DataMapper\Registry\LockedPropertyRegistry;
 
 /**
  * Trait for domain objects that need lazy loading capabilities.
@@ -13,11 +14,13 @@ use Kassko\DataMapper\Registry\LoaderRegistry;
  * - Use this trait in your domain objects
  * - Call loadProperty() in your getters to trigger lazy loading
  * - Use lockProperty()/unlockProperty() to control when properties can be loaded
+ * 
+ * Note: Locked properties are tracked externally in LockedPropertyRegistry,
+ * not in the object itself. This prevents the lock state from being serialized
+ * with the object.
  */
 trait LoadableTrait
 {
-    private array $lockedProperties = [];
-
     /**
      * Load a property on-demand using the global Loader.
      * 
@@ -41,7 +44,7 @@ trait LoadableTrait
      */
     protected function lockProperty(string $propertyName): void
     {
-        $this->lockedProperties[$propertyName] = true;
+        LockedPropertyRegistry::lock($this, $propertyName);
     }
 
     /**
@@ -49,7 +52,7 @@ trait LoadableTrait
      */
     protected function unlockProperty(string $propertyName): void
     {
-        unset($this->lockedProperties[$propertyName]);
+        LockedPropertyRegistry::unlock($this, $propertyName);
     }
 
     /**
@@ -58,6 +61,6 @@ trait LoadableTrait
      */
     public function isPropertyLocked(string $propertyName): bool
     {
-        return $this->lockedProperties[$propertyName] ?? false;
+        return LockedPropertyRegistry::isLocked($this, $propertyName);
     }
 }

--- a/src/Registry/ContextRegistry.php
+++ b/src/Registry/ContextRegistry.php
@@ -4,26 +4,121 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper\Registry;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Registry for context values used during hydration.
+ * 
+ * Context values can come from two sources:
+ * 1. Application context: Set externally via addToContext() before hydration
+ * 2. Hydration context: Set via #[Context] attributes during hydration
+ * 
+ * Values from hydration context can override application context values.
+ * Context values accumulate as hydration descends into nested objects.
+ */
 final class ContextRegistry
 {
-    /** @var array<string, mixed> */
-    private static array $context = [];
+    /** @var array<string, mixed> Application-level context */
+    private static array $applicationContext = [];
+    
+    /** @var array<string, mixed> Hydration context (from #[Context] attributes) */
+    private static array $hydrationContext = [];
 
+    /** @var LoggerInterface */
+    private static ?LoggerInterface $logger = null;
+
+    /**
+     * Set the logger for context access warnings.
+     */
+    public static function setLogger(LoggerInterface $logger): void
+    {
+        self::$logger = $logger;
+    }
+
+    private static function getLogger(): LoggerInterface
+    {
+        if (self::$logger === null) {
+            self::$logger = new NullLogger();
+        }
+        return self::$logger;
+    }
+
+    /**
+     * Add a value to the application context.
+     * This context persists across hydration operations.
+     */
+    public static function addToApplicationContext(string $key, mixed $value): void
+    {
+        self::$applicationContext[$key] = $value;
+    }
+
+    /**
+     * Add multiple values to the application context.
+     * 
+     * @param array<string, mixed> $values
+     */
+    public static function addManyToApplicationContext(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            self::$applicationContext[$key] = $value;
+        }
+    }
+
+    /**
+     * Set a hydration context value (from #[Context] attributes).
+     */
     public static function set(string $key, mixed $value): void
     {
-        self::$context[$key] = $value;
+        self::$hydrationContext[$key] = $value;
     }
 
-    public static function get(string $key, mixed $default = null): mixed
+    /**
+     * Get a context value. Hydration context takes precedence over application context.
+     * If the key doesn't exist, logs a warning and returns null.
+     * 
+     * @param string $key
+     * @param mixed $default Default value if key not found (avoids warning if provided)
+     * @param bool $warnIfMissing Whether to log a warning if key is missing
+     * @return mixed
+     */
+    public static function get(string $key, mixed $default = null, bool $warnIfMissing = true): mixed
     {
-        return self::$context[$key] ?? $default;
+        // Hydration context takes precedence
+        if (array_key_exists($key, self::$hydrationContext)) {
+            return self::$hydrationContext[$key];
+        }
+        
+        // Fall back to application context
+        if (array_key_exists($key, self::$applicationContext)) {
+            return self::$applicationContext[$key];
+        }
+        
+        // Key not found
+        if ($warnIfMissing && $default === null) {
+            self::getLogger()->warning(
+                'Accessing non-existent context key',
+                ['key' => $key]
+            );
+        }
+        
+        return $default;
     }
 
+    /**
+     * Check if a context key exists (in either application or hydration context).
+     */
     public static function has(string $key): bool
     {
-        return array_key_exists($key, self::$context);
+        return array_key_exists($key, self::$hydrationContext) 
+            || array_key_exists($key, self::$applicationContext);
     }
 
+    /**
+     * Set multiple hydration context values at once.
+     * 
+     * @param array<string, mixed> $values
+     */
     public static function setMany(array $values): void
     {
         foreach ($values as $key => $value) {
@@ -31,13 +126,58 @@ final class ContextRegistry
         }
     }
 
-    public static function clear(): void
+    /**
+     * Clear hydration context only (preserves application context).
+     */
+    public static function clearHydrationContext(): void
     {
-        self::$context = [];
+        self::$hydrationContext = [];
     }
 
+    /**
+     * Clear application context only.
+     */
+    public static function clearApplicationContext(): void
+    {
+        self::$applicationContext = [];
+    }
+
+    /**
+     * Clear all context (both application and hydration).
+     */
+    public static function clear(): void
+    {
+        self::$applicationContext = [];
+        self::$hydrationContext = [];
+    }
+
+    /**
+     * Get all context values (merged, hydration context takes precedence).
+     * 
+     * @return array<string, mixed>
+     */
     public static function all(): array
     {
-        return self::$context;
+        return array_merge(self::$applicationContext, self::$hydrationContext);
+    }
+
+    /**
+     * Get application context values only.
+     * 
+     * @return array<string, mixed>
+     */
+    public static function getApplicationContext(): array
+    {
+        return self::$applicationContext;
+    }
+
+    /**
+     * Get hydration context values only.
+     * 
+     * @return array<string, mixed>
+     */
+    public static function getHydrationContext(): array
+    {
+        return self::$hydrationContext;
     }
 }

--- a/src/Registry/LockedPropertyRegistry.php
+++ b/src/Registry/LockedPropertyRegistry.php
@@ -44,7 +44,10 @@ final class LockedPropertyRegistry
     {
         $map = self::getMap();
         if (isset($map[$object])) {
-            unset($map[$object][$propertyName]);
+            // WeakMap doesn't support indirect modification, need to get/modify/set
+            $properties = $map[$object];
+            unset($properties[$propertyName]);
+            $map[$object] = $properties;
         }
     }
 

--- a/src/Registry/LockedPropertyRegistry.php
+++ b/src/Registry/LockedPropertyRegistry.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Registry;
+
+use WeakMap;
+
+/**
+ * Registry for tracking locked properties.
+ * 
+ * This registry uses WeakMap to track which properties are locked for each object,
+ * ensuring the locked state is not serialized with the object itself.
+ */
+final class LockedPropertyRegistry
+{
+    /** @var WeakMap<object, array<string, bool>> */
+    private static ?WeakMap $lockedProperties = null;
+
+    private static function getMap(): WeakMap
+    {
+        if (self::$lockedProperties === null) {
+            self::$lockedProperties = new WeakMap();
+        }
+        return self::$lockedProperties;
+    }
+
+    /**
+     * Lock a property to prevent lazy/eager loading from modifying its value.
+     */
+    public static function lock(object $object, string $propertyName): void
+    {
+        $map = self::getMap();
+        if (!isset($map[$object])) {
+            $map[$object] = [];
+        }
+        $map[$object][$propertyName] = true;
+    }
+
+    /**
+     * Unlock a property to allow lazy/eager loading to modify its value.
+     */
+    public static function unlock(object $object, string $propertyName): void
+    {
+        $map = self::getMap();
+        if (isset($map[$object])) {
+            unset($map[$object][$propertyName]);
+        }
+    }
+
+    /**
+     * Check if a property is locked.
+     */
+    public static function isLocked(object $object, string $propertyName): bool
+    {
+        $map = self::getMap();
+        return ($map[$object][$propertyName] ?? false);
+    }
+
+    /**
+     * Get all locked properties for an object.
+     * 
+     * @return array<string, bool>
+     */
+    public static function getLockedProperties(object $object): array
+    {
+        $map = self::getMap();
+        return $map[$object] ?? [];
+    }
+
+    /**
+     * Clear all locked properties for an object.
+     */
+    public static function clearObject(object $object): void
+    {
+        $map = self::getMap();
+        unset($map[$object]);
+    }
+
+    /**
+     * Clear all locked properties (for testing purposes).
+     */
+    public static function clear(): void
+    {
+        self::$lockedProperties = new WeakMap();
+    }
+}

--- a/tests/Integration/ContextIntegrationTest.php
+++ b/tests/Integration/ContextIntegrationTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\ArrayServiceLocator;
+use Kassko\DataMapper\Attribute\Context;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\MultiPropDataSource;
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\Attribute\PropertyCandidate;
+use Kassko\DataMapper\Attribute\PropertyCandidates;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\ObjectExtension\LoadableInternalTrait;
+use Kassko\DataMapper\Registry\ContextRegistry;
+use Kassko\DataMapper\Registry\LoaderRegistry;
+use Kassko\DataMapper\ServiceResolver;
+use PHPUnit\Framework\TestCase;
+
+class ContextIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ContextRegistry::clear();
+        LoaderRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        ContextRegistry::clear();
+        LoaderRegistry::clear();
+    }
+
+    public function testContextWithNamedArguments(): void
+    {
+        $dataSource = new class {
+            public function getData(): array
+            {
+                return ['name' => 'John', 'role' => 'admin'];
+            }
+        };
+
+        $serviceLocator = new ArrayServiceLocator([
+            'TestSource' => $dataSource,
+        ]);
+
+        $builder = new DataMapperBuilder();
+        $builder->addLocator($serviceLocator);
+        $builder->build();
+
+        $testObject = new #[DataSourcesStore([
+            new MultiPropDataSource(id: 'source', class: 'TestSource', method: 'getData'),
+        ])]
+        class {
+            use LoadableInternalTrait;
+
+            #[Context(role: 'admin', level: 'high')]
+            #[DataSourceRef(id: 'source')]
+            private ?string $name = null;
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $testObject->getName();
+
+        // Context values should be set
+        $this->assertEquals('admin', ContextRegistry::get('role'));
+        $this->assertEquals('high', ContextRegistry::get('level'));
+    }
+
+    public function testApplicationContextViaDataMapper(): void
+    {
+        $serviceResolver = new ServiceResolver();
+        $dataMapper = new DataMapper($serviceResolver);
+
+        // Add application context
+        $dataMapper->addToContext('feature_flag', true);
+        $dataMapper->addToContext('api_version', 'v2');
+
+        // Verify context is accessible
+        $this->assertTrue($dataMapper->hasContext('feature_flag'));
+        $this->assertTrue($dataMapper->getContext('feature_flag'));
+        $this->assertEquals('v2', $dataMapper->getContext('api_version'));
+
+        // Add multiple at once
+        $dataMapper->addManyToContext([
+            'env' => 'production',
+            'debug' => false,
+        ]);
+
+        $this->assertEquals('production', $dataMapper->getContext('env'));
+        $this->assertFalse($dataMapper->getContext('debug'));
+    }
+
+    public function testHydrationContextOverridesApplicationContext(): void
+    {
+        // Set application context
+        ContextRegistry::addToApplicationContext('mode', 'app_mode');
+
+        // Set hydration context (should override)
+        ContextRegistry::set('mode', 'hydration_mode');
+
+        // Hydration context should take precedence
+        $this->assertEquals('hydration_mode', ContextRegistry::get('mode'));
+
+        // Clear hydration context
+        ContextRegistry::clearHydrationContext();
+
+        // Now should get application context
+        $this->assertEquals('app_mode', ContextRegistry::get('mode'));
+    }
+
+    public function testContextKeyExistsExpression(): void
+    {
+        $dataSource = new class {
+            public function getData(): array
+            {
+                return [
+                    'items' => [
+                        ['type' => 'a', 'value' => 'item1'],
+                        ['type' => 'b', 'value' => 'item2'],
+                    ]
+                ];
+            }
+        };
+
+        $serviceLocator = new ArrayServiceLocator([
+            'TestSource' => $dataSource,
+        ]);
+
+        $builder = new DataMapperBuilder();
+        $builder->addLocator($serviceLocator);
+        $builder->build();
+
+        // Set context to test contextKeyExists
+        ContextRegistry::set('premium_user', true);
+
+        $this->assertTrue(ContextRegistry::has('premium_user'));
+        $this->assertFalse(ContextRegistry::has('non_existent_key'));
+    }
+
+    public function testDataLineageCollector(): void
+    {
+        $dataSource = new class {
+            public function getData(): array
+            {
+                return ['name' => 'John'];
+            }
+        };
+
+        $serviceLocator = new ArrayServiceLocator([
+            'TestSource' => $dataSource,
+        ]);
+
+        $builder = new DataMapperBuilder();
+        $builder->addLocator($serviceLocator);
+        $dataMapper = $builder->build();
+
+        // Enable lineage collection
+        $dataMapper->enableLineageCollection();
+
+        $testObject = new #[DataSourcesStore([
+            new MultiPropDataSource(id: 'source', class: 'TestSource', method: 'getData'),
+        ])]
+        class {
+            use LoadableInternalTrait;
+
+            #[DataSourceRef(id: 'source')]
+            private ?string $name = null;
+
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+
+        $testObject->getName();
+
+        // Check that events were recorded
+        $collector = $dataMapper->getLineageCollector();
+        $events = $collector->getEvents();
+
+        $this->assertNotEmpty($events);
+    }
+}

--- a/tests/Unit/Attribute/ContextTest.php
+++ b/tests/Unit/Attribute/ContextTest.php
@@ -27,10 +27,10 @@ class ContextTest extends TestCase
         ContextRegistry::clear();
     }
 
-    public function testContextAttributeExists(): void
+    public function testContextAttributeWithNamedArguments(): void
     {
         $testClass = new class {
-            #[Context(['key' => 'value'])]
+            #[Context(key1: 'value1', key2: 'value2')]
             private ?string $name = null;
         };
 
@@ -40,7 +40,7 @@ class ContextTest extends TestCase
         $context = $this->reader->readContext($property);
 
         $this->assertInstanceOf(Context::class, $context);
-        $this->assertEquals(['key' => 'value'], $context->values);
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], $context->values);
     }
 
     public function testContextAttributeNotPresentReturnsNull(): void

--- a/tests/Unit/DataCollector/DataLineageCollectorTest.php
+++ b/tests/Unit/DataCollector/DataLineageCollectorTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit\DataCollector;
+
+use Kassko\DataMapper\DataCollector\DataLineageCollector;
+use Kassko\DataMapper\DataCollector\LineageEvent;
+use PHPUnit\Framework\TestCase;
+
+class DataLineageCollectorTest extends TestCase
+{
+    private DataLineageCollector $collector;
+
+    protected function setUp(): void
+    {
+        $this->collector = new DataLineageCollector();
+    }
+
+    public function testCollectorIsDisabledByDefault(): void
+    {
+        $this->assertFalse($this->collector->isEnabled());
+    }
+
+    public function testEnableAndDisable(): void
+    {
+        $this->collector->enable();
+        $this->assertTrue($this->collector->isEnabled());
+
+        $this->collector->disable();
+        $this->assertFalse($this->collector->isEnabled());
+    }
+
+    public function testEventsAreNotRecordedWhenDisabled(): void
+    {
+        $this->collector->recordDataSourceCall(
+            'TestClass',
+            'SourceClass',
+            'getData',
+            [],
+            ['result' => 'data'],
+            'testSource'
+        );
+
+        $this->assertEmpty($this->collector->getEvents());
+    }
+
+    public function testRecordDataSourceCall(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordDataSourceCall(
+            'TestClass',
+            'SourceClass',
+            'getData',
+            ['arg1'],
+            ['result' => 'data'],
+            'testSource'
+        );
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        $this->assertEquals(LineageEvent::TYPE_DATASOURCE_CALL, $events[0]->type);
+        $this->assertEquals('TestClass', $events[0]->objectClass);
+        $this->assertEquals('SourceClass::getData', $events[0]->source);
+    }
+
+    public function testRecordPropertyHydration(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordPropertyHydration(
+            'TestClass',
+            'testProperty',
+            'original',
+            'hydrated',
+            'testSource',
+            5
+        );
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        $this->assertEquals(LineageEvent::TYPE_PROPERTY_HYDRATION, $events[0]->type);
+        $this->assertEquals('testProperty', $events[0]->propertyName);
+        $this->assertEquals('original', $events[0]->originalValue);
+        $this->assertEquals('hydrated', $events[0]->finalValue);
+    }
+
+    public function testRecordPropertySkipped(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordPropertySkipped(
+            'TestClass',
+            'testProperty',
+            'locked',
+            ['extra' => 'info']
+        );
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        $this->assertEquals(LineageEvent::TYPE_PROPERTY_SKIPPED, $events[0]->type);
+        $this->assertEquals('locked', $events[0]->reason);
+    }
+
+    public function testRecordHookExecution(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordHookExecution(
+            'TestClass',
+            'property_setting',
+            'beforeSet',
+            'HookClass',
+            ['arg1']
+        );
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        $this->assertEquals(LineageEvent::TYPE_HOOK_EXECUTED, $events[0]->type);
+        $this->assertEquals('HookClass::beforeSet', $events[0]->source);
+    }
+
+    public function testRecordContextSet(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordContextSet(
+            'TestClass',
+            'testProperty',
+            'contextKey',
+            'contextValue'
+        );
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        $this->assertEquals(LineageEvent::TYPE_CONTEXT_SET, $events[0]->type);
+        $this->assertEquals('contextValue', $events[0]->finalValue);
+        $this->assertEquals('contextKey', $events[0]->metadata['contextKey']);
+    }
+
+    public function testDepthTracking(): void
+    {
+        $this->collector->enable();
+        $this->assertEquals(0, $this->collector->getCurrentDepth());
+
+        $this->collector->incrementDepth();
+        $this->assertEquals(1, $this->collector->getCurrentDepth());
+
+        $this->collector->recordPropertyHydration('Test', 'prop', null, 'value', 'source');
+
+        $events = $this->collector->getEvents();
+        $this->assertEquals(1, $events[0]->depth);
+
+        $this->collector->decrementDepth();
+        $this->assertEquals(0, $this->collector->getCurrentDepth());
+    }
+
+    public function testGetEventsByType(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordPropertyHydration('Test', 'prop1', null, 'v1', 'source');
+        $this->collector->recordPropertySkipped('Test', 'prop2', 'locked');
+        $this->collector->recordPropertyHydration('Test', 'prop3', null, 'v3', 'source');
+
+        $hydrationEvents = $this->collector->getEventsByType(LineageEvent::TYPE_PROPERTY_HYDRATION);
+        $this->assertCount(2, $hydrationEvents);
+
+        $skippedEvents = $this->collector->getEventsByType(LineageEvent::TYPE_PROPERTY_SKIPPED);
+        $this->assertCount(1, $skippedEvents);
+    }
+
+    public function testGetSummary(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordPropertyHydration('Test', 'prop1', null, 'v1', 'source');
+        $this->collector->recordPropertySkipped('Test', 'prop2', 'locked');
+        $this->collector->recordPropertySkipped('Test', 'prop3', 'priority');
+
+        $summary = $this->collector->getSummary();
+
+        $this->assertEquals(3, $summary['totalEvents']);
+        $this->assertEquals(1, $summary['eventsByType'][LineageEvent::TYPE_PROPERTY_HYDRATION]);
+        $this->assertEquals(2, $summary['eventsByType'][LineageEvent::TYPE_PROPERTY_SKIPPED]);
+        $this->assertEquals(1, $summary['skippedReasons']['locked']);
+        $this->assertEquals(1, $summary['skippedReasons']['priority']);
+    }
+
+    public function testClear(): void
+    {
+        $this->collector->enable();
+        $this->collector->recordPropertyHydration('Test', 'prop', null, 'v', 'source');
+        $this->collector->incrementDepth();
+
+        $this->assertCount(1, $this->collector->getEvents());
+        $this->assertEquals(1, $this->collector->getCurrentDepth());
+
+        $this->collector->clear();
+
+        $this->assertEmpty($this->collector->getEvents());
+        $this->assertEquals(0, $this->collector->getCurrentDepth());
+    }
+
+    public function testReset(): void
+    {
+        $this->collector->enable();
+        $this->collector->recordPropertyHydration('Test', 'prop', null, 'v', 'source');
+
+        $this->collector->reset();
+
+        $this->assertFalse($this->collector->isEnabled());
+        $this->assertEmpty($this->collector->getEvents());
+    }
+}

--- a/tests/Unit/Registry/LockedPropertyRegistryTest.php
+++ b/tests/Unit/Registry/LockedPropertyRegistryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Unit\Registry;
+
+use Kassko\DataMapper\Registry\LockedPropertyRegistry;
+use PHPUnit\Framework\TestCase;
+
+class LockedPropertyRegistryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        LockedPropertyRegistry::clear();
+    }
+
+    public function testLockAndUnlockProperty(): void
+    {
+        $object = new class {
+            public string $name = 'test';
+        };
+
+        // Initially not locked
+        $this->assertFalse(LockedPropertyRegistry::isLocked($object, 'name'));
+
+        // Lock the property
+        LockedPropertyRegistry::lock($object, 'name');
+        $this->assertTrue(LockedPropertyRegistry::isLocked($object, 'name'));
+
+        // Unlock the property
+        LockedPropertyRegistry::unlock($object, 'name');
+        $this->assertFalse(LockedPropertyRegistry::isLocked($object, 'name'));
+    }
+
+    public function testGetLockedProperties(): void
+    {
+        $object = new class {
+            public string $name = 'test';
+            public string $email = 'test@test.com';
+        };
+
+        LockedPropertyRegistry::lock($object, 'name');
+        LockedPropertyRegistry::lock($object, 'email');
+
+        $locked = LockedPropertyRegistry::getLockedProperties($object);
+        
+        $this->assertArrayHasKey('name', $locked);
+        $this->assertArrayHasKey('email', $locked);
+        $this->assertTrue($locked['name']);
+        $this->assertTrue($locked['email']);
+    }
+
+    public function testClearObject(): void
+    {
+        $object = new class {
+            public string $name = 'test';
+        };
+
+        LockedPropertyRegistry::lock($object, 'name');
+        $this->assertTrue(LockedPropertyRegistry::isLocked($object, 'name'));
+
+        LockedPropertyRegistry::clearObject($object);
+        $this->assertFalse(LockedPropertyRegistry::isLocked($object, 'name'));
+    }
+
+    public function testClearAll(): void
+    {
+        $object1 = new class {
+            public string $name = 'test1';
+        };
+        $object2 = new class {
+            public string $name = 'test2';
+        };
+
+        LockedPropertyRegistry::lock($object1, 'name');
+        LockedPropertyRegistry::lock($object2, 'name');
+
+        LockedPropertyRegistry::clear();
+
+        $this->assertFalse(LockedPropertyRegistry::isLocked($object1, 'name'));
+        $this->assertFalse(LockedPropertyRegistry::isLocked($object2, 'name'));
+    }
+
+    public function testDifferentObjectsHaveSeparateLocks(): void
+    {
+        $object1 = new class {
+            public string $name = 'test1';
+        };
+        $object2 = new class {
+            public string $name = 'test2';
+        };
+
+        LockedPropertyRegistry::lock($object1, 'name');
+
+        $this->assertTrue(LockedPropertyRegistry::isLocked($object1, 'name'));
+        $this->assertFalse(LockedPropertyRegistry::isLocked($object2, 'name'));
+    }
+}


### PR DESCRIPTION
# PR - 2025-12-27: Context Improvements, Property Locking & Data Lineage

## Summary

This PR introduces several major features and improvements to the DataMapper library:

1. **Property Lock Registry Externalization**
2. **Context Attribute Revision**
3. **Application Context Support**
4. **Data Lineage Collector**

---

## 1. Property Lock Registry Externalization

### Problem
Previously, locked properties were tracked inside the `LoadableTrait` using a `$lockedProperties` array. This meant the lock state was stored in the data object itself and could be accidentally serialized.

### Solution
Created a new `LockedPropertyRegistry` that uses a `WeakMap` to track locked properties externally. This prevents the lock state from being serialized with the object.

### Files Changed
- `src/Registry/LockedPropertyRegistry.php` (new)
- `src/ObjectExtension/LoadableTrait.php` (updated)
- `src/Loader/Loader.php` (updated to use registry)

### Usage
```php
// The trait still works the same way for users
class MyEntity {
    use LoadableTrait;
    
    public function setValue(string $value): void
    {
        $this->value = $value;
        $this->lockProperty('value'); // Now stored in registry, not in object
    }
}
```

---

## 2. Context Attribute Revision

### Problem
The previous `#[Context]` attribute used an array parameter which was not intuitive.

### Solution
Changed to use named arguments for a cleaner syntax:

```php
// Before (old syntax - removed)
#[Context(['key' => 'value'])]

// After (new syntax)
#[Context(key1: 'value1', key2: 'value2')]
```

### New Expression Function
Added `contextKeyExists('key')` to check if a context key exists without triggering a warning.

### Context Behavior
- Context values accumulate as hydration descends into nested objects
- Later values for the same key override earlier ones (last writer wins)
- Context values are set AFTER the property is hydrated

### Files Changed
- `src/Attribute/Context.php` (updated)
- `src/Registry/ContextRegistry.php` (updated)
- `src/Expression/ExpressionParser.php` (added `contextKeyExists`)
- `src/Loader/Loader.php` (updated `resolvePropertyCandidate`)
- `src/Metadata/AttributeReader.php` (added `readAllContexts`)

---

## 3. Application Context Support

### Problem
Context was limited to values set during hydration via `#[Context]` attributes. Users needed to pass external values (like feature flags) into the hydration process.

### Solution
Added application context support via the `DataMapper` class:

```php
$dataMapper = new DataMapper($serviceResolver);

// Add application context
$dataMapper->addToContext('feature_enabled', $featureFlag->isEnabled());

// Or add multiple at once
$dataMapper->addManyToContext([
    'env' => 'production',
    'user_role' => 'admin',
]);
```

Application context values are available in expressions:
```php
#[MultiPropDataSource(
    args: "expr(context('feature_enabled') ? property('propA') : property('propB'))"
)]
```

### Precedence
Hydration context (`#[Context]`) takes precedence over application context.

### Files Changed
- `src/DataMapper.php` (added context methods)
- `src/Registry/ContextRegistry.php` (split into application/hydration context)

---

## 4. Data Lineage Collector

### Problem
Debugging hydration issues was difficult without visibility into how data flows and transforms.

### Solution
Created a `DataLineageCollector` that records all data flow events during hydration:

- DataSource calls and results
- Property hydrations and transformations
- Decision points (skipped due to priority, lock, scope, etc.)
- Hook executions
- Custom hydrator invocations
- Context changes

### Usage
```php
$dataMapper = new DataMapper($serviceResolver);
$dataMapper->enableLineageCollection();

// ... hydration happens ...

$collector = $dataMapper->getLineageCollector();
$events = $collector->getEvents();
$summary = $collector->getSummary();
```

### Event Types
- `datasource_call` - DataSource method called
- `property_hydration` - Property hydrated
- `property_skipped` - Property skipped (with reason)
- `property_transformed` - Value transformed
- `hook_executed` - Lifecycle hook executed
- `custom_hydrator` - Custom hydrator invoked
- `context_set` - Context value set

### Files Changed
- `src/DataCollector/LineageEvent.php` (new)
- `src/DataCollector/DataLineageCollector.php` (new)
- `src/DataMapper.php` (integrated collector)
- `src/DataMapperBuilder.php` (updated)
- `src/Loader/Loader.php` (added lineage recording)

---

## Breaking Changes

⚠️ **This is an alpha version with breaking changes:**

1. `#[Context]` syntax changed from array to named arguments
2. `ContextRegistry` API updated (split application/hydration context)
3. `LoadableTrait` no longer stores `$lockedProperties` in the object

---

## New Files

- `src/Registry/LockedPropertyRegistry.php`
- `src/DataCollector/LineageEvent.php`
- `src/DataCollector/DataLineageCollector.php`
- `docs/attributes/Context.md` (rewritten)
- `docs/classes/DataLineageCollector.md`
- `tests/Unit/Registry/LockedPropertyRegistryTest.php`
- `tests/Unit/DataCollector/DataLineageCollectorTest.php`
- `tests/Integration/ContextIntegrationTest.php`

---

## Documentation Updates

- Updated `docs/attributes/Context.md` with new syntax and features
- Created `docs/classes/DataLineageCollector.md`
- This PR history file

---

## Testing

Run tests with:
```bash
vendor/bin/phpunit
```

---

## Future Work

- Symfony Bundle integration for Profiler visualization
- More detailed transformation tracking
- Performance metrics in lineage events
