### PR TITLE
feat: Track data flow, handle sensitive data, document some exposed API

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -161,7 +161,7 @@ class Product
     #[DataSourceRef(
         id: 'cache',
         fallbacks: ['database', 'api'],
-        exceptionOnNoValidDataSource: NotFoundException::class
+        exceptionOnNoValidFallback: NotFoundException::class
     )]
     private ?ProductData $data = null;
 }
@@ -361,13 +361,14 @@ class ValidationService
 }
 
 // Use the service in hooks
-#[DataSource(
-    id: 'personSource',
-    class: PersonDataSource::class,
-    method: 'getData',
-    args: ['#id'],
-    supplySeveralProperties: true
-)]
+#[DataSourcesStore([
+    new MultiPropDataSource(
+        id: 'personSource',
+        class: PersonDataSource::class,
+        method: 'getData',
+        args: ['#id']
+    )
+])]
 class Person
 {
     use LoadableTrait;
@@ -403,11 +404,14 @@ class Person
 ### Example 1: Auto-Loading in Args (No Needs Required)
 
 ```php
-use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\MultiPropDataSource;
 use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
 
-#[DataSource(id: 'userSource', class: UserDataSource::class, method: 'getUser', args: ['#userId'], supplySeveralProperties: true)]
-#[DataSource(id: 'preferencesSource', class: PreferencesDataSource::class, method: 'getPreferences', args: ['#userId', '#role'], supplySeveralProperties: true)]
+#[DataSourcesStore([
+    new MultiPropDataSource(id: 'userSource', class: UserDataSource::class, method: 'getUser', args: ['#userId']),
+    new MultiPropDataSource(id: 'preferencesSource', class: PreferencesDataSource::class, method: 'getPreferences', args: ['#userId', '#role'])
+])]
 class UserProfile
 {
     use LoadableTrait;
@@ -434,12 +438,15 @@ class UserProfile
 
 ```php
 use Kassko\DataMapper\Attribute\Needs;
-use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\MultiPropDataSource;
 use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
 
-#[DataSource(id: 'discountSource', class: DiscountDataSource::class, method: 'getDiscount', args: ['#customerId'], supplySeveralProperties: true)]
-#[DataSource(id: 'customerSource', class: CustomerDataSource::class, method: 'getCustomer', args: ['#customerId'], supplySeveralProperties: true)]
-#[DataSource(id: 'orderSource', class: OrderDataSource::class, method: 'getOrder', args: ['#orderId'], supplySeveralProperties: true)]
+#[DataSourcesStore([
+    new MultiPropDataSource(id: 'discountSource', class: DiscountDataSource::class, method: 'getDiscount', args: ['#customerId']),
+    new MultiPropDataSource(id: 'customerSource', class: CustomerDataSource::class, method: 'getCustomer', args: ['#customerId']),
+    new MultiPropDataSource(id: 'orderSource', class: OrderDataSource::class, method: 'getOrder', args: ['#orderId'])
+])]
 class Order
 {
     use LoadableTrait;
@@ -476,12 +483,15 @@ class Order
 
 ```php
 use Kassko\DataMapper\Attribute\Needs;
-use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Attribute\MultiPropDataSource;
 use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\Attribute\DataSourcesStore;
 
-#[DataSource(id: 'sourceA', class: SourceA::class, method: 'getData', supplySeveralProperties: true)]
-#[DataSource(id: 'sourceB', class: SourceB::class, method: 'getData', supplySeveralProperties: true)]
-#[DataSource(id: 'sourceC', class: SourceC::class, method: 'process', args: ['#propA'], supplySeveralProperties: true)]
+#[DataSourcesStore([
+    new MultiPropDataSource(id: 'sourceA', class: SourceA::class, method: 'getData'),
+    new MultiPropDataSource(id: 'sourceB', class: SourceB::class, method: 'getData'),
+    new MultiPropDataSource(id: 'sourceC', class: SourceC::class, method: 'process', args: ['#propA'])
+])]
 class Example
 {
     use LoadableTrait;
@@ -601,7 +611,7 @@ class Config
     #[DataSourceRef(
         id: 'primaryApi',
         fallbacks: ['cacheBackup', 'defaultValues'],
-        exceptionOnNoValidDataSource: NoValidDataSourceException::class,
+        exceptionOnNoValidFallback: NoValidDataSourceException::class,
         priority: 5
     )]
     private ?array $settings = null;
@@ -711,14 +721,14 @@ Summary
 // v1.x (DEPRECATED)
 #[DataSourceRef(
     chain: ['primary', 'backup'],
-    exceptionOnNoValidDataSource: MyException::class
+    exceptionOnNoValidFallback: MyException::class
 )]
 
 // v2.0
 #[DataSourceRef(
     id: 'primary',
     fallbacks: ['backup'],
-    exceptionOnNoValidDataSource: MyException::class
+    exceptionOnNoValidFallback: MyException::class
 )]
 ```
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ DataSourceRef now uses `id` + `fallbacks` instead of `chain` for clearer semanti
 #[DataSourceRef(
     id: 'primarySource',
     fallbacks: ['backupSource', 'lastResort'],
-    exceptionOnNoValidDataSource: NoValidDataSourceException::class,
+    exceptionOnNoValidFallback: NoValidDataSourceException::class,
     priority: 5
 )]
 private ?string $data = null;
@@ -303,7 +303,7 @@ Reference DataSources with three modes:
 #[DataSourceRef(
     id: 'primaryApi',
     fallbacks: ['cacheBackup', 'defaultValues'],
-    exceptionOnNoValidDataSource: NoValidDataSourceException::class
+    exceptionOnNoValidFallback: NoValidDataSourceException::class
 )]
 
 // Aggregation (merges all provider results)

--- a/docs/attributes/DataSourceRef.md
+++ b/docs/attributes/DataSourceRef.md
@@ -51,15 +51,17 @@ class Person
 | `providers` | `?array` | Conditional | Array of IDs for aggregation |
 | `candidates` | `?array` | Conditional | Array of candidates with rule expressions |
 | `defaultCandidate` | `?array` | Conditional | Default candidate if no rule matches (required with `candidates`) |
-| `exceptionOnNoValidDataSource` | `?string` | No | Exception class for fallback handling |
+| `exceptionOnNoValidFallback` | `?string` | No | Exception class for fallback handling |
+| `ignoreProviderOnNotFound` | `bool` | No | Silently skip missing providers (requires `providers`, default: false) |
 | `priority` | `int` | No | Hydration priority (default: 0) |
 
 **Validation Rules:**
 - `id`, `providers`, and `candidates` are mutually exclusive
 - `candidates` and `defaultCandidate` must both be present or both absent
-- `fallbacks` and `exceptionOnNoValidDataSource` cannot be used with `candidates`
+- `fallbacks` and `exceptionOnNoValidFallback` cannot be used with `candidates`
 - `fallbacks` can only be used with `id`
-- `exceptionOnNoValidDataSource` requires `fallbacks` to be set
+- `exceptionOnNoValidFallback` requires `fallbacks` to be set
+- `ignoreProviderOnNotFound` can only be used with `providers`
 - Each candidate must have `id` and `rule` keys
 
 ## Modes
@@ -79,7 +81,7 @@ Try primary source, then fallbacks in order until one succeeds:
 #[DataSourceRef(
     id: 'primaryApi',
     fallbacks: ['cacheBackup', 'defaultValues'],
-    exceptionOnNoValidDataSource: NoValidDataSourceException::class
+    exceptionOnNoValidFallback: NoValidDataSourceException::class
 )]
 private ?string $data = null;
 ```
@@ -97,6 +99,50 @@ Merge results from multiple sources (uses `array_replace_recursive`):
 ```php
 #[DataSourceRef(providers: ['basicConfig', 'userPreferences', 'overrides'])]
 private ?array $config = null;
+```
+
+#### Complete Providers Example
+
+```php
+use Kassko\DataMapper\Attribute\DataSourcesStore;
+use Kassko\DataMapper\Attribute\MultiPropDataSource;
+use Kassko\DataMapper\Attribute\DataSourceRef;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+#[DataSourcesStore([
+    new MultiPropDataSource(id: 'basicInfo', class: UserBasicDataSource::class, method: 'getBasic', args: ['#userId']),
+    new MultiPropDataSource(id: 'extendedInfo', class: UserExtendedDataSource::class, method: 'getExtended', args: ['#userId']),
+    new MultiPropDataSource(id: 'preferences', class: UserPreferencesDataSource::class, method: 'getPrefs', args: ['#userId']),
+])]
+class UserProfile
+{
+    use LoadableTrait;
+    
+    private int $userId;
+    
+    /**
+     * Aggregates data from all three sources.
+     * Later providers override earlier ones for conflicting keys.
+     */
+    #[DataSourceRef(providers: ['basicInfo', 'extendedInfo', 'preferences'])]
+    private ?array $userData = null;
+    
+    /**
+     * With ignoreProviderOnNotFound: true, missing providers are silently skipped.
+     * Useful when some providers may not be available in all environments.
+     */
+    #[DataSourceRef(
+        providers: ['basicInfo', 'optionalProvider', 'preferences'],
+        ignoreProviderOnNotFound: true
+    )]
+    private ?array $partialData = null;
+    
+    public function getUserData(): ?array
+    {
+        $this->loadProperty('userData');
+        return $this->userData;
+    }
+}
 ```
 
 ### Priority-Based Hydration

--- a/docs/classes/DataMapperBuilder.md
+++ b/docs/classes/DataMapperBuilder.md
@@ -1,0 +1,312 @@
+# DataMapperBuilder
+
+A fluent builder for configuring and creating `DataMapper` instances.
+
+## Overview
+
+The `DataMapperBuilder` provides a fluent API for configuring all aspects of the DataMapper:
+
+- Service resolution (containers, locators, factories)
+- Custom hydrators
+- Caching
+- Logging
+- Sensitive data handling
+
+## Basic Usage
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+
+$builder = new DataMapperBuilder();
+$dataMapper = $builder->build();
+```
+
+## Configuration Methods
+
+### Container & Service Locators
+
+#### `setContainer(ContainerInterface $container): self`
+
+Sets the PSR-11 container for service resolution.
+
+```php
+use Psr\Container\ContainerInterface;
+
+$builder->setContainer($container);
+```
+
+#### `addLocator(ServiceLocatorInterface $locator): self`
+
+Adds a custom service locator for resolving services.
+
+```php
+use Kassko\DataMapper\ArrayServiceLocator;
+
+$builder->addLocator(new ArrayServiceLocator([
+    'user.datasource' => UserDataSource::class,
+    'address.datasource' => AddressDataSource::class,
+]));
+```
+
+### Factory Services
+
+#### `addFactoryService(object $factoryService, string $method): self`
+
+Adds a factory service that can create instances. The factory method receives the service key as argument.
+
+```php
+class ServiceFactory
+{
+    public function create(string $key): object
+    {
+        return match ($key) {
+            'user.datasource' => new UserDataSource(),
+            default => throw new \Exception("Unknown service: $key"),
+        };
+    }
+}
+
+$builder->addFactoryService(new ServiceFactory(), 'create');
+```
+
+#### `addStaticFactory(string|object $factoryClass, string $method): self`
+
+Adds a static factory (class with static method) that can create instances.
+
+```php
+class StaticFactory
+{
+    public static function create(string $key): object
+    {
+        return match ($key) {
+            'user.datasource' => new UserDataSource(),
+            default => throw new \Exception("Unknown service: $key"),
+        };
+    }
+}
+
+$builder->addStaticFactory(StaticFactory::class, 'create');
+```
+
+#### `addCallable(callable $callable): self`
+
+Adds a callable that can create instances. Supports all callable types.
+
+```php
+// Using a closure
+$builder->addCallable(fn(string $key) => match ($key) {
+    'user.datasource' => new UserDataSource(),
+    default => null,
+});
+
+// Using array callable
+$builder->addCallable([MyFactory::class, 'create']);
+
+// Using string callable
+$builder->addCallable('MyFactory::create');
+```
+
+### Custom Hydrators
+
+#### `addCustomHydrator(string $key, callable $callable): self`
+
+Adds a custom hydrator for special object creation logic.
+
+```php
+$builder->addCustomHydrator('person_hydrator', function (array $data): Person {
+    $person = new Person();
+    $person->firstName = $data['first_name'] ?? '';
+    $person->lastName = $data['last_name'] ?? '';
+    return $person;
+});
+```
+
+Usage in attributes:
+
+```php
+use Kassko\DataMapper\Attribute\CustomHydrator;
+use Kassko\DataMapper\Attribute\Property;
+
+class Team
+{
+    #[Property]
+    public string $name;
+    
+    #[Property]
+    #[CustomHydrator(key: 'person_hydrator')]
+    public Person $leader;
+}
+```
+
+### Caching & Logging
+
+#### `setCache(CacheInterface $cache): self`
+
+Sets the PSR-16 simple cache for caching metadata.
+
+```php
+use Psr\SimpleCache\CacheInterface;
+
+$builder->setCache($cache);
+```
+
+#### `setLogger(LoggerInterface $logger): self`
+
+Sets the PSR-3 logger for debug logging.
+
+```php
+use Psr\Log\LoggerInterface;
+
+$builder->setLogger($logger);
+```
+
+### Sensitive Data Handling
+
+Control how sensitive data is displayed in lineage collection.
+
+#### `setDefaultSensitiveLevel(SensitiveLevel $level): self`
+
+Sets the default sensitive level for all properties.
+
+```php
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
+$builder->setDefaultSensitiveLevel(SensitiveLevel::MASK);
+```
+
+#### `setSensitiveKeys(array $sensitiveKeys): self`
+
+Sets all sensitive keys at once. Replaces any existing configuration.
+
+```php
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
+$builder->setSensitiveKeys([
+    'password' => SensitiveLevel::HIDE,
+    'ssn' => SensitiveLevel::MASK,
+    '*secret*' => SensitiveLevel::HIDE,  // Pattern matching
+    'User.email' => SensitiveLevel::MASK,  // Class-specific
+]);
+```
+
+#### `addSensitiveKey(string $key, SensitiveLevel $level): self`
+
+Adds a single sensitive key.
+
+```php
+$builder->addSensitiveKey('password', SensitiveLevel::HIDE);
+```
+
+#### `removeSensitiveKeys(string ...$keys): self`
+
+Removes one or more sensitive keys.
+
+```php
+$builder->removeSensitiveKeys('password', 'ssn');
+```
+
+#### `getSensitiveKeys(): array`
+
+Gets the configured sensitive keys.
+
+```php
+$keys = $builder->getSensitiveKeys();
+// ['password' => SensitiveLevel::HIDE, ...]
+```
+
+#### `getDefaultSensitiveLevel(): SensitiveLevel`
+
+Gets the default sensitive level.
+
+```php
+$level = $builder->getDefaultSensitiveLevel();
+```
+
+### Building
+
+#### `build(): DataMapper`
+
+Builds and returns a configured `DataMapper` instance.
+
+```php
+$dataMapper = $builder->build();
+```
+
+## Sensitive Levels
+
+The `SensitiveLevel` enum provides four levels:
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| `SHOW` | Display full value (default) | `"mysecretpassword"` |
+| `HIDE` | Replace with `[SENSITIVE]` | `"[SENSITIVE]"` |
+| `MASK` | Show first 2 and last 2 chars | `"my**********rd"` |
+| `TYPE_ONLY` | Show only the type | `"[string(16)]"` |
+
+### Pattern Matching
+
+Sensitive key patterns support wildcards:
+
+- `password` - Exact match
+- `*password*` - Contains "password"
+- `password*` - Starts with "password"
+- `*password` - Ends with "password"
+- `User.*` - All properties of User class
+
+## Complete Example
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\Enum\SensitiveLevel;
+use Kassko\DataMapper\ArrayServiceLocator;
+
+$builder = new DataMapperBuilder();
+
+$dataMapper = $builder
+    // Service resolution
+    ->setContainer($container)
+    ->addLocator(new ArrayServiceLocator([
+        'user.datasource' => UserDataSource::class,
+        'address.datasource' => AddressDataSource::class,
+    ]))
+    
+    // Factories
+    ->addCallable(fn(string $key) => match ($key) {
+        'custom.service' => new CustomService(),
+        default => null,
+    })
+    
+    // Custom hydrators
+    ->addCustomHydrator('person_hydrator', function (array $data): Person {
+        return Person::fromArray($data);
+    })
+    
+    // Caching and logging
+    ->setCache($cache)
+    ->setLogger($logger)
+    
+    // Sensitive data handling
+    ->setDefaultSensitiveLevel(SensitiveLevel::SHOW)
+    ->addSensitiveKey('password', SensitiveLevel::HIDE)
+    ->addSensitiveKey('*token*', SensitiveLevel::MASK)
+    ->addSensitiveKey('ssn', SensitiveLevel::MASK)
+    
+    // Build
+    ->build();
+
+// Enable lineage collection for debugging
+$dataMapper->enableLineageCollection();
+
+// Use the DataMapper
+$hydrator = $dataMapper->getHydrator();
+$user = $hydrator->hydrate(User::class, $userData);
+
+// Check collected events (sensitive values are protected)
+$events = $dataMapper->getLineageCollector()->getEventsAsArrays();
+```
+
+## See Also
+
+- [Hydrator](Hydrator.md) - For hydrating objects from raw data
+- [DataLineageCollector](DataLineageCollector.md) - For debugging hydration
+- [ArrayServiceLocator](../classes/ArrayServiceLocator.md) - Simple service locator

--- a/docs/classes/Hydrator.md
+++ b/docs/classes/Hydrator.md
@@ -1,0 +1,179 @@
+# Hydrator
+
+A clean, simple interface for hydrating objects from raw data.
+
+## Overview
+
+The `Hydrator` class provides a convenient API for creating and populating objects from associative arrays. It wraps the internal `Loader` functionality and handles:
+
+- Object instantiation with `#[Param]` attribute support
+- Execution of `#[PropertyInstantiatingHook]` hooks
+- Property hydration from raw data
+
+## Usage
+
+### Getting the Hydrator
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+
+$builder = new DataMapperBuilder();
+$dataMapper = $builder->build();
+
+$hydrator = $dataMapper->getHydrator();
+```
+
+### Basic Hydration
+
+```php
+// Create and hydrate a new object from raw data
+$person = $hydrator->hydrate(Person::class, [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'email' => 'john.doe@example.com',
+]);
+
+echo $person->firstName; // "John"
+```
+
+### Hydrating Existing Objects
+
+```php
+// Create an object first
+$person = new Person();
+
+// Hydrate it with raw data
+$hydrator->hydrateExisting($person, [
+    'first_name' => 'Jane',
+    'last_name' => 'Smith',
+]);
+
+echo $person->firstName; // "Jane"
+```
+
+## Methods
+
+### `hydrate(string $className, array $rawData): object`
+
+Creates a new instance of the specified class and hydrates its properties from the provided raw data array.
+
+**Parameters:**
+- `$className` - The fully qualified class name to instantiate
+- `$rawData` - An associative array of raw data to hydrate the object with
+
+**Returns:** The hydrated object instance
+
+**Throws:**
+- `\InvalidArgumentException` if the class cannot be instantiated
+- `\ReflectionException` if reflection fails
+
+```php
+$user = $hydrator->hydrate(User::class, [
+    'username' => 'johndoe',
+    'email' => 'john@example.com',
+]);
+```
+
+### `hydrateExisting(object $object, array $rawData): object`
+
+Hydrates the properties of an existing object instance from the provided raw data array.
+
+**Parameters:**
+- `$object` - The object instance to hydrate
+- `$rawData` - An associative array of raw data to hydrate the object with
+
+**Returns:** The same object instance, now hydrated
+
+```php
+$user = new User();
+$hydrator->hydrateExisting($user, [
+    'username' => 'johndoe',
+]);
+```
+
+## Lifecycle
+
+When using `hydrate()`, the following steps occur:
+
+1. **Instantiation** - The object is created using `#[Param]` attributes if present
+2. **Instantiating Hooks** - `#[PropertyInstantiatingHook]` hooks are executed
+3. **Hydration** - Properties are hydrated from the raw data
+
+When using `hydrateExisting()`:
+
+1. **Instantiating Hooks** - `#[PropertyInstantiatingHook]` hooks are executed
+2. **Hydration** - Properties are hydrated from the raw data
+
+## Example with Attributes
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\Attribute\PropertyInstantiatingHook;
+
+class Person
+{
+    #[Property(name: 'first_name')]
+    public string $firstName;
+    
+    #[Property(name: 'last_name')]
+    public string $lastName;
+    
+    public ?string $fullName = null;
+    
+    #[PropertyInstantiatingHook]
+    public function onInstantiate(array $rawData): void
+    {
+        // Called before hydration
+        $this->fullName = ($rawData['first_name'] ?? '') . ' ' . ($rawData['last_name'] ?? '');
+    }
+}
+
+$person = $hydrator->hydrate(Person::class, [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+]);
+
+echo $person->fullName; // "John Doe"
+```
+
+## Nested Object Hydration
+
+The hydrator supports nested object hydration when the `class` parameter is specified:
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class User
+{
+    #[Property]
+    public string $name;
+    
+    #[Property(class: Address::class)]
+    public Address $address;
+}
+
+class Address
+{
+    #[Property]
+    public string $street;
+    
+    #[Property]
+    public string $city;
+}
+
+$user = $hydrator->hydrate(User::class, [
+    'name' => 'John',
+    'address' => [
+        'street' => '123 Main St',
+        'city' => 'New York',
+    ],
+]);
+
+echo $user->address->city; // "New York"
+```
+
+## See Also
+
+- [DataMapperBuilder](DataMapperBuilder.md) - For building and configuring the DataMapper
+- [Property](../attributes/Property.md) - Property attribute documentation
+- [PropertyInstantiatingHook](../attributes/PropertyInstantiatingHook.md) - Instantiating hooks

--- a/docs/history/PR-2025_12_30_23_35_39.md
+++ b/docs/history/PR-2025_12_30_23_35_39.md
@@ -1,0 +1,100 @@
+# PR: Add sensitiveKeys to DataSource Attributes and Move SensitiveLevel to Enum Namespace
+
+## Summary
+
+This PR enhances the data lineage collection system by adding `sensitiveKeys` support to DataSource attributes and relocates the `SensitiveLevel` enum to a dedicated `Enum` namespace for cleaner public API design.
+
+## Changes
+
+### 1. SensitiveLevel Enum Relocation
+
+- **Moved** `SensitiveLevel` enum from `Kassko\DataMapper\DataCollector` to `Kassko\DataMapper\Enum` namespace
+- **Rationale**: Avoid forcing public API users to import from the `DataCollector` namespace when using `SensitiveLevel` in their entity attributes
+- **Updated** all internal references across the codebase
+
+### 2. Added `sensitiveKeys` Parameter to DataSource Attributes
+
+The following attributes now support `sensitiveKeys` for masking sensitive data in lineage collection:
+
+- `DataSource`
+- `SinglePropDataSource`
+- `MultiPropDataSource`
+
+#### Example Usage
+
+```php
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
+#[DataSource(
+    class: UserRepository::class,
+    method: 'findUser',
+    args: ['#id'],
+    sensitiveKeys: [
+        'password' => SensitiveLevel::HIDE,      // Exact match → [SENSITIVE]
+        '*Token' => SensitiveLevel::MASK,        // Pattern → to**********23
+        'secret*' => SensitiveLevel::TYPE_ONLY,  // Pattern → [string(12)]
+    ]
+)]
+private ?array $userData = null;
+```
+
+### 3. DataLineageCollector Enhancements
+
+- Updated `recordDataSourceCall()` to accept a `sensitiveKeys` parameter
+- Added `applySensitiveKeysToResult()` method to mask sensitive keys in DataSource results
+- Added `getSensitiveLevelForKey()` method to resolve sensitive levels for specific keys
+- Metadata now includes `hasSensitiveKeys` flag to indicate if masking was applied
+
+### 4. Loader Updates
+
+- All three `recordDataSourceCall()` invocations now pass `$dataSource->sensitiveKeys` to the collector
+
+## Files Changed
+
+### Modified
+- `src/Enum/SensitiveLevel.php` (moved from `src/DataCollector/SensitiveLevel.php`)
+- `src/Attribute/DataSource.php` - Added `sensitiveKeys` parameter
+- `src/Attribute/SinglePropDataSource.php` - Added `sensitiveKeys` parameter
+- `src/Attribute/MultiPropDataSource.php` - Added `sensitiveKeys` parameter
+- `src/DataCollector/DataLineageCollector.php` - Updated import, enhanced `recordDataSourceCall()`, added helper methods
+- `src/DataCollector/LineageEvent.php` - Updated import
+- `src/DataMapperBuilder.php` - Updated import
+- `src/DataMapper.php` - Updated import
+- `src/Attribute/Property.php` - Updated import
+- `src/Attribute/PropertyConfig.php` - Updated import
+- `src/Loader/Loader.php` - Pass `sensitiveKeys` to collector
+
+### Deleted
+- `src/DataCollector/SensitiveLevel.php` (moved to Enum namespace)
+
+### Tests
+- `tests/Unit/DataCollector/DataLineageCollectorTest.php` - Updated import, added 2 new tests for DataSource sensitiveKeys
+
+## Test Results
+
+```
+Tests: 264, Assertions: 611, Skipped: 2
+OK
+```
+
+## Breaking Changes
+
+- **Namespace Change**: `Kassko\DataMapper\DataCollector\SensitiveLevel` → `Kassko\DataMapper\Enum\SensitiveLevel`
+  - Users must update their imports if they were using `SensitiveLevel` from the old namespace
+
+## Migration Guide
+
+Replace imports:
+```php
+// Before
+use Kassko\DataMapper\DataCollector\SensitiveLevel;
+
+// After
+use Kassko\DataMapper\Enum\SensitiveLevel;
+```
+
+## Related Issues
+
+- Improves debugging experience by allowing granular control over sensitive data visibility in DataSource results
+- Provides cleaner public API by separating core enums from internal collector implementation

--- a/docs/summary/SUMMARY-2025-12-30---23-35-39.md
+++ b/docs/summary/SUMMARY-2025-12-30---23-35-39.md
@@ -1,0 +1,120 @@
+# Work Session Summary - December 30, 2025
+
+## Session Overview
+
+This session focused on two main enhancements to the DataMapper library:
+1. Relocating the `SensitiveLevel` enum to a dedicated `Enum` namespace
+2. Adding `sensitiveKeys` parameter support to DataSource attributes
+
+## Tasks Completed
+
+### 1. SensitiveLevel Enum Relocation
+
+**Objective**: Move `SensitiveLevel` enum from `DataCollector` namespace to `Enum` namespace for cleaner public API.
+
+**Changes Made**:
+- Created new file `src/Enum/SensitiveLevel.php` with namespace `Kassko\DataMapper\Enum`
+- Deleted old file `src/DataCollector/SensitiveLevel.php`
+- Updated all import statements across the codebase:
+  - `src/DataCollector/DataLineageCollector.php`
+  - `src/DataCollector/LineageEvent.php`
+  - `src/DataMapperBuilder.php`
+  - `src/DataMapper.php`
+  - `src/Attribute/Property.php`
+  - `src/Attribute/PropertyConfig.php`
+  - `tests/Unit/DataCollector/DataLineageCollectorTest.php`
+  - `docs/classes/DataMapperBuilder.md`
+
+### 2. Added sensitiveKeys to DataSource Attributes
+
+**Objective**: Allow users to specify which keys in a DataSource result should be masked in the lineage collector.
+
+**Attributes Modified**:
+| Attribute | New Parameter |
+|-----------|---------------|
+| `DataSource` | `sensitiveKeys: array` |
+| `SinglePropDataSource` | `sensitiveKeys: array` |
+| `MultiPropDataSource` | `sensitiveKeys: array` |
+
+**DataLineageCollector Enhancements**:
+- Updated `recordDataSourceCall()` signature to accept `sensitiveKeys` parameter
+- Added `applySensitiveKeysToResult()` private method for masking result values
+- Added `getSensitiveLevelForKey()` private method for resolving sensitive levels
+- Metadata now includes `hasSensitiveKeys` boolean flag
+
+**Loader Updates**:
+- All 3 calls to `recordDataSourceCall()` now pass `$dataSource->sensitiveKeys`
+
+### 3. Tests Added
+
+Added 2 new test cases to `DataLineageCollectorTest.php`:
+- `testDataSourceSensitiveKeys()` - Verifies sensitiveKeys masking works correctly
+- `testDataSourceWithoutSensitiveKeys()` - Verifies data is unchanged when no sensitiveKeys
+
+## Technical Details
+
+### SensitiveLevel Enum Cases
+
+| Case | Value | Behavior |
+|------|-------|----------|
+| `SHOW` | `'show'` | Display full value |
+| `HIDE` | `'hide'` | Display `[SENSITIVE]` |
+| `MASK` | `'mask'` | Display `se**********rd` |
+| `TYPE_ONLY` | `'type_only'` | Display `[string(14)]` |
+
+### sensitiveKeys Pattern Matching
+
+Supports:
+- **Exact match**: `'password'` matches only `password`
+- **Wildcard patterns**: `'*Token'` matches `apiToken`, `refreshToken`
+- **Prefix patterns**: `'secret*'` matches `secretKey`, `secretValue`
+
+## Test Results
+
+```
+PHPUnit 11.5.46
+Tests: 264, Assertions: 611, Skipped: 2
+Status: OK
+```
+
+## Files Summary
+
+| Action | Count |
+|--------|-------|
+| Created | 1 (`src/Enum/SensitiveLevel.php`) |
+| Modified | 11 files |
+| Deleted | 1 (`src/DataCollector/SensitiveLevel.php`) |
+
+## Usage Example
+
+```php
+use Kassko\DataMapper\Attribute\DataSource;
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
+class User
+{
+    #[DataSource(
+        class: UserRepository::class,
+        method: 'findUserData',
+        args: ['#id'],
+        sensitiveKeys: [
+            'password' => SensitiveLevel::HIDE,
+            '*Token' => SensitiveLevel::MASK,
+            'ssn' => SensitiveLevel::TYPE_ONLY,
+        ]
+    )]
+    private ?array $userData = null;
+}
+```
+
+## Breaking Changes
+
+⚠️ **Namespace Change**: Users importing `SensitiveLevel` must update their imports:
+
+```php
+// Before
+use Kassko\DataMapper\DataCollector\SensitiveLevel;
+
+// After  
+use Kassko\DataMapper\Enum\SensitiveLevel;
+```

--- a/src/Attribute/DataSource.php
+++ b/src/Attribute/DataSource.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Attribute;
 
 use Attribute;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 
 /**
  * Alias for SinglePropDataSource.
@@ -31,5 +32,7 @@ final class DataSource
         public readonly string $method = '',
         public readonly array $args = [],
         public readonly int $priority = 0,
+        /** @var array<string, SensitiveLevel> Keys to mark as sensitive (exact name or regex pattern) */
+        public readonly array $sensitiveKeys = [],
     ) {}
 }

--- a/src/Attribute/DataSourceRef.php
+++ b/src/Attribute/DataSourceRef.php
@@ -23,7 +23,8 @@ final class DataSourceRef
     public readonly ?array $providers;
     public readonly ?array $candidates;
     public readonly ?array $defaultCandidate;
-    public readonly ?string $exceptionOnNoValidDataSource;
+    public readonly ?string $exceptionOnNoValidFallback;
+    public readonly bool $ignoreProviderOnNotFound;
     public readonly int $priority;
 
     /**
@@ -34,7 +35,8 @@ final class DataSourceRef
      *                               Each candidate: ['id' => string, 'rule' => string, 'priority' => int (optional)]
      * @param array|null $defaultCandidate Default candidate if no rule matches.
      *                                      Structure: ['id' => string, 'priority' => int (optional)]
-     * @param string|null $exceptionOnNoValidDataSource Exception class for fallbacks
+     * @param string|null $exceptionOnNoValidFallback Exception class for fallbacks (thrown when all fallbacks fail)
+     * @param bool $ignoreProviderOnNotFound If true, missing providers are silently skipped (requires providers)
      * @param int $priority Base priority for hydration
      */
     public function __construct(
@@ -43,7 +45,8 @@ final class DataSourceRef
         ?array $providers = null,
         ?array $candidates = null,
         ?array $defaultCandidate = null,
-        ?string $exceptionOnNoValidDataSource = null,
+        ?string $exceptionOnNoValidFallback = null,
+        bool $ignoreProviderOnNotFound = false,
         int $priority = 0
     ) {
         // Count how many "modes" are set
@@ -70,8 +73,8 @@ final class DataSourceRef
             if ($fallbacks !== null) {
                 throw new \InvalidArgumentException('DataSourceRef: fallbacks cannot be used with candidates');
             }
-            if ($exceptionOnNoValidDataSource !== null) {
-                throw new \InvalidArgumentException('DataSourceRef: exceptionOnNoValidDataSource cannot be used with candidates');
+            if ($exceptionOnNoValidFallback !== null) {
+                throw new \InvalidArgumentException('DataSourceRef: exceptionOnNoValidFallback cannot be used with candidates');
             }
         }
 
@@ -80,9 +83,14 @@ final class DataSourceRef
             throw new \InvalidArgumentException('DataSourceRef: fallbacks can only be used with id');
         }
 
-        // Build-time validation: exceptionOnNoValidDataSource requires fallbacks
-        if ($exceptionOnNoValidDataSource !== null && $fallbacks === null) {
-            throw new \InvalidArgumentException('DataSourceRef: exceptionOnNoValidDataSource requires fallbacks to be set');
+        // Build-time validation: exceptionOnNoValidFallback requires fallbacks
+        if ($exceptionOnNoValidFallback !== null && $fallbacks === null) {
+            throw new \InvalidArgumentException('DataSourceRef: exceptionOnNoValidFallback requires fallbacks to be set');
+        }
+
+        // Build-time validation: ignoreProviderOnNotFound requires providers
+        if ($ignoreProviderOnNotFound && $providers === null) {
+            throw new \InvalidArgumentException('DataSourceRef: ignoreProviderOnNotFound can only be used with providers');
         }
 
         // Build-time validation: candidates structure
@@ -115,7 +123,8 @@ final class DataSourceRef
         $this->providers = $providers;
         $this->candidates = $candidates;
         $this->defaultCandidate = $defaultCandidate;
-        $this->exceptionOnNoValidDataSource = $exceptionOnNoValidDataSource;
+        $this->exceptionOnNoValidFallback = $exceptionOnNoValidFallback;
+        $this->ignoreProviderOnNotFound = $ignoreProviderOnNotFound;
         $this->priority = $priority;
     }
 }

--- a/src/Attribute/MultiPropDataSource.php
+++ b/src/Attribute/MultiPropDataSource.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Attribute;
 
 use Attribute;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 
 /**
  * Defines a data source that hydrates multiple properties.
@@ -44,5 +45,7 @@ final class MultiPropDataSource
         public readonly array $loadingScopeKeys = [],    // Filter by raw data keys
         public readonly array $loadingScopeProps = [],   // Filter by property names (NEW)
         public readonly int $priority = 0,
+        /** @var array<string, SensitiveLevel> Keys to mark as sensitive (exact name or regex pattern) */
+        public readonly array $sensitiveKeys = [],
     ) {}
 }

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Attribute;
 
 use Attribute;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Property
@@ -28,6 +29,7 @@ final class Property
         /** @var array<array{id: string, rule: string}>|null Config candidates with rules */
         public readonly ?array $configCandidates = null,
         public readonly ?string $defaultConfigCandidate = null,  // Default config ID when no rule matches
+        public readonly ?SensitiveLevel $sensitiveLevel = null,  // Sensitivity level for lineage collection
     ) {
         // Validation: mapping requires class to be set
         if ($mapping !== null && $class === null) {

--- a/src/Attribute/PropertyConfig.php
+++ b/src/Attribute/PropertyConfig.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper\Attribute;
 
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
 /**
  * PropertyConfig defines a reusable property configuration with an ID.
  * Used inside PropertyConfigStore at class level.
@@ -26,6 +28,7 @@ final class PropertyConfig
         public readonly ?string $expand = null,
         public readonly ?string $noExpand = null,
         public readonly ?array $mapping = null,
+        public readonly ?SensitiveLevel $sensitiveLevel = null,  // Sensitivity level for lineage collection
     ) {
         // Validation: mapping requires class to be set
         if ($mapping !== null && $class === null) {

--- a/src/Attribute/SinglePropDataSource.php
+++ b/src/Attribute/SinglePropDataSource.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper\Attribute;
 
 use Attribute;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 
 /**
  * Defines a data source that hydrates a single property.
@@ -32,6 +33,8 @@ final class SinglePropDataSource
         public readonly string $method = '',
         public readonly array $args = [],
         public readonly int $priority = 0,
+        /** @var array<string, SensitiveLevel> Keys to mark as sensitive (exact name or regex pattern) */
+        public readonly array $sensitiveKeys = [],
         // NO loadingScope/loadingScopeKeys - single property only
     ) {}
 }

--- a/src/DataCollector/DataLineageCollector.php
+++ b/src/DataCollector/DataLineageCollector.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper\DataCollector;
 
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
 /**
  * Collector for data lineage and audit information.
  * 
@@ -43,9 +45,29 @@ final class DataLineageCollector
     /** @var float Start time of collection */
     private float $startTime;
 
-    public function __construct()
-    {
+    /** @var string|null Current flow ID for grouping related events */
+    private ?string $currentFlowId = null;
+
+    /** @var string[] Stack of flow IDs for nested flows */
+    private array $flowStack = [];
+
+    /** @var array<string, SensitiveLevel> Global sensitive keys configuration */
+    private array $sensitiveKeys;
+
+    /** @var SensitiveLevel Default sensitive level for all properties */
+    private SensitiveLevel $defaultSensitiveLevel;
+
+    /**
+     * @param array<string, SensitiveLevel> $sensitiveKeys Global sensitive keys configuration
+     * @param SensitiveLevel $defaultSensitiveLevel Default sensitive level for all properties
+     */
+    public function __construct(
+        array $sensitiveKeys = [],
+        SensitiveLevel $defaultSensitiveLevel = SensitiveLevel::SHOW
+    ) {
         $this->startTime = microtime(true);
+        $this->sensitiveKeys = $sensitiveKeys;
+        $this->defaultSensitiveLevel = $defaultSensitiveLevel;
     }
 
     /**
@@ -100,7 +122,99 @@ final class DataLineageCollector
     }
 
     /**
+     * Start a new flow for grouping related events.
+     * 
+     * @param string $objectClass The class being hydrated
+     * @param string|null $label Optional descriptive label for the flow
+     * @return string The generated flow ID
+     */
+    public function startFlow(string $objectClass, ?string $label = null): string
+    {
+        $flowId = uniqid('flow_', true);
+        
+        // Push current flow onto stack if any
+        if ($this->currentFlowId !== null) {
+            $this->flowStack[] = $this->currentFlowId;
+        }
+        
+        $this->currentFlowId = $flowId;
+        
+        if ($this->enabled) {
+            $this->events[] = new LineageEvent(
+                type: LineageEvent::TYPE_FLOW_START,
+                objectClass: $objectClass,
+                propertyName: null,
+                source: null,
+                originalValue: null,
+                finalValue: null,
+                reason: $label,
+                metadata: [
+                    'parentFlowId' => $this->flowStack[count($this->flowStack) - 1] ?? null,
+                ],
+                timestamp: microtime(true) - $this->startTime,
+                depth: $this->currentDepth,
+                flowId: $flowId,
+                datetime: $this->createDatetime()
+            );
+        }
+        
+        return $flowId;
+    }
+
+    /**
+     * End the current flow.
+     * 
+     * @param string|null $result Optional result/summary of the flow
+     */
+    public function endFlow(?string $result = null): void
+    {
+        if ($this->currentFlowId === null) {
+            return;
+        }
+        
+        $endingFlowId = $this->currentFlowId;
+        
+        if ($this->enabled) {
+            $this->events[] = new LineageEvent(
+                type: LineageEvent::TYPE_FLOW_END,
+                objectClass: '',
+                propertyName: null,
+                source: null,
+                originalValue: null,
+                finalValue: null,
+                reason: $result,
+                metadata: [],
+                timestamp: microtime(true) - $this->startTime,
+                depth: $this->currentDepth,
+                flowId: $endingFlowId,
+                datetime: $this->createDatetime()
+            );
+        }
+        
+        // Restore parent flow if any
+        $this->currentFlowId = array_pop($this->flowStack);
+    }
+
+    /**
+     * Get the current flow ID.
+     */
+    public function getCurrentFlowId(): ?string
+    {
+        return $this->currentFlowId;
+    }
+
+    /**
+     * Create the current datetime for events.
+     */
+    private function createDatetime(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable();
+    }
+
+    /**
      * Record a DataSource call.
+     * 
+     * @param array<string, SensitiveLevel> $sensitiveKeys Keys to mask in the result (exact name or regex pattern)
      */
     public function recordDataSourceCall(
         string $objectClass,
@@ -108,11 +222,15 @@ final class DataLineageCollector
         string $sourceMethod,
         array $args,
         mixed $result,
-        ?string $sourceId = null
+        ?string $sourceId = null,
+        array $sensitiveKeys = []
     ): void {
         if (!$this->enabled) {
             return;
         }
+
+        // Apply sensitive masking to result
+        $maskedResult = $this->applySensitiveKeysToResult($result, $sensitiveKeys);
 
         $this->events[] = new LineageEvent(
             type: LineageEvent::TYPE_DATASOURCE_CALL,
@@ -120,14 +238,17 @@ final class DataLineageCollector
             propertyName: null,
             source: sprintf('%s::%s', $sourceClass, $sourceMethod),
             originalValue: $args,
-            finalValue: $result,
+            finalValue: $maskedResult,
             reason: null,
             metadata: [
                 'sourceId' => $sourceId,
                 'argsCount' => count($args),
+                'hasSensitiveKeys' => !empty($sensitiveKeys),
             ],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -140,11 +261,15 @@ final class DataLineageCollector
         mixed $originalValue,
         mixed $finalValue,
         string $source,
-        int $priority = 0
+        int $priority = 0,
+        ?SensitiveLevel $sensitiveLevel = null
     ): void {
         if (!$this->enabled) {
             return;
         }
+
+        // Resolve the sensitive level for this property
+        $resolvedLevel = $this->getSensitiveLevelForProperty($propertyName, $sensitiveLevel);
 
         $this->events[] = new LineageEvent(
             type: LineageEvent::TYPE_PROPERTY_HYDRATION,
@@ -158,7 +283,10 @@ final class DataLineageCollector
                 'priority' => $priority,
             ],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            sensitiveLevel: $resolvedLevel,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -185,7 +313,9 @@ final class DataLineageCollector
             reason: $reason,
             metadata: $metadata,
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -198,11 +328,15 @@ final class DataLineageCollector
         mixed $originalValue,
         mixed $transformedValue,
         string $transformer,
-        string $transformerType = 'hook'
+        string $transformerType = 'hook',
+        ?SensitiveLevel $sensitiveLevel = null
     ): void {
         if (!$this->enabled) {
             return;
         }
+
+        // Resolve the sensitive level for this property
+        $resolvedLevel = $this->getSensitiveLevelForProperty($propertyName, $sensitiveLevel);
 
         $this->events[] = new LineageEvent(
             type: LineageEvent::TYPE_PROPERTY_TRANSFORMED,
@@ -216,7 +350,10 @@ final class DataLineageCollector
                 'transformerType' => $transformerType,
             ],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            sensitiveLevel: $resolvedLevel,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -246,7 +383,9 @@ final class DataLineageCollector
                 'hookType' => $hookType,
             ],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -273,7 +412,9 @@ final class DataLineageCollector
             reason: null,
             metadata: [],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -284,11 +425,15 @@ final class DataLineageCollector
         string $objectClass,
         string $propertyName,
         string $key,
-        mixed $value
+        mixed $value,
+        ?SensitiveLevel $sensitiveLevel = null
     ): void {
         if (!$this->enabled) {
             return;
         }
+
+        // Resolve the sensitive level for this property
+        $resolvedLevel = $this->getSensitiveLevelForProperty($propertyName, $sensitiveLevel);
 
         $this->events[] = new LineageEvent(
             type: LineageEvent::TYPE_CONTEXT_SET,
@@ -302,7 +447,10 @@ final class DataLineageCollector
                 'contextKey' => $key,
             ],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            sensitiveLevel: $resolvedLevel,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -330,7 +478,9 @@ final class DataLineageCollector
             reason: $reason,
             metadata: array_merge(['decisionType' => $decisionType], $metadata),
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -371,7 +521,9 @@ final class DataLineageCollector
                 'electedCandidatePriority' => $electedCandidate['priority'] ?? null,
             ],
             timestamp: microtime(true) - $this->startTime,
-            depth: $this->currentDepth
+            depth: $this->currentDepth,
+            flowId: $this->currentFlowId,
+            datetime: $this->createDatetime()
         );
     }
 
@@ -449,6 +601,176 @@ final class DataLineageCollector
                 ? $this->events[count($this->events) - 1]->timestamp 
                 : 0,
         ];
+    }
+
+    /**
+     * Get the sensitive level for a property.
+     * 
+     * @param string $propertyName The property name (can include class prefix like 'User.password')
+     * @param SensitiveLevel|null $attributeLevel The level specified in the Property/PropertyConfig attribute
+     * @return SensitiveLevel The resolved sensitive level
+     */
+    public function getSensitiveLevelForProperty(string $propertyName, ?SensitiveLevel $attributeLevel = null): SensitiveLevel
+    {
+        // Attribute-level configuration takes highest precedence
+        if ($attributeLevel !== null) {
+            return $attributeLevel;
+        }
+
+        // Check for exact match in global sensitive keys
+        if (isset($this->sensitiveKeys[$propertyName])) {
+            return $this->sensitiveKeys[$propertyName];
+        }
+
+        // Check for pattern matches (e.g., '*password*')
+        foreach ($this->sensitiveKeys as $pattern => $level) {
+            if ($this->matchesPattern($propertyName, $pattern)) {
+                return $level;
+            }
+        }
+
+        return $this->defaultSensitiveLevel;
+    }
+
+    /**
+     * Apply sensitive level to a value.
+     * 
+     * @param mixed $value The value to process
+     * @param string $propertyName The property name
+     * @param SensitiveLevel|null $attributeLevel The level specified in the attribute
+     * @return mixed The processed value
+     */
+    public function applySensitiveLevel(mixed $value, string $propertyName, ?SensitiveLevel $attributeLevel = null): mixed
+    {
+        $level = $this->getSensitiveLevelForProperty($propertyName, $attributeLevel);
+        return $level->apply($value);
+    }
+
+    /**
+     * Check if a property name matches a pattern.
+     * 
+     * Supports patterns like:
+     * - 'password' - exact match
+     * - '*password*' - contains 'password'
+     * - 'password*' - starts with 'password'
+     * - '*password' - ends with 'password'
+     * - 'User.*' - all properties of User class
+     * 
+     * @param string $propertyName The property name to check
+     * @param string $pattern The pattern to match against
+     * @return bool True if the property matches the pattern
+     */
+    private function matchesPattern(string $propertyName, string $pattern): bool
+    {
+        // Convert pattern to regex
+        $regex = '/^' . str_replace(
+            ['\\*', '\\?'],
+            ['.*', '.'],
+            preg_quote($pattern, '/')
+        ) . '$/i';
+
+        return preg_match($regex, $propertyName) === 1;
+    }
+
+    /**
+     * Add a sensitive key at runtime.
+     * 
+     * @param string $key The property name or pattern
+     * @param SensitiveLevel $level The sensitive level
+     */
+    public function addSensitiveKey(string $key, SensitiveLevel $level): void
+    {
+        $this->sensitiveKeys[$key] = $level;
+    }
+
+    /**
+     * Remove a sensitive key at runtime.
+     * 
+     * @param string $key The property name or pattern to remove
+     */
+    public function removeSensitiveKey(string $key): void
+    {
+        unset($this->sensitiveKeys[$key]);
+    }
+
+    /**
+     * Get all configured sensitive keys.
+     * 
+     * @return array<string, SensitiveLevel>
+     */
+    public function getSensitiveKeys(): array
+    {
+        return $this->sensitiveKeys;
+    }
+
+    /**
+     * Get the default sensitive level.
+     * 
+     * @return SensitiveLevel
+     */
+    public function getDefaultSensitiveLevel(): SensitiveLevel
+    {
+        return $this->defaultSensitiveLevel;
+    }
+
+    /**
+     * Set the default sensitive level.
+     * 
+     * @param SensitiveLevel $level
+     */
+    public function setDefaultSensitiveLevel(SensitiveLevel $level): void
+    {
+        $this->defaultSensitiveLevel = $level;
+    }
+
+    /**
+     * Apply sensitive keys masking to a DataSource result.
+     * 
+     * @param mixed $result The result from the DataSource call
+     * @param array<string, SensitiveLevel> $sensitiveKeys Keys to mask (exact name or pattern)
+     * @return mixed The result with sensitive keys masked
+     */
+    private function applySensitiveKeysToResult(mixed $result, array $sensitiveKeys): mixed
+    {
+        if (empty($sensitiveKeys)) {
+            return $result;
+        }
+
+        if (!is_array($result)) {
+            return $result;
+        }
+
+        $masked = [];
+        foreach ($result as $key => $value) {
+            $level = $this->getSensitiveLevelForKey((string) $key, $sensitiveKeys);
+            $masked[$key] = $level->apply($value);
+        }
+
+        return $masked;
+    }
+
+    /**
+     * Get the sensitive level for a specific key in a DataSource result.
+     * 
+     * @param string $key The key name
+     * @param array<string, SensitiveLevel> $sensitiveKeys The sensitive keys configuration
+     * @return SensitiveLevel The resolved sensitive level
+     */
+    private function getSensitiveLevelForKey(string $key, array $sensitiveKeys): SensitiveLevel
+    {
+        // Check for exact match
+        if (isset($sensitiveKeys[$key])) {
+            return $sensitiveKeys[$key];
+        }
+
+        // Check for pattern matches
+        foreach ($sensitiveKeys as $pattern => $level) {
+            if ($this->matchesPattern($key, $pattern)) {
+                return $level;
+            }
+        }
+
+        return SensitiveLevel::SHOW;
     }
 
     /**

--- a/src/DataCollector/LineageEvent.php
+++ b/src/DataCollector/LineageEvent.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper\DataCollector;
 
+use Kassko\DataMapper\Enum\SensitiveLevel;
+
 /**
  * Represents a single event in the data lineage.
  */
@@ -27,6 +29,8 @@ final class LineageEvent
     public const TYPE_CONTEXT_SET = 'context_set';
     public const TYPE_DECISION_POINT = 'decision_point';
     public const TYPE_CANDIDATE_RESOLUTION = 'candidate_resolution';
+    public const TYPE_FLOW_START = 'flow_start';
+    public const TYPE_FLOW_END = 'flow_end';
 
     public function __construct(
         public readonly string $type,
@@ -38,27 +42,53 @@ final class LineageEvent
         public readonly ?string $reason,
         public readonly array $metadata,
         public readonly float $timestamp,
-        public readonly int $depth
+        public readonly int $depth,
+        public readonly ?string $flowId = null,
+        public readonly ?SensitiveLevel $sensitiveLevel = null,
+        public readonly ?\DateTimeImmutable $datetime = null
     ) {}
 
-    public function toArray(): array
+    /**
+     * Convert the event to an array, optionally applying sensitive level.
+     * 
+     * @param SensitiveLevel|null $overrideSensitiveLevel Override the event's sensitive level
+     * @return array
+     */
+    public function toArray(?SensitiveLevel $overrideSensitiveLevel = null): array
     {
+        $level = $overrideSensitiveLevel ?? $this->sensitiveLevel;
+        
         return [
             'type' => $this->type,
             'objectClass' => $this->objectClass,
             'propertyName' => $this->propertyName,
             'source' => $this->source,
-            'originalValue' => $this->serializeValue($this->originalValue),
-            'finalValue' => $this->serializeValue($this->finalValue),
+            'originalValue' => $this->serializeValue($this->originalValue, $level),
+            'finalValue' => $this->serializeValue($this->finalValue, $level),
             'reason' => $this->reason,
             'metadata' => $this->metadata,
             'timestamp' => $this->timestamp,
+            'datetime' => $this->datetime?->format(\DateTimeInterface::ATOM),
             'depth' => $this->depth,
+            'flowId' => $this->flowId,
+            'sensitiveLevel' => $level?->value,
         ];
     }
 
-    private function serializeValue(mixed $value): mixed
+    /**
+     * Serialize a value for output, optionally applying sensitive level.
+     * 
+     * @param mixed $value The value to serialize
+     * @param SensitiveLevel|null $sensitiveLevel The sensitive level to apply
+     * @return mixed
+     */
+    private function serializeValue(mixed $value, ?SensitiveLevel $sensitiveLevel = null): mixed
     {
+        // Apply sensitive level first if specified
+        if ($sensitiveLevel !== null && $sensitiveLevel !== SensitiveLevel::SHOW) {
+            return $sensitiveLevel->apply($value);
+        }
+        
         if (is_object($value)) {
             return sprintf('[object %s]', get_class($value));
         }
@@ -66,7 +96,7 @@ final class LineageEvent
             if (count($value) > 10) {
                 return sprintf('[array with %d items]', count($value));
             }
-            return array_map(fn($v) => $this->serializeValue($v), $value);
+            return array_map(fn($v) => $this->serializeValue($v, $sensitiveLevel), $value);
         }
         return $value;
     }

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper;
 
 use Kassko\DataMapper\DataCollector\DataLineageCollector;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 use Kassko\DataMapper\Loader\Loader;
 use Kassko\DataMapper\Registry\ContextRegistry;
 use Kassko\DataMapper\Registry\LoaderRegistry;
@@ -34,17 +35,21 @@ final class DataMapper
      * @param CacheInterface|null $cache PSR-16 cache interface
      * @param LoggerInterface|null $logger PSR-3 logger interface
      * @param array<string, callable> $customHydrators Custom hydrators (key => callable)
+     * @param array<string, SensitiveLevel> $sensitiveKeys Global sensitive keys configuration
+     * @param SensitiveLevel $defaultSensitiveLevel Default sensitive level for all properties
      */
     public function __construct(
         ServiceResolver $serviceResolver,
         ?CacheInterface $cache = null,
         ?LoggerInterface $logger = null,
-        array $customHydrators = []
+        array $customHydrators = [],
+        array $sensitiveKeys = [],
+        SensitiveLevel $defaultSensitiveLevel = SensitiveLevel::SHOW
     ) {
         $this->cache = $cache;
         $this->logger = $logger;
         $this->serviceResolver = $serviceResolver;
-        $this->lineageCollector = new DataLineageCollector();
+        $this->lineageCollector = new DataLineageCollector($sensitiveKeys, $defaultSensitiveLevel);
         
         // Register Loader in the registry
         $this->loader = new Loader($this->serviceResolver, $this->logger, $customHydrators, $this->lineageCollector);

--- a/src/DataMapperBuilder.php
+++ b/src/DataMapperBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Kassko\DataMapper;
 
 use Kassko\DataMapper\DataCollector\DataLineageCollector;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 use Kassko\DataMapper\Loader\Loader;
 use Kassko\DataMapper\Registry\LoaderRegistry;
 use Psr\Container\ContainerInterface;
@@ -40,6 +41,12 @@ final class DataMapperBuilder
     
     /** @var array<string, callable> */
     private array $customHydrators = [];
+
+    /** @var array<string, SensitiveLevel> Global sensitive keys configuration */
+    private array $sensitiveKeys = [];
+
+    /** @var SensitiveLevel Default sensitive level for all properties */
+    private SensitiveLevel $defaultSensitiveLevel = SensitiveLevel::SHOW;
 
     public function setContainer(ContainerInterface $container): self
     {
@@ -123,6 +130,79 @@ final class DataMapperBuilder
         return $this;
     }
 
+    /**
+     * Set the default sensitive level for all properties.
+     * This is used when no specific level is set for a property.
+     *
+     * @param SensitiveLevel $level The default sensitive level
+     * @return self
+     */
+    public function setDefaultSensitiveLevel(SensitiveLevel $level): self
+    {
+        $this->defaultSensitiveLevel = $level;
+        return $this;
+    }
+
+    /**
+     * Set all sensitive keys at once.
+     * Replaces any existing sensitive keys configuration.
+     *
+     * @param array<string, SensitiveLevel> $sensitiveKeys Map of property names to their sensitive levels
+     * @return self
+     */
+    public function setSensitiveKeys(array $sensitiveKeys): self
+    {
+        $this->sensitiveKeys = $sensitiveKeys;
+        return $this;
+    }
+
+    /**
+     * Add a sensitive key with its level.
+     *
+     * @param string $key The property name (can be a pattern like 'password', '*password*', 'user.ssn')
+     * @param SensitiveLevel $level The sensitive level for this key
+     * @return self
+     */
+    public function addSensitiveKey(string $key, SensitiveLevel $level): self
+    {
+        $this->sensitiveKeys[$key] = $level;
+        return $this;
+    }
+
+    /**
+     * Remove one or more sensitive keys.
+     *
+     * @param string ...$keys The property names to remove from sensitive configuration
+     * @return self
+     */
+    public function removeSensitiveKeys(string ...$keys): self
+    {
+        foreach ($keys as $key) {
+            unset($this->sensitiveKeys[$key]);
+        }
+        return $this;
+    }
+
+    /**
+     * Get the configured sensitive keys.
+     *
+     * @return array<string, SensitiveLevel>
+     */
+    public function getSensitiveKeys(): array
+    {
+        return $this->sensitiveKeys;
+    }
+
+    /**
+     * Get the default sensitive level.
+     *
+     * @return SensitiveLevel
+     */
+    public function getDefaultSensitiveLevel(): SensitiveLevel
+    {
+        return $this->defaultSensitiveLevel;
+    }
+
     public function build(): DataMapper
     {
         $serviceResolver = new ServiceResolver(
@@ -134,6 +214,13 @@ final class DataMapperBuilder
         );
         
         // Create the DataMapper which will create and register the Loader
-        return new DataMapper($serviceResolver, $this->cache, $this->logger, $this->customHydrators);
+        return new DataMapper(
+            $serviceResolver,
+            $this->cache,
+            $this->logger,
+            $this->customHydrators,
+            $this->sensitiveKeys,
+            $this->defaultSensitiveLevel
+        );
     }
 }

--- a/src/Enum/SensitiveLevel.php
+++ b/src/Enum/SensitiveLevel.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DataMapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\DataMapper\Enum;
+
+/**
+ * Enum for sensitive data handling levels.
+ * 
+ * Controls how sensitive data is displayed in lineage collection and debugging output.
+ */
+enum SensitiveLevel: string
+{
+    /**
+     * Show the full value (no masking).
+     * Use with caution - only for non-sensitive data or secured environments.
+     */
+    case SHOW = 'show';
+
+    /**
+     * Completely hide the value, showing only "[SENSITIVE]".
+     * Recommended for passwords, tokens, secrets.
+     */
+    case HIDE = 'hide';
+
+    /**
+     * Mask the value, showing only first/last characters.
+     * Example: "secretpassword" becomes "se**********rd"
+     * Good balance between debugging and security.
+     */
+    case MASK = 'mask';
+
+    /**
+     * Show only the type and length of the value.
+     * Example: "[string(14)]" for "secretpassword"
+     */
+    case TYPE_ONLY = 'type_only';
+
+    /**
+     * Apply masking to the value based on the level.
+     */
+    public function apply(mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return match ($this) {
+            self::SHOW => $value,
+            self::HIDE => '[SENSITIVE]',
+            self::MASK => $this->maskValue($value),
+            self::TYPE_ONLY => $this->formatTypeOnly($value),
+        };
+    }
+
+    private function maskValue(mixed $value): string
+    {
+        if (is_string($value)) {
+            $length = strlen($value);
+            if ($length <= 4) {
+                return str_repeat('*', $length);
+            }
+            return substr($value, 0, 2) . str_repeat('*', $length - 4) . substr($value, -2);
+        }
+        
+        if (is_numeric($value)) {
+            $str = (string) $value;
+            $length = strlen($str);
+            if ($length <= 4) {
+                return str_repeat('*', $length);
+            }
+            return substr($str, 0, 2) . str_repeat('*', $length - 4) . substr($str, -2);
+        }
+        
+        if (is_array($value)) {
+            return sprintf('[array(%d items) - MASKED]', count($value));
+        }
+        
+        if (is_object($value)) {
+            return sprintf('[object %s - MASKED]', get_class($value));
+        }
+        
+        return '[MASKED]';
+    }
+
+    private function formatTypeOnly(mixed $value): string
+    {
+        $type = gettype($value);
+        
+        if (is_string($value)) {
+            return sprintf('[string(%d)]', strlen($value));
+        }
+        
+        if (is_array($value)) {
+            return sprintf('[array(%d)]', count($value));
+        }
+        
+        if (is_object($value)) {
+            return sprintf('[object %s]', get_class($value));
+        }
+        
+        return sprintf('[%s]', $type);
+    }
+}

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -620,7 +620,7 @@ class Loader implements LoaderInterface
     private function loadPropertyWithFallbacks(object $object, string $propertyName, ReflectionProperty $property, $dataSourceRef): void
     {
         $dataSourceMap = $this->attributeReader->getDataSourceMap($object);
-        $exceptionClass = $dataSourceRef->exceptionOnNoValidDataSource;
+        $exceptionClass = $dataSourceRef->exceptionOnNoValidFallback;
         
         // Build the chain: start with primary id, then add fallbacks if any
         $sourceChain = [$dataSourceRef->id];
@@ -785,7 +785,8 @@ class Loader implements LoaderInterface
             $dataSource->method,
             $dataSource->args,
             $result,
-            $sourceId
+            $sourceId,
+            $dataSource->sensitiveKeys
         );
         
         // Hydrate the property
@@ -834,14 +835,35 @@ class Loader implements LoaderInterface
         
         $dataSourceMap = $this->attributeReader->getDataSourceMap($object);
         $aggregatedResult = [];
-        
+        $ignoreNotFound = $dataSourceRef->ignoreProviderOnNotFound;
+
         foreach ($dataSourceRef->providers as $sourceId) {
             if (!isset($dataSourceMap[$sourceId])) {
+                if ($ignoreNotFound) {
+                    $this->logger->info(
+                        'Skipping unknown provider (ignoreProviderOnNotFound is enabled)',
+                        ['property' => $propertyName, 'provider' => $sourceId]
+                    );
+                    continue;
+                }
+                // Default behavior: skip silently (existing behavior)
                 continue;
             }
             
             $dataSource = $dataSourceMap[$sourceId];
-            $result = $this->executeDataSource($dataSource, $object);
+            
+            try {
+                $result = $this->executeDataSource($dataSource, $object);
+            } catch (\Throwable $e) {
+                if ($ignoreNotFound) {
+                    $this->logger->info(
+                        'Skipping failed provider (ignoreProviderOnNotFound is enabled)',
+                        ['property' => $propertyName, 'provider' => $sourceId, 'error' => $e->getMessage()]
+                    );
+                    continue;
+                }
+                throw $e;
+            }
             
             // Only aggregate arrays
             if (is_array($result)) {
@@ -904,7 +926,8 @@ class Loader implements LoaderInterface
             $source->method,
             $source->args,
             $data,
-            $source->id ?? null
+            $source->id ?? null,
+            $source->sensitiveKeys
         );
         
         // Apply recursive hydration if needed (handles PropertyCandidates, nested objects, etc.)
@@ -968,7 +991,8 @@ class Loader implements LoaderInterface
             $source->method,
             $source->args,
             $data,
-            $source->id ?? null
+            $source->id ?? null,
+            $source->sensitiveKeys
         );
         
         if (!is_array($data)) {
@@ -1560,6 +1584,9 @@ class Loader implements LoaderInterface
     /**
      * Merge a PropertyConfig into a new Property-like object
      *
+     * Property attribute values take precedence over PropertyConfig values.
+     * This allows Property to override specific PropertyConfig settings.
+     *
      * @param Property $propertyAttr Original Property attribute
      * @param PropertyConfig $config PropertyConfig to merge
      * @return Property
@@ -1567,11 +1594,12 @@ class Loader implements LoaderInterface
     private function mergePropertyConfig(Property $propertyAttr, PropertyConfig $config): Property
     {
         return new Property(
-            name: $config->name ?? $propertyAttr->name,
-            class: $config->class ?? $propertyAttr->class,
-            expand: $config->expand ?? $propertyAttr->expand,
-            noExpand: $config->noExpand ?? $propertyAttr->noExpand,
-            mapping: $config->mapping ?? $propertyAttr->mapping,
+            // Property.name takes precedence over PropertyConfig.name
+            name: $propertyAttr->name ?? $config->name,
+            class: $propertyAttr->class ?? $config->class,
+            expand: $propertyAttr->expand ?? $config->expand,
+            noExpand: $propertyAttr->noExpand ?? $config->noExpand,
+            mapping: $propertyAttr->mapping ?? $config->mapping,
         );
     }
 
@@ -1970,9 +1998,6 @@ class Loader implements LoaderInterface
         
         if ($this->attributeReader->readProperty($property) !== null) {
             $conflictingAttributes[] = 'Property';
-        }
-        if ($this->attributeReader->readPropertyCandidates($property) !== null) {
-            $conflictingAttributes[] = 'PropertyCandidates';
         }
         if ($this->attributeReader->readDataSource($property) !== null) {
             $conflictingAttributes[] = 'DataSource';

--- a/src/Validation/MetadataValidator.php
+++ b/src/Validation/MetadataValidator.php
@@ -190,11 +190,11 @@ class MetadataValidator
         }
 
         // Validate exception class if specified
-        if ($ref->exceptionOnNoValidDataSource !== null) {
-            if (!class_exists($ref->exceptionOnNoValidDataSource)) {
-                $this->errors[] = "{$context}: Exception class '{$ref->exceptionOnNoValidDataSource}' does not exist.";
-            } elseif (!is_subclass_of($ref->exceptionOnNoValidDataSource, \Throwable::class)) {
-                $this->errors[] = "{$context}: Exception class '{$ref->exceptionOnNoValidDataSource}' must implement Throwable.";
+        if ($ref->exceptionOnNoValidFallback !== null) {
+            if (!class_exists($ref->exceptionOnNoValidFallback)) {
+                $this->errors[] = "{$context}: Exception class '{$ref->exceptionOnNoValidFallback}' does not exist.";
+            } elseif (!is_subclass_of($ref->exceptionOnNoValidFallback, \Throwable::class)) {
+                $this->errors[] = "{$context}: Exception class '{$ref->exceptionOnNoValidFallback}' must implement Throwable.";
             }
         }
     }

--- a/tests/Fixtures/Address.php
+++ b/tests/Fixtures/Address.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\Sample;
+
+/**
+ * Simple Address fixture for testing CustomHydrator.
+ */
+class Address
+{
+    public function __construct(
+        public readonly string $street,
+        public readonly string $city,
+        public readonly string $zipCode,
+        public readonly string $country = 'France'
+    ) {}
+
+    public function __toString(): string
+    {
+        return sprintf('%s, %s %s, %s', $this->street, $this->zipCode, $this->city, $this->country);
+    }
+}

--- a/tests/Fixtures/PersonCustomHydrator.php
+++ b/tests/Fixtures/PersonCustomHydrator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\Sample;
+
+use Kassko\DataMapper\Attribute\CustomHydrator;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+/**
+ * Fixture for testing CustomHydrator functionality.
+ */
+class PersonCustomHydrator
+{
+    use LoadableTrait;
+
+    private int $id;
+
+    #[CustomHydrator(key: 'address_hydrator', objectClass: Address::class)]
+    private ?Address $address = null;
+
+    #[CustomHydrator(key: 'phone_hydrator')]
+    private ?string $phone = null;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getAddress(): ?Address
+    {
+        $this->loadProperty('address');
+        return $this->address;
+    }
+
+    public function getPhone(): ?string
+    {
+        $this->loadProperty('phone');
+        return $this->phone;
+    }
+}

--- a/tests/Fixtures/PropertyNameDataSource.php
+++ b/tests/Fixtures/PropertyNameDataSource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\Sample;
+
+/**
+ * DataSource for PropertyNamePrecedence tests.
+ * 
+ * Returns data with both 'property_value' and 'config_value' keys.
+ * The test verifies which key is used based on Property vs PropertyConfig precedence.
+ */
+class PropertyNameDataSource
+{
+    public function getItems(int $id): array
+    {
+        return match($id) {
+            1 => [
+                ['property_value' => 'Value from property', 'config_value' => 'Value from config'],
+                ['property_value' => 'Value 2 from property', 'config_value' => 'Value 2 from config'],
+            ],
+            default => [],
+        };
+    }
+
+    public function getSingleItem(int $id): array
+    {
+        return match($id) {
+            1 => ['property_value' => 'Single value from property', 'config_value' => 'Single value from config'],
+            default => [],
+        };
+    }
+}

--- a/tests/Fixtures/PropertyNameItem.php
+++ b/tests/Fixtures/PropertyNameItem.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\Sample;
+
+use Kassko\DataMapper\Attribute\Property;
+
+/**
+ * Simple item fixture for PropertyNamePrecedence tests.
+ * 
+ * This class has a 'value' property. The Property.name or PropertyConfig.name
+ * on the parent controls which raw data key maps to 'value'.
+ */
+class PropertyNameItem
+{
+    /**
+     * The Property.name on the parent attribute controls which raw data key maps to this property.
+     * - If parent has Property(name: 'property_value'), raw data['property_value'] maps here
+     * - If parent has PropertyConfig(name: 'config_value') and no Property.name, raw data['config_value'] maps here
+     */
+    #[Property(name: 'property_value')]
+    private ?string $value = null;
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    public function setValue(?string $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/Fixtures/PropertyNamePrecedence.php
+++ b/tests/Fixtures/PropertyNamePrecedence.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\Sample;
+
+use Kassko\DataMapper\Attribute\SinglePropDataSource;
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\Attribute\PropertyConfig;
+use Kassko\DataMapper\Attribute\PropertyConfigStore;
+use Kassko\DataMapper\ObjectExtension\LoadableTrait;
+
+/**
+ * Fixture for testing that Property.name takes precedence over PropertyConfig.name
+ * 
+ * The 'name' field controls how the CHILD object's properties are mapped from raw data.
+ */
+#[PropertyConfigStore([
+    // PropertyConfig.name is 'config_value' - would map child's 'value' prop from 'config_value' in raw data
+    new PropertyConfig(id: 'itemConfig', class: PropertyNameItem::class, name: 'config_value'),
+])]
+class PropertyNamePrecedence
+{
+    use LoadableTrait;
+
+    private ?int $id = null;
+
+    /**
+     * Property.name 'property_value' takes precedence over PropertyConfig.name 'config_value'
+     * The child object's 'value' property will be mapped from 'property_value' in raw data.
+     */
+    #[SinglePropDataSource(class: PropertyNameDataSource::class, method: 'getItems', args: ['#id'])]
+    #[Property(config: 'itemConfig', name: 'property_value')]
+    private array $items = [];
+
+    /**
+     * When Property.name is not set, PropertyConfig.name 'config_value' should be used.
+     * The child object's 'value' property will be mapped from 'config_value' in raw data.
+     */
+    #[SinglePropDataSource(class: PropertyNameDataSource::class, method: 'getSingleItem', args: ['#id'])]
+    #[Property(config: 'itemConfig')]
+    private ?PropertyNameItem $singleItem = null;
+
+    public function __construct(?int $id = null)
+    {
+        $this->id = $id;
+    }
+
+    public function getItems(): array
+    {
+        $this->loadProperty('items');
+        return $this->items;
+    }
+
+    public function getSingleItem(): ?PropertyNameItem
+    {
+        $this->loadProperty('singleItem');
+        return $this->singleItem;
+    }
+}

--- a/tests/Integration/CustomHydratorTest.php
+++ b/tests/Integration/CustomHydratorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\Registry\LoaderRegistry;
+use Kassko\Sample\PersonCustomHydrator;
+use Kassko\Sample\Address;
+use PHPUnit\Framework\TestCase;
+
+class CustomHydratorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        LoaderRegistry::clear();
+    }
+
+    public function testCustomHydratorWithObjectClass(): void
+    {
+        $dataMapper = (new DataMapperBuilder())
+            ->addCustomHydrator('address_hydrator', function (array $data): Address {
+                return new Address(
+                    street: '123 Main Street',
+                    city: 'Paris',
+                    zipCode: '75001'
+                );
+            })
+            ->addCustomHydrator('phone_hydrator', function (array $data): string {
+                return '+33 1 23 45 67 89';
+            })
+            ->build();
+
+        $person = new PersonCustomHydrator(1);
+
+        $address = $person->getAddress();
+        
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('123 Main Street', $address->street);
+        $this->assertEquals('Paris', $address->city);
+        $this->assertEquals('75001', $address->zipCode);
+        $this->assertEquals('France', $address->country);
+    }
+
+    public function testCustomHydratorWithSimpleType(): void
+    {
+        $dataMapper = (new DataMapperBuilder())
+            ->addCustomHydrator('address_hydrator', function (array $data): Address {
+                return new Address(
+                    street: '123 Main Street',
+                    city: 'Paris',
+                    zipCode: '75001'
+                );
+            })
+            ->addCustomHydrator('phone_hydrator', function (array $data): string {
+                return '+33 1 23 45 67 89';
+            })
+            ->build();
+
+        $person = new PersonCustomHydrator(1);
+
+        $phone = $person->getPhone();
+        
+        $this->assertEquals('+33 1 23 45 67 89', $phone);
+    }
+
+    public function testCustomHydratorNotRegisteredThrowsException(): void
+    {
+        $dataMapper = (new DataMapperBuilder())
+            // Only register phone_hydrator, not address_hydrator
+            ->addCustomHydrator('phone_hydrator', function (array $data): string {
+                return '+33 1 23 45 67 89';
+            })
+            ->build();
+
+        $person = new PersonCustomHydrator(1);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Custom hydrator with key "address_hydrator" not found');
+        
+        $person->getAddress();
+    }
+
+    public function testCustomHydratorWrongObjectClassThrowsException(): void
+    {
+        $dataMapper = (new DataMapperBuilder())
+            ->addCustomHydrator('address_hydrator', function (array $data): object {
+                // Return wrong type - should throw because PersonCustomHydrator expects Address::class
+                return new \stdClass();
+            })
+            ->addCustomHydrator('phone_hydrator', function (array $data): string {
+                return '+33 1 23 45 67 89';
+            })
+            ->build();
+
+        $person = new PersonCustomHydrator(1);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Custom hydrator "address_hydrator" returned object of type stdClass, but expected Kassko\\Sample\\Address');
+        
+        $person->getAddress();
+    }
+
+    public function testCustomHydratorCanReturnNull(): void
+    {
+        $dataMapper = (new DataMapperBuilder())
+            ->addCustomHydrator('address_hydrator', function (array $data): ?Address {
+                return null; // Null is always valid regardless of objectClass
+            })
+            ->addCustomHydrator('phone_hydrator', function (array $data): ?string {
+                return null;
+            })
+            ->build();
+
+        $person = new PersonCustomHydrator(1);
+
+        $address = $person->getAddress();
+        
+        $this->assertNull($address);
+    }
+
+    public function testCustomHydratorWithMultipleInstances(): void
+    {
+        $callCount = 0;
+        
+        $dataMapper = (new DataMapperBuilder())
+            ->addCustomHydrator('address_hydrator', function (array $data) use (&$callCount): Address {
+                $callCount++;
+                return new Address(
+                    street: 'Street ' . $callCount,
+                    city: 'City ' . $callCount,
+                    zipCode: '7500' . $callCount
+                );
+            })
+            ->addCustomHydrator('phone_hydrator', function (array $data): string {
+                return '+33 1 23 45 67 89';
+            })
+            ->build();
+
+        $person1 = new PersonCustomHydrator(1);
+        $person2 = new PersonCustomHydrator(2);
+
+        // Each person should get their own address
+        $address1 = $person1->getAddress();
+        $address2 = $person2->getAddress();
+        
+        $this->assertEquals('Street 1', $address1->street);
+        $this->assertEquals('Street 2', $address2->street);
+        $this->assertEquals(2, $callCount);
+    }
+
+    public function testCustomHydratorPropertyLoadedOnlyOnce(): void
+    {
+        $callCount = 0;
+        
+        $dataMapper = (new DataMapperBuilder())
+            ->addCustomHydrator('address_hydrator', function (array $data) use (&$callCount): Address {
+                $callCount++;
+                return new Address(
+                    street: '123 Main Street',
+                    city: 'Paris',
+                    zipCode: '75001'
+                );
+            })
+            ->addCustomHydrator('phone_hydrator', function (array $data): string {
+                return '+33 1 23 45 67 89';
+            })
+            ->build();
+
+        $person = new PersonCustomHydrator(1);
+
+        // Call getAddress multiple times
+        $address1 = $person->getAddress();
+        $address2 = $person->getAddress();
+        $address3 = $person->getAddress();
+        
+        // Hydrator should only be called once
+        $this->assertEquals(1, $callCount);
+        $this->assertSame($address1, $address2);
+        $this->assertSame($address2, $address3);
+    }
+}

--- a/tests/Integration/DataSourceAggregationTest.php
+++ b/tests/Integration/DataSourceAggregationTest.php
@@ -106,4 +106,33 @@ class DataSourceAggregationTest extends TestCase
         $this->assertEquals(5432, $config['db']['port']); // providerB overwrites
         $this->assertEquals('admin', $config['db']['user']); // Added by providerB
     }
+
+    public function testIgnoreProviderOnNotFoundSkipsMissingProviders(): void
+    {
+        new DataMapper(new \Kassko\DataMapper\ServiceResolver());
+        
+        // One provider exists, one doesn't, but ignoreProviderOnNotFound is true
+        $object = new #[DataSourcesStore([
+            new SinglePropDataSource(id: 'providerA', class: AggregationDataSource::class, method: 'providerA'),
+            // 'providerX' is NOT defined in the store
+        ])] class {
+            use LoadableTrait;
+            
+            #[DataSourceRef(
+                providers: ['providerA', 'providerX'], 
+                ignoreProviderOnNotFound: true
+            )]
+            #[Property(name: 'name')]
+            private ?string $name = null;
+            
+            public function getName(): ?string
+            {
+                $this->loadProperty('name');
+                return $this->name;
+            }
+        };
+        
+        // Should work despite missing providerX
+        $this->assertEquals('Alice', $object->getName());
+    }
 }

--- a/tests/Integration/DataSourceChainTest.php
+++ b/tests/Integration/DataSourceChainTest.php
@@ -46,7 +46,7 @@ class DataSourceChainTest extends TestCase
         ])] class {
             use LoadableTrait;
             
-            #[DataSourceRef(id: 'sourceA', fallbacks: ['sourceB'], exceptionOnNoValidDataSource: UnsuitableSourceException::class)]
+            #[DataSourceRef(id: 'sourceA', fallbacks: ['sourceB'], exceptionOnNoValidFallback: UnsuitableSourceException::class)]
             private ?string $data = null;
             
             public function getData(): ?string
@@ -69,7 +69,7 @@ class DataSourceChainTest extends TestCase
         ])] class {
             use LoadableTrait;
             
-            #[DataSourceRef(id: 'sourceA', fallbacks: ['sourceB'], exceptionOnNoValidDataSource: UnsuitableSourceException::class)]
+            #[DataSourceRef(id: 'sourceA', fallbacks: ['sourceB'], exceptionOnNoValidFallback: UnsuitableSourceException::class)]
             private ?string $data = null;
             
             public function getData(): ?string
@@ -92,7 +92,7 @@ class DataSourceChainTest extends TestCase
         ])] class {
             use LoadableTrait;
             
-            #[DataSourceRef(id: 'sourceA', fallbacks: [], exceptionOnNoValidDataSource: UnsuitableSourceException::class)]
+            #[DataSourceRef(id: 'sourceA', fallbacks: [], exceptionOnNoValidFallback: UnsuitableSourceException::class)]
             private ?string $data = null;
             
             public function getData(): ?string

--- a/tests/Integration/PropertyNamePrecedenceTest.php
+++ b/tests/Integration/PropertyNamePrecedenceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Data Mapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\DataMapper\Tests\Integration;
+
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\Registry\LoaderRegistry;
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\Attribute\PropertyConfig;
+use PHPUnit\Framework\TestCase;
+
+class PropertyNamePrecedenceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        LoaderRegistry::clear();
+    }
+
+    /**
+     * Test that Property attribute fields take precedence over PropertyConfig fields during merge.
+     * 
+     * This is a unit test for the mergePropertyConfig logic.
+     * When both Property and PropertyConfig have a value for the same field,
+     * Property's value should take precedence.
+     */
+    public function testPropertyTakesPrecedenceOverPropertyConfigInMerge(): void
+    {
+        // Create Property with name set
+        $property = new Property(
+            name: 'property_name',
+            class: null,
+            expand: 'property_expand',
+            noExpand: null,
+            mapping: null,
+        );
+        
+        // Create PropertyConfig with different values
+        $config = new PropertyConfig(
+            id: 'testConfig',
+            class: 'SomeClass',
+            name: 'config_name',
+            expand: 'config_expand',
+            noExpand: 'config_noExpand',
+            mapping: null,
+        );
+        
+        // Access the private mergePropertyConfig method via reflection
+        new DataMapper(new \Kassko\DataMapper\ServiceResolver());
+        $loader = LoaderRegistry::get();
+        $method = new \ReflectionMethod($loader, 'mergePropertyConfig');
+        
+        $merged = $method->invoke($loader, $property, $config);
+        
+        // Property.name takes precedence
+        $this->assertEquals('property_name', $merged->name);
+        
+        // Property.expand takes precedence
+        $this->assertEquals('property_expand', $merged->expand);
+        
+        // Property.class is null, so PropertyConfig.class is used
+        $this->assertEquals('SomeClass', $merged->class);
+        
+        // Property.noExpand is null, so PropertyConfig.noExpand is used  
+        $this->assertEquals('config_noExpand', $merged->noExpand);
+    }
+
+    /**
+     * Test that PropertyConfig values are used when Property values are null.
+     */
+    public function testPropertyConfigUsedWhenPropertyValuesAreNull(): void
+    {
+        // Create Property with only config reference (most fields null)
+        $property = new Property(
+            name: null,
+            class: null,
+            expand: null,
+            noExpand: null,
+            mapping: null,
+        );
+        
+        // Create PropertyConfig with all values
+        $config = new PropertyConfig(
+            id: 'testConfig',
+            class: 'ConfigClass',
+            name: 'config_name',
+            expand: 'config_expand',
+            noExpand: 'config_noExpand',
+            mapping: ['a' => 'b'],
+        );
+        
+        new DataMapper(new \Kassko\DataMapper\ServiceResolver());
+        $loader = LoaderRegistry::get();
+        $method = new \ReflectionMethod($loader, 'mergePropertyConfig');
+        
+        $merged = $method->invoke($loader, $property, $config);
+        
+        // All PropertyConfig values should be used
+        $this->assertEquals('config_name', $merged->name);
+        $this->assertEquals('ConfigClass', $merged->class);
+        $this->assertEquals('config_expand', $merged->expand);
+        $this->assertEquals('config_noExpand', $merged->noExpand);
+        $this->assertEquals(['a' => 'b'], $merged->mapping);
+    }
+}

--- a/tests/Unit/Attribute/DataSourceRefValidationTest.php
+++ b/tests/Unit/Attribute/DataSourceRefValidationTest.php
@@ -33,11 +33,11 @@ class DataSourceRefValidationTest extends TestCase
         $ref = new DataSourceRef(
             id: 'sourceA',
             fallbacks: ['sourceB', 'sourceC'],
-            exceptionOnNoValidDataSource: 'SomeException'
+            exceptionOnNoValidFallback: 'SomeException'
         );
         $this->assertEquals('sourceA', $ref->id);
         $this->assertEquals(['sourceB', 'sourceC'], $ref->fallbacks);
-        $this->assertEquals('SomeException', $ref->exceptionOnNoValidDataSource);
+        $this->assertEquals('SomeException', $ref->exceptionOnNoValidFallback);
         $this->assertNull($ref->providers);
     }
     
@@ -82,11 +82,11 @@ class DataSourceRefValidationTest extends TestCase
     public function testExceptionWithoutFallbacksThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('DataSourceRef: exceptionOnNoValidDataSource requires fallbacks to be set');
+        $this->expectExceptionMessage('DataSourceRef: exceptionOnNoValidFallback requires fallbacks to be set');
         
         new DataSourceRef(
             id: 'sourceA',
-            exceptionOnNoValidDataSource: 'SomeException'
+            exceptionOnNoValidFallback: 'SomeException'
         );
     }
     
@@ -232,14 +232,14 @@ class DataSourceRefValidationTest extends TestCase
     public function testCandidatesCannotUseExceptionOnNoValidDataSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('DataSourceRef: exceptionOnNoValidDataSource cannot be used with candidates');
+        $this->expectExceptionMessage('DataSourceRef: exceptionOnNoValidFallback cannot be used with candidates');
 
         new DataSourceRef(
             candidates: [
                 ['id' => 'sourceA', 'rule' => 'expr(true)'],
             ],
             defaultCandidate: ['id' => 'sourceB'],
-            exceptionOnNoValidDataSource: 'SomeException'
+            exceptionOnNoValidFallback: 'SomeException'
         );
     }
 }

--- a/tests/Unit/DataCollector/DataLineageCollectorTest.php
+++ b/tests/Unit/DataCollector/DataLineageCollectorTest.php
@@ -15,6 +15,7 @@ namespace Kassko\DataMapper\Tests\Unit\DataCollector;
 
 use Kassko\DataMapper\DataCollector\DataLineageCollector;
 use Kassko\DataMapper\DataCollector\LineageEvent;
+use Kassko\DataMapper\Enum\SensitiveLevel;
 use PHPUnit\Framework\TestCase;
 
 class DataLineageCollectorTest extends TestCase
@@ -221,5 +222,213 @@ class DataLineageCollectorTest extends TestCase
 
         $this->assertFalse($this->collector->isEnabled());
         $this->assertEmpty($this->collector->getEvents());
+    }
+
+    public function testSensitiveLevelHide(): void
+    {
+        $collector = new DataLineageCollector([
+            'password' => SensitiveLevel::HIDE,
+        ]);
+        $collector->enable();
+
+        $collector->recordPropertyHydration('Test', 'password', null, 'secret123', 'source');
+
+        $events = $collector->getEvents();
+        $this->assertCount(1, $events);
+        
+        $array = $events[0]->toArray();
+        $this->assertEquals('[SENSITIVE]', $array['finalValue']);
+    }
+
+    public function testSensitiveLevelMask(): void
+    {
+        $collector = new DataLineageCollector([
+            'ssn' => SensitiveLevel::MASK,
+        ]);
+        $collector->enable();
+
+        $collector->recordPropertyHydration('Test', 'ssn', null, '123-45-6789', 'source');
+
+        $events = $collector->getEvents();
+        $array = $events[0]->toArray();
+        
+        // Should mask the middle
+        $this->assertStringStartsWith('12', $array['finalValue']);
+        $this->assertStringEndsWith('89', $array['finalValue']);
+        $this->assertStringContainsString('*', $array['finalValue']);
+    }
+
+    public function testSensitiveLevelTypeOnly(): void
+    {
+        $collector = new DataLineageCollector([
+            'data' => SensitiveLevel::TYPE_ONLY,
+        ]);
+        $collector->enable();
+
+        $collector->recordPropertyHydration('Test', 'data', null, 'some value', 'source');
+
+        $events = $collector->getEvents();
+        $array = $events[0]->toArray();
+        
+        $this->assertStringContainsString('[string', $array['finalValue']);
+    }
+
+    public function testSensitivePatternMatching(): void
+    {
+        $collector = new DataLineageCollector([
+            '*password*' => SensitiveLevel::HIDE,
+        ]);
+        $collector->enable();
+
+        $collector->recordPropertyHydration('Test', 'user_password_hash', null, 'hashvalue', 'source');
+
+        $events = $collector->getEvents();
+        $array = $events[0]->toArray();
+        
+        $this->assertEquals('[SENSITIVE]', $array['finalValue']);
+    }
+
+    public function testDatetimeIsRecorded(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordPropertyHydration('Test', 'prop', null, 'value', 'source');
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $events[0]->datetime);
+        
+        $array = $events[0]->toArray();
+        $this->assertArrayHasKey('datetime', $array);
+        $this->assertNotNull($array['datetime']);
+    }
+
+    public function testFlowTracking(): void
+    {
+        $this->collector->enable();
+
+        // Start a flow
+        $flowId = $this->collector->startFlow('TestClass', 'Test hydration');
+        $this->assertNotEmpty($flowId);
+        $this->assertEquals($flowId, $this->collector->getCurrentFlowId());
+
+        // Record an event - should have the flow ID
+        $this->collector->recordPropertyHydration('TestClass', 'prop', null, 'value', 'source');
+
+        // End the flow
+        $this->collector->endFlow('completed');
+
+        $events = $this->collector->getEvents();
+        
+        // Flow start + property hydration + flow end = 3 events
+        $this->assertCount(3, $events);
+        
+        // Check flow start event
+        $this->assertEquals(LineageEvent::TYPE_FLOW_START, $events[0]->type);
+        $this->assertEquals($flowId, $events[0]->flowId);
+        
+        // Check hydration event has flow ID
+        $this->assertEquals($flowId, $events[1]->flowId);
+        
+        // Check flow end event
+        $this->assertEquals(LineageEvent::TYPE_FLOW_END, $events[2]->type);
+        $this->assertEquals($flowId, $events[2]->flowId);
+    }
+
+    public function testAddAndRemoveSensitiveKeyAtRuntime(): void
+    {
+        $this->collector->enable();
+        
+        // Add a sensitive key at runtime
+        $this->collector->addSensitiveKey('secret', SensitiveLevel::HIDE);
+        
+        $this->collector->recordPropertyHydration('Test', 'secret', null, 'value', 'source');
+        
+        $events = $this->collector->getEvents();
+        $array = $events[0]->toArray();
+        $this->assertEquals('[SENSITIVE]', $array['finalValue']);
+        
+        // Remove the key and verify
+        $this->collector->removeSensitiveKey('secret');
+        $this->assertArrayNotHasKey('secret', $this->collector->getSensitiveKeys());
+    }
+
+    public function testDefaultSensitiveLevel(): void
+    {
+        $collector = new DataLineageCollector([], SensitiveLevel::TYPE_ONLY);
+        $collector->enable();
+
+        $collector->recordPropertyHydration('Test', 'anyProperty', null, 'any value', 'source');
+
+        $events = $collector->getEvents();
+        $array = $events[0]->toArray();
+        
+        $this->assertStringContainsString('[string', $array['finalValue']);
+    }
+
+    public function testDataSourceSensitiveKeys(): void
+    {
+        $this->collector->enable();
+
+        // Record a DataSource call with sensitiveKeys
+        $this->collector->recordDataSourceCall(
+            'TestClass',
+            'UserRepository',
+            'findUser',
+            ['id' => 123],
+            [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'password' => 'secret123',
+                'apiToken' => 'token-abc-123',
+            ],
+            'userSource',
+            [
+                'password' => SensitiveLevel::HIDE,
+                '*Token' => SensitiveLevel::MASK,
+            ]
+        );
+
+        $events = $this->collector->getEvents();
+        $this->assertCount(1, $events);
+        
+        $array = $events[0]->toArray();
+        
+        // password should be hidden
+        $this->assertEquals('[SENSITIVE]', $array['finalValue']['password']);
+        
+        // apiToken should be masked (pattern match *Token)
+        $this->assertStringContainsString('***', $array['finalValue']['apiToken']);
+        
+        // name and email should be shown as-is
+        $this->assertEquals('John Doe', $array['finalValue']['name']);
+        $this->assertEquals('john@example.com', $array['finalValue']['email']);
+        
+        // metadata should indicate hasSensitiveKeys
+        $this->assertTrue($array['metadata']['hasSensitiveKeys']);
+    }
+
+    public function testDataSourceWithoutSensitiveKeys(): void
+    {
+        $this->collector->enable();
+
+        $this->collector->recordDataSourceCall(
+            'TestClass',
+            'Repository',
+            'findAll',
+            [],
+            ['data' => 'value'],
+            'source',
+            [] // No sensitive keys
+        );
+
+        $events = $this->collector->getEvents();
+        $array = $events[0]->toArray();
+        
+        // Data should be shown as-is
+        $this->assertEquals(['data' => 'value'], $array['finalValue']);
+        
+        // metadata should indicate no sensitive keys
+        $this->assertFalse($array['metadata']['hasSensitiveKeys']);
     }
 }


### PR DESCRIPTION
# PR: Track data flow, handle sensitive data, document some exposed API

## Summary

This PR enhances the data lineage collection system by adding `sensitiveKeys` support to DataSource attributes and relocates the `SensitiveLevel` enum to a dedicated `Enum` namespace for cleaner public API design.

## Changes

### 1. Add SensitiveLevel Enum

- Add SensitiveLevel` enum to `Kassko\DataMapper\Enum` namespace
- **Rationale**: Avoid forcing public API users to import from the `DataCollector` namespace when using `SensitiveLevel` in their entity attributes

### 2. Added `sensitiveKeys` Parameter to DataSource Attributes

The following attributes now support `sensitiveKeys` for masking sensitive data in lineage collection:

- `Property`
- `PropertyConfig`
- `DataSource`
- `SinglePropDataSource`
- `MultiPropDataSource`

#### Example Usage

```php
use Kassko\DataMapper\Attribute\DataSource;
use Kassko\DataMapper\Enum\SensitiveLevel;

#[DataSource(
    class: UserRepository::class,
    method: 'findUser',
    args: ['#id'],
    sensitiveKeys: [
        'password' => SensitiveLevel::HIDE,      // Exact match → [SENSITIVE]
        '*Token' => SensitiveLevel::MASK,        // Pattern → to**********23
        'secret*' => SensitiveLevel::TYPE_ONLY,  // Pattern → [string(12)]
    ]
)]
private ?array $userData = null;
```

### 3. DataLineageCollector Enhancements

- Updated `recordDataSourceCall()` to accept a `sensitiveKeys` parameter
- Added `applySensitiveKeysToResult()` method to mask sensitive keys in DataSource results
- Added `getSensitiveLevelForKey()` method to resolve sensitive levels for specific keys
- Metadata now includes `hasSensitiveKeys` flag to indicate if masking was applied

### 4. Loader Updates

- All three `recordDataSourceCall()` invocations now pass `$dataSource->sensitiveKeys` to the collector

## Files Changed

### Modified
- `src/Attribute/Property.php` - Added `sensitiveKeys` parameter
- `src/Attribute/PropertyConfig.php` - Added `sensitiveKeys` parameter
- `src/Attribute/DataSource.php` - Added `sensitiveKeys` parameter
- `src/Attribute/SinglePropDataSource.php` - Added `sensitiveKeys` parameter
- `src/Attribute/MultiPropDataSource.php` - Added `sensitiveKeys` parameter
- `src/DataCollector/DataLineageCollector.php` - Enhanced `recordDataSourceCall()`, added helper methods
- `src/Loader/Loader.php` - Pass `sensitiveKeys` to collector

### Tests
- `tests/Unit/DataCollector/DataLineageCollectorTest.php` - Updated import, added 2 new tests for DataSource sensitiveKeys

## Test Results

```
Tests: 264, Assertions: 611, Skipped: 2
OK
```

## Related Issues

- Improves debugging experience by allowing granular control over sensitive data visibility in DataSource results
