### PR TITLE
feat: Make optional cascading attributes, context with method result and more

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -176,9 +176,9 @@ class Product
 private array $fullProfile = [];
 ```
 
-### DataSource Candidates (Rule-Based Selection)
+### DataSource Candidates (Expression-Based Selection)
 
-Select a data source dynamically based on context or conditions. When no rule matches, `defaultCandidate` is used:
+Select a data source dynamically based on context or conditions. When no expression matches, `defaultCandidate` is used:
 
 ```php
 use Kassko\DataMapper\Attribute\DataSourcesStore;
@@ -194,9 +194,9 @@ class User
     #[DataSourceRef(
         candidates: [
             // Candidate: selected if new_feature_enabled context is true
-            ['id' => 'newFeatureSource', 'rule' => "expr(context('new_feature_enabled'))", 'priority' => 15],
+            ['id' => 'newFeatureSource', 'when' => "expr(context('new_feature_enabled'))", 'priority' => 15],
         ],
-        // Default: used when no rule matches
+        // Default: used when no expression matches
         defaultCandidate: ['id' => 'oldFeatureSource'],
         priority: 10
     )]
@@ -251,8 +251,8 @@ class Garage
 {
     #[Property(
         configCandidates: [
-            ['id' => 'gasolineCar', 'rule' => "expr(rawDataItemExists('fuel_type'))"],
-            ['id' => 'electricCar', 'rule' => "expr(rawDataItemExists('battery_capacity'))"],
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('fuel_type'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('battery_capacity'))"],
         ],
         defaultConfigCandidate: 'gasolineCar'
     )]
@@ -774,8 +774,8 @@ class Chief
     // Access parent context in expressions
     #[Property(
         configCandidates: [
-            ['id' => 'premium', 'rule' => "expr(context('tier') === 'premium')"],
-            ['id' => 'regional', 'rule' => "expr(contextKeyExists('region'))"],
+            ['id' => 'premium', 'when' => "expr(context('tier') === 'premium')"],
+            ['id' => 'regional', 'when' => "expr(contextKeyExists('region'))"],
         ],
         defaultConfigCandidate: 'default'
     )]
@@ -1061,9 +1061,9 @@ class ChildContainer extends BaseContainer
     
     #[Property(
         configCandidates: [
-            ['id' => 'childConfig', 'rule' => "expr(rawDataItemExists('childType'))"],
-            ['id' => 'parentConfig', 'rule' => "expr(rawDataItemExists('parentType'))"], // Works!
-            ['id' => 'traitConfig', 'rule' => "expr(rawDataItemExists('traitType'))"], // Works!
+            ['id' => 'childConfig', 'when' => "expr(rawDataItemExists('childType'))"],
+            ['id' => 'parentConfig', 'when' => "expr(rawDataItemExists('parentType'))"], // Works!
+            ['id' => 'traitConfig', 'when' => "expr(rawDataItemExists('traitType'))"], // Works!
         ],
         defaultConfigCandidate: 'childConfig'
     )]

--- a/README.md
+++ b/README.md
@@ -221,14 +221,14 @@ DataSourceRef now uses `id` + `fallbacks` instead of `chain` for clearer semanti
 private ?string $data = null;
 ```
 
-#### Candidates (Rule-Based Selection)
+#### Candidates (Expression-Based Selection)
 
-Select a data source dynamically based on context or conditions. When no rule matches, `defaultCandidate` is used:
+Select a data source dynamically based on context or conditions. When no expression matches, `defaultCandidate` is used:
 
 ```php
 #[DataSourceRef(
     candidates: [
-        ['id' => 'newFeatureSource', 'rule' => "expr(context('new_feature_enabled'))", 'priority' => 15],
+        ['id' => 'newFeatureSource', 'when' => "expr(context('new_feature_enabled'))", 'priority' => 15],
     ],
     defaultCandidate: ['id' => 'oldFeatureSource'],
     priority: 10
@@ -236,7 +236,7 @@ Select a data source dynamically based on context or conditions. When no rule ma
 private ?string $name = null;
 ```
 
-The first candidate whose `rule` evaluates to `true` is elected. If a candidate defines its own `priority`, it overrides the base priority. If no rule matches, `defaultCandidate` is used as fallback.
+The first candidate whose `when` expression evaluates to `true` is elected. If a candidate defines its own `priority`, it overrides the base priority. If no expression matches, `defaultCandidate` is used as fallback.
 
 #### Build-Time Validation
 

--- a/docs/attributes/Context.md
+++ b/docs/attributes/Context.md
@@ -1,123 +1,217 @@
-# Context
+# Context Attribute
 
-Adds key-value pairs to the hydration context, enabling conditional behavior based on parent object configuration.
+The `Context` attribute adds contextual data to the hydration process, enabling conditional behavior based on runtime values.
 
 ## Overview
 
-The `Context` attribute allows you to pass contextual information down through the object hierarchy during hydration. Context values accumulate as hydration descends into nested objects, and later values for the same key override earlier ones (last writer wins).
+The `Context` attribute supports three context levels:
 
-## Usage
+1. **Application Context**: Shared across all hydration sessions
+2. **Hydration Context**: Shared within one hydration session
+3. **Object Instance Context**: Specific to one object instance (values may depend on object data)
 
-### Basic Usage with Named Arguments
+## Syntax
+
+```php
+#[Context(
+    ['key' => 'keyName', 'value' => 'staticValue'],                    // Simple key-value
+    ['key' => 'dataKey', 'class' => 'service', 'method' => 'fetch'],   // Method result
+    ['cascade' => true]  // Optional: last entry can be cascade config
+)]
+```
+
+Each entry must be an array with:
+- `key` (required): The context key name
+- Either:
+  - `value`: A static value
+  - `class` + `method`: A service and method to call to get the value
+    - Optional `args`: Arguments to pass to the method
+
+## Usage Examples
+
+### Simple Key-Value Context
 
 ```php
 use Kassko\DataMapper\Attribute\Context;
 
-class CompanyA
+class Person
 {
     #[Context(
-        key1: 'value1',
-        key2: 'value2',
-        key3: 'value3'
+        ['key' => 'environment', 'value' => 'production'],
+        ['key' => 'version', 'value' => '2.0']
     )]
-    private Chief $chief;
+    private ?Data $data = null;
+}
+```
+
+### Capturing Method Results
+
+Fetch data from a service and store it in the context:
+
+```php
+#[Context(
+    ['key' => 'personRawData', 'class' => 'person.data_source', 'method' => 'fetchData', 'args' => ['#id']],
+)]
+class Person
+{
+    private int $id;
     
-    // Adds 3 variables to the context when chief is hydrated
+    // context('personRawData') is now available in expressions
 }
 ```
 
-### Context Accumulation
+### Chaining Context Dependencies
 
-Context values accumulate as you descend into nested objects:
+Context entries are evaluated in order, allowing later entries to depend on earlier ones:
 
 ```php
-class CompanyB
+#[Context(
+    ['key' => 'baseData', 'class' => 'base.service', 'method' => 'fetch', 'args' => ['#id']],
+    ['key' => 'derivedData', 'class' => 'other.service', 'method' => 'process', 'args' => ["expr(context('baseData'))"]],
+)]
+class Entity
 {
-    #[Context(key3: 'value3')]
-    private Chief $chief;
-    // Adds 1 variable to the context
-}
-
-class Chief
-{
-    #[Context(
-        key2: 'new_value2',  // Overrides any previous key2 value
-        key4: 'value4'       // Adds new key
-    )]
-    private $prop;
+    // Both baseData and derivedData are available
 }
 ```
 
-### Using Context in Expressions
+### Using ##object for Current Object Methods
 
-Access context values in expressions using `context()` and `contextKeyExists()`:
+Reference methods on the current object being hydrated:
 
 ```php
-class Chief
+#[MethodAlias(name: 'checkKey', class: '##object', method: 'hasKey')]
+#[Context(
+    ['key' => 'rawData', 'class' => 'data.service', 'method' => 'fetch', 'args' => ['#id']],
+)]
+class Person
 {
-    #[Context(key2: 'new_value2', key4: 'value4')]
+    private function hasKey(array $data, string $key): bool
+    {
+        return isset($data[$key]);
+    }
+}
+```
+
+### Class-Level Context
+
+Context can be applied at class level to set values before any properties are hydrated:
+
+```php
+#[Context(
+    ['key' => 'entityType', 'value' => 'person'],
+    ['key' => 'personData', 'class' => 'person.service', 'method' => 'loadData', 'args' => ['#id']],
+)]
+class Person
+{
+    private int $id;
+    
     #[Property(
-        args: "expr(context('key1') === 'foo' ? property('propA') : property('propB'))"
+        configCandidates: [
+            ['id' => 'premium', 'when' => "expr(context('personData')['type'] === 'premium')"],
+        ],
+        defaultConfigCandidate: 'standard'
     )]
-    private $prop;
+    private ?Subscription $subscription = null;
 }
 ```
 
-### Using Context with PropertyCandidates
+### Property-Level Context
+
+Context can also be applied at property level:
 
 ```php
-class Chief
+class Company
 {
-    #[Context(key2: 'new_value2', key4: 'value4')]
-    #[PropertyCandidates([
-        new PropertyCandidate(
-            discriminator: "expr(context('key1') === 'value1')",
-            property: new Property(class: TypeA::class)
-        ),
-        new PropertyCandidate(
-            discriminator: "expr(contextKeyExists('key3'))",
-            property: new Property(class: TypeB::class)
-        )
-    ])]
-    private $prop;
+    #[Context(['key' => 'companyId', 'value' => '#id'])]
+    private ?Department $department = null;
+    
+    // When department is hydrated, context('companyId') will be available
 }
 ```
 
-## Application Context
+## Accessing Context Values
 
-You can also set context values from your application before hydration:
+### In Expressions
+
+```php
+#[Property(
+    configCandidates: [
+        ['id' => 'config1', 'when' => "expr(context('myKey') === 'expectedValue')"],
+        ['id' => 'config2', 'when' => "expr(contextKeyExists('otherKey'))"],
+    ],
+    defaultConfigCandidate: 'default'
+)]
+private ?object $data = null;
+```
+
+### Available Context Functions
+
+- `context('key')` - Returns the value or null if not found (logs warning)
+- `contextKeyExists('key')` - Returns true/false
+
+## Application Context via DataMapper
+
+Set context values from your application before hydration:
 
 ```php
 $dataMapper = new DataMapper($serviceResolver);
 
-// Add application-level context
-$dataMapper->addToContext('new_profile_api_feature', $featureFlag->isEnabled());
-$dataMapper->addToContext('current_user_role', 'admin');
+// Add individual context value
+$dataMapper->addToContext('feature_flag', true);
+$dataMapper->addToContext('api_version', 'v2');
 
-// Or add multiple at once
+// Add multiple context values
 $dataMapper->addManyToContext([
     'env' => 'production',
     'debug' => false,
 ]);
+
+// Check and retrieve context
+if ($dataMapper->hasContext('feature_flag')) {
+    $value = $dataMapper->getContext('feature_flag');
+}
 ```
 
-Application context values are available during hydration and can be overridden by `#[Context]` attributes.
+## Context Cascading
 
-## Expression Functions
+By default, context attributes cascade to child classes. Control this with the cascade configuration:
 
-| Function | Description |
-|----------|-------------|
-| `context('key')` | Get context value (returns null if not found, logs warning) |
-| `contextKeyExists('key')` | Check if context key exists (returns boolean) |
+```php
+// Context will cascade to child classes (default)
+#[Context(['key' => 'inherited', 'value' => 'yes'])]
 
-## Context Behavior
+// Context will NOT cascade to child classes
+#[Context(['key' => 'notInherited', 'value' => 'no'], ['cascade' => false])]
+```
 
-1. **Accumulation**: Context values accumulate as hydration descends into nested objects
-2. **Override**: Later values for the same key override earlier ones (last writer wins)
-3. **Timing**: Context values are set AFTER the property is hydrated
-4. **Precedence**: Hydration context (`#[Context]`) takes precedence over application context
+## Context Levels Explained
 
-## See Also
+### Application Context
+Set via `DataMapper::addToContext()`. Persists across all hydration sessions.
 
-- [Property](Property.md)
-- [PropertyCandidates](PropertyCandidates.md)
+### Hydration Context
+Set at the start of a hydration session. Shared within that session.
+
+### Object Instance Context
+Set via `#[Context]` attributes. Values may depend on the specific object being hydrated (e.g., data fetched based on the object's ID). This is useful when context values vary per object instance.
+
+Example:
+```php
+#[Context(
+    ['key' => 'personData', 'class' => 'person.service', 'method' => 'fetch', 'args' => ['#id']],
+)]
+class Person
+{
+    private int $id;  // Different for each Person instance
+    // personData will be different for each Person based on their id
+}
+```
+
+## Best Practices
+
+1. **Order matters**: Declare context entries in dependency order
+2. **Use meaningful keys**: `personRawData` is clearer than `prd`
+3. **Document complex contexts**: Add comments explaining what context values represent
+4. **Consider scope**: Use application context for global settings, object context for instance-specific data
+5. **Handle missing keys**: Use `contextKeyExists()` to check before accessing optional keys

--- a/docs/attributes/DataSourceRef.md
+++ b/docs/attributes/DataSourceRef.md
@@ -49,7 +49,7 @@ class Person
 | `id` | `?string` | Conditional | Primary data source ID |
 | `fallbacks` | `?array` | No | Array of fallback source IDs (requires `id`) |
 | `providers` | `?array` | Conditional | Array of IDs for aggregation |
-| `candidates` | `?array` | Conditional | Array of candidates with rule expressions |
+| `candidates` | `?array` | Conditional | Array of candidates with `when` expressions |
 | `defaultCandidate` | `?array` | Conditional | Default candidate if no rule matches (required with `candidates`) |
 | `exceptionOnNoValidFallback` | `?string` | No | Exception class for fallback handling |
 | `ignoreProviderOnNotFound` | `bool` | No | Silently skip missing providers (requires `providers`, default: false) |
@@ -62,7 +62,7 @@ class Person
 - `fallbacks` can only be used with `id`
 - `exceptionOnNoValidFallback` requires `fallbacks` to be set
 - `ignoreProviderOnNotFound` can only be used with `providers`
-- Each candidate must have `id` and `rule` keys
+- Each candidate must have `id` and `when` keys
 
 ## Modes
 
@@ -159,9 +159,9 @@ private ?string $value = null;
 private ?string $value = null;
 ```
 
-### Candidates (Rule-Based Selection)
+### Candidates (Expression-Based Selection)
 
-Select a data source dynamically based on expression evaluation. The first candidate whose `rule` evaluates to `true` is elected. If no rule matches, `defaultCandidate` is used:
+Select a data source dynamically based on expression evaluation. The first candidate whose `when` expression evaluates to `true` is elected. If no expression matches, `defaultCandidate` is used:
 
 ```php
 #[DataSourcesStore([
@@ -172,7 +172,7 @@ class User
 {
     #[DataSourceRef(
         candidates: [
-            ['id' => 'newFeatureSource', 'rule' => "expr(context('new_feature_enabled'))", 'priority' => 15],
+            ['id' => 'newFeatureSource', 'when' => "expr(context('new_feature_enabled'))", 'priority' => 15],
         ],
         defaultCandidate: ['id' => 'oldFeatureSource'],
         priority: 10
@@ -183,7 +183,7 @@ class User
 
 **Candidate Structure:**
 - `id` (required): The data source ID to use if this candidate is elected
-- `rule` (required): An expression that returns a boolean
+- `when` (required): An expression that returns a boolean
 - `priority` (optional): Overrides the base `priority` if this candidate is elected
 
 **defaultCandidate Structure:**

--- a/docs/attributes/MethodAlias.md
+++ b/docs/attributes/MethodAlias.md
@@ -1,0 +1,155 @@
+# MethodAlias Attribute
+
+The `MethodAlias` attribute defines reusable method references that can be used in data source attributes and expressions.
+
+## Purpose
+
+`MethodAlias` allows you to:
+- Define method references at class level for reuse across properties
+- Create named functions for use in expression language
+- Reference methods on the current object using `##object`
+- Simplify complex data source configurations
+
+## Syntax
+
+```php
+#[MethodAlias(
+    name: string,      // Alias name to reference this method
+    class: string,     // Service class, service ID, or '##object' for current object
+    method: string,    // Method name to call
+    cascade: bool = true  // Whether this attribute cascades to child classes
+)]
+```
+
+## Usage
+
+### Basic Usage
+
+```php
+use Kassko\DataMapper\Attribute\MethodAlias;
+use Kassko\DataMapper\Attribute\DataSource;
+
+#[MethodAlias(name: 'fetchPersonData', class: 'person.data_source', method: 'fetchData')]
+class Person
+{
+    private int $id;
+    
+    #[DataSource(methodAlias: 'fetchPersonData', args: ['#id'])]
+    private ?string $email = null;
+}
+```
+
+### Using `##object` for Current Object Methods
+
+Reference a method on the current object being hydrated:
+
+```php
+#[MethodAlias(name: 'checkDataKey', class: '##object', method: 'hasDataKey')]
+class Person
+{
+    private ?string $email = null;
+    
+    private function hasDataKey(array $data, string $key): bool
+    {
+        return isset($data[$key]);
+    }
+}
+```
+
+### Using with configCandidates
+
+```php
+#[MethodAlias(name: 'personDataKeyExists', class: '##object', method: 'keyExists')]
+#[Context(
+    ['key' => 'personData', 'class' => 'person.service', 'method' => 'fetchData', 'args' => ['#id']],
+)]
+#[PropertyConfigStore([
+    new PropertyConfig(id: 'personal', name: 'personal-email'),
+    new PropertyConfig(id: 'professional', name: 'professional-email'),
+])]
+class Person
+{
+    private int $id;
+    
+    #[Property(
+        configCandidates: [
+            ['id' => 'personal', 'when' => "expr(personDataKeyExists(context('personData'), 'personal-email'))"],
+            ['id' => 'professional', 'when' => "expr(personDataKeyExists(context('personData'), 'professional-email'))"],
+        ],
+        defaultConfigCandidate: []  // No-op
+    )]
+    private ?string $email = null;
+    
+    private function keyExists(array $data, string $key): bool
+    {
+        return isset($data[$key]);
+    }
+}
+```
+
+## Using methodAlias in DataSource Attributes
+
+The `methodAlias` parameter can be used in:
+
+- `DataSource`
+- `SinglePropDataSource`
+- `MultiPropDataSource`
+
+When using `methodAlias`, you cannot also specify `class` and `method` - they are mutually exclusive:
+
+```php
+// ✅ Correct - uses methodAlias
+#[DataSource(methodAlias: 'fetchData', args: ['#id'])]
+
+// ✅ Correct - uses class/method directly
+#[DataSource(class: 'MyService', method: 'fetchData', args: ['#id'])]
+
+// ❌ Invalid - cannot combine methodAlias with class/method
+#[DataSource(methodAlias: 'fetchData', class: 'MyService', method: 'fetchData')]
+```
+
+## Cascading
+
+By default, `MethodAlias` attributes cascade to child classes. Set `cascade: false` to prevent inheritance:
+
+```php
+#[MethodAlias(name: 'parentMethod', class: 'service', method: 'method', cascade: false)]
+abstract class BaseEntity
+{
+    // MethodAlias will NOT be available in child classes
+}
+```
+
+## Error Handling
+
+If a referenced `methodAlias` is not found, a `MethodAliasNotFoundException` is thrown:
+
+```
+MethodAlias "fetchData" not found in class "App\Entity\Person" or its parent classes.
+Make sure to define the MethodAlias attribute on the class.
+```
+
+## Integration with Expression Language
+
+Method aliases are available in expressions:
+
+```php
+#[MethodAlias(name: 'checkFeature', class: 'feature.service', method: 'isEnabled')]
+class User
+{
+    #[Property(
+        configCandidates: [
+            ['id' => 'premium', 'when' => "expr(checkFeature('premium_access'))"],
+        ],
+        defaultConfigCandidate: 'standard'
+    )]
+    private ?object $subscription = null;
+}
+```
+
+## Best Practices
+
+1. **Use descriptive names**: `fetchPersonData` is clearer than `fpd`
+2. **Group related aliases**: Define all related method aliases together at class level
+3. **Document complex aliases**: Add PHPDoc comments explaining what the alias does
+4. **Consider cascade settings**: Disable cascade for class-specific aliases that shouldn't be inherited

--- a/docs/attributes/Property.md
+++ b/docs/attributes/Property.md
@@ -55,8 +55,8 @@ class Garage
 {
     #[Property(
         configCandidates: [
-            ['id' => 'gasolineCar', 'rule' => "expr(rawDataItemExists('gasolineKind'))"],
-            ['id' => 'electricCar', 'rule' => "expr(rawDataItemExists('energyProvider'))"],
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasolineKind'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energyProvider'))"],
         ],
         defaultConfigCandidate: 'gasolineCar'
     )]
@@ -74,7 +74,7 @@ class Garage
 | `expand` | `?string` | No | Comma-separated fields to expand |
 | `noExpand` | `?string` | No | Comma-separated fields to skip |
 | `config` | `?string` | No | Reference to a PropertyConfig by ID |
-| `configCandidates` | `?array` | No | Array of config candidates with rule expressions |
+| `configCandidates` | `?array` | No | Array of config candidates with `when` expressions |
 | `defaultConfigCandidate` | `?string` | No | Default config ID if no rule matches |
 
 ## Validation Rules
@@ -83,7 +83,7 @@ class Garage
 - `config` is mutually exclusive with `class`, `expand`, `noExpand`, and `mapping`
 - `configCandidates` is mutually exclusive with `class`, `expand`, `noExpand`, `mapping`, and `config`
 - `configCandidates` and `defaultConfigCandidate` must both be present or both absent
-- Each configCandidate must have `id` and `rule` keys
+- Each configCandidate must have `id` and `when` keys
 
 ## Modes
 
@@ -112,8 +112,8 @@ Select a configuration based on runtime data evaluation:
 ```php
 #[Property(
     configCandidates: [
-        ['id' => 'typeA', 'rule' => "expr(rawDataItem('type') == 'A')"],
-        ['id' => 'typeB', 'rule' => "expr(rawDataItem('type') == 'B')"],
+        ['id' => 'typeA', 'when' => "expr(rawDataItem('type') == 'A')"],
+        ['id' => 'typeB', 'when' => "expr(rawDataItem('type') == 'B')"],
     ],
     defaultConfigCandidate: 'typeDefault'
 )]
@@ -122,14 +122,14 @@ private ?Item $item = null;
 
 **configCandidate Structure:**
 - `id` (required): Reference to a PropertyConfig ID
-- `rule` (required): Expression that returns a boolean
+- `when` (required): Expression that returns a boolean
 
 **Resolution Logic:**
-1. Each candidate's `rule` is evaluated against the raw data item
-2. First candidate whose `rule` evaluates to `true` is selected
-3. If no rule matches, `defaultConfigCandidate` is used
+1. Each candidate's `when` expression is evaluated against the raw data item
+2. First candidate whose expression evaluates to `true` is selected
+3. If no expression matches, `defaultConfigCandidate` is used
 
-## Expression Functions for Rules
+## Expression Functions
 
 - `rawDataItemExists('key')` - Check if key exists in data item
 - `rawDataItem('key')` - Get value of key from data item

--- a/docs/attributes/PropertyConfig.md
+++ b/docs/attributes/PropertyConfig.md
@@ -26,8 +26,8 @@ class Garage
 {
     #[Property(
         configCandidates: [
-            ['id' => 'gasolineCar', 'rule' => "expr(rawDataItemExists('gasolineKind'))"],
-            ['id' => 'electricCar', 'rule' => "expr(rawDataItemExists('energyProvider'))"],
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasolineKind'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energyProvider'))"],
         ],
         defaultConfigCandidate: 'gasolineCar'
     )]

--- a/docs/attributes/PropertyConfigStore.md
+++ b/docs/attributes/PropertyConfigStore.md
@@ -31,8 +31,8 @@ class Garage
     // Use polymorphic resolution with configCandidates
     #[Property(
         configCandidates: [
-            ['id' => 'gasolineCar', 'rule' => "expr(rawDataItemExists('gasolineKind'))"],
-            ['id' => 'electricCar', 'rule' => "expr(rawDataItemExists('energyProvider'))"],
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasolineKind'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energyProvider'))"],
         ],
         defaultConfigCandidate: 'hybridCar'
     )]
@@ -44,9 +44,9 @@ class Garage
 
 The `configCandidates` mechanism allows runtime selection of property configuration based on the data being hydrated:
 
-1. Each candidate has a `rule` expression that is evaluated against the raw data item
-2. The first candidate whose rule evaluates to `true` is selected
-3. If no rule matches, `defaultConfigCandidate` is used as fallback
+1. Each candidate has a `when` expression that is evaluated against the raw data item
+2. The first candidate whose expression evaluates to `true` is selected
+3. If no expression matches, `defaultConfigCandidate` is used as fallback
 
 ```php
 #[PropertyConfigStore([
@@ -57,7 +57,7 @@ class UserContainer
 {
     #[Property(
         configCandidates: [
-            ['id' => 'admin', 'rule' => "expr(rawDataItem('role') == 'admin')"],
+            ['id' => 'admin', 'when' => "expr(rawDataItem('role') == 'admin')"],
         ],
         defaultConfigCandidate: 'regular'
     )]
@@ -77,9 +77,9 @@ class UserContainer
 - Config IDs must be unique within the store
 - Duplicate IDs will throw an exception
 
-## Expression Functions for Rules
+## Expression Functions
 
-The `rule` expression can use:
+The `when` expression can use:
 - `rawDataItemExists('key')` - Check if key exists in data item
 - `rawDataItem('key')` - Get value of key from data item
 - `context('key')` - Get value from context registry
@@ -115,8 +115,8 @@ class ChildContainer extends BaseContainer
     
     #[Property(
         configCandidates: [
-            ['id' => 'parentConfig', 'rule' => "expr(rawDataItemExists('parentType'))"], // Works!
-            ['id' => 'traitConfig', 'rule' => "expr(rawDataItemExists('traitType'))"], // Works!
+            ['id' => 'parentConfig', 'when' => "expr(rawDataItemExists('parentType'))"], // Works!
+            ['id' => 'traitConfig', 'when' => "expr(rawDataItemExists('traitType'))"], // Works!
         ],
         defaultConfigCandidate: 'parentConfig'
     )]

--- a/docs/concepts/AttributeCascading.md
+++ b/docs/concepts/AttributeCascading.md
@@ -114,15 +114,42 @@ class ChildContainer extends BaseContainer
     
     #[Property(
         configCandidates: [
-            ['id' => 'childConfig', 'rule' => "expr(rawDataItemExists('childType'))"],
-            ['id' => 'parentConfig', 'rule' => "expr(rawDataItemExists('parentType'))"],
-            ['id' => 'traitConfig', 'rule' => "expr(rawDataItemExists('traitType'))"],
+            ['id' => 'childConfig', 'when' => "expr(rawDataItemExists('childType'))"],
+            ['id' => 'parentConfig', 'when' => "expr(rawDataItemExists('parentType'))"],
+            ['id' => 'traitConfig', 'when' => "expr(rawDataItemExists('traitType'))"],
         ],
         defaultConfigCandidate: 'childConfig'
     )]
     private ?object $item = null;
 }
 ```
+
+## Configurable Cascade Behavior
+
+All DataMapper attributes support a `cascade` field that controls whether the attribute is inherited by child classes:
+
+```php
+#[DataSourcesStore([
+    new SinglePropDataSource(id: 'parentSource', class: ParentDataSource::class, method: 'getData', cascade: false),
+])]
+abstract class BaseEntity
+{
+    // parentSource will NOT be available in child classes
+}
+```
+
+### Per-Attribute Cascade Control
+
+```php
+class ParentClass
+{
+    #[Property(name: 'parent_name', cascade: false)]
+    private ?string $name = null;
+    // Child classes will NOT inherit this Property configuration
+}
+```
+
+The `cascade` field defaults to `true` for all attributes.
 
 ## Property Attribute Override
 

--- a/docs/concepts/ExpressionLanguage.md
+++ b/docs/concepts/ExpressionLanguage.md
@@ -1,0 +1,345 @@
+# Expression Language
+
+The DataMapper Expression Language provides a powerful way to reference data dynamically during object hydration. This document covers all available expression patterns, from simple property references to complex context-based evaluations.
+
+## Overview
+
+Expressions in DataMapper allow you to:
+- Reference property values from the current object
+- Access context values shared across hydration
+- Call data sources dynamically
+- Access environment variables
+- Perform conditional logic in `configCandidates` and `candidates`
+
+## Basic Property References
+
+### Simple Property Reference: `#propertyName`
+
+The most basic expression is a property reference. Use `#` followed by the property name to reference another property's value.
+
+```php
+use Kassko\DataMapper\Attribute\DataSource;
+
+class Person
+{
+    private int $id;
+    
+    #[DataSource(class: EmailService::class, method: 'getEmail', args: ['#id'])]
+    private ?string $email = null;
+}
+```
+
+The `#id` will be resolved to the current value of the `$id` property when the data source method is called.
+
+### Object Reference: `##object`
+
+Reference the current object being hydrated:
+
+```php
+#[PropertyInstantiatingHook(after_instantiating: 'onCreated', args: ['##object'])]
+class Entity
+{
+    public function onCreated(self $entity): void
+    {
+        // Called with the entity itself
+    }
+}
+```
+
+### Parent Object Reference: `#parentObject` or `##parentObject`
+
+Reference the parent object when hydrating nested objects:
+
+```php
+class Child
+{
+    #[DataSource(class: DataService::class, method: 'getData', args: ['#parentObject'])]
+    private ?string $data = null;
+}
+```
+
+### Direct Property Access: `!#propertyName`
+
+Bypass the getter method and access the property value directly:
+
+```php
+#[DataSource(class: Service::class, method: 'process', args: ['!#internalValue'])]
+private ?string $result = null;
+```
+
+## Expression Functions: `expr(...)`
+
+For more complex scenarios, wrap your expression in `expr()`:
+
+### Context Access: `context('key')` and `contextKeyExists('key')`
+
+Access values from the hydration context:
+
+```php
+#[DataSource(class: Service::class, method: 'getData', args: ["expr(context('user_id'))"])]
+private ?string $data = null;
+```
+
+Check if a context key exists:
+
+```php
+#[Property(
+    configCandidates: [
+        ['id' => 'premium', 'when' => "expr(contextKeyExists('premium_enabled'))"],
+    ],
+    defaultConfigCandidate: 'standard'
+)]
+private ?object $subscription = null;
+```
+
+### Raw Data Access: `rawDataItem('key')` and `rawDataItemExists('key')`
+
+Access values from the raw data being used for hydration:
+
+```php
+#[Property(
+    configCandidates: [
+        ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasoline_kind'))"],
+        ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energy_provider'))"],
+    ],
+    defaultConfigCandidate: 'gasolineCar'
+)]
+private array $cars = [];
+```
+
+### Service Access: `service('service_id')`
+
+Get a service from the service locator:
+
+```php
+#[DataSource(args: ["expr(service('my.service'))"])]
+private ?string $data = null;
+```
+
+### Data Source Access: `source('source_id')`
+
+Get the result of a data source by its ID:
+
+```php
+#[DataSourcesStore([
+    new MultiPropDataSource(id: 'personData', class: PersonService::class, method: 'getData'),
+])]
+class Person
+{
+    #[DataSource(args: ["expr(source('personData')['email'])"])]
+    private ?string $email = null;
+}
+```
+
+### Environment Variables: `envVar('KEY')`
+
+Access environment variables:
+
+```php
+#[DataSource(args: ["expr(envVar('API_KEY'))"])]
+private ?string $apiKey = null;
+```
+
+### Property Access: `property('propertyName')` and `strictProperty('propertyName')`
+
+Explicit property access functions:
+
+```php
+// Uses getter if available
+#[DataSource(args: ["expr(property('id'))"])]
+
+// Direct access, bypasses getter
+#[DataSource(args: ["expr(strictProperty('id'))"])]
+```
+
+### Object and Parent Object Functions
+
+```php
+// Get current object
+#[DataSource(args: ["expr(object())"])]
+
+// Get parent object
+#[DataSource(args: ["expr(parentObject())"])]
+```
+
+## Conditional Expressions with `when`
+
+The `when` key in `configCandidates` and `candidates` allows conditional configuration selection:
+
+### PropertyConfig Candidates
+
+```php
+#[PropertyConfigStore([
+    new PropertyConfig(id: 'gasolineCar', class: GasolineCar::class),
+    new PropertyConfig(id: 'electricCar', class: ElectricCar::class),
+])]
+class Garage
+{
+    #[Property(
+        configCandidates: [
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasoline_kind'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energy_provider'))"],
+        ],
+        defaultConfigCandidate: 'gasolineCar'
+    )]
+    private array $cars = [];
+}
+```
+
+### DataSourceRef Candidates
+
+```php
+#[DataSourcesStore([
+    new MultiPropDataSource(id: 'newFeatureSource', class: NewService::class, method: 'getData'),
+    new MultiPropDataSource(id: 'oldFeatureSource', class: OldService::class, method: 'getData'),
+])]
+class Feature
+{
+    #[DataSourceRef(
+        candidates: [
+            ['id' => 'newFeatureSource', 'when' => "expr(context('new_feature_enabled'))"],
+        ],
+        defaultCandidate: ['id' => 'oldFeatureSource']
+    )]
+    private ?string $data = null;
+}
+```
+
+### No-Op Default Configuration
+
+To intentionally skip hydration when no candidate matches, use an empty array:
+
+```php
+#[Property(
+    configCandidates: [
+        ['id' => 'premium', 'when' => "expr(context('is_premium'))"],
+    ],
+    defaultConfigCandidate: []  // No-op: do nothing if no candidate matches
+)]
+private ?object $premiumFeature = null;
+```
+
+## Advanced: Context with Method Results
+
+The `Context` attribute supports capturing method results into the context:
+
+### Simple Key-Value Context
+
+```php
+#[Context(
+    ['key' => 'staticValue', 'value' => 'hello'],
+)]
+class Person
+{
+    // context('staticValue') returns 'hello'
+}
+```
+
+### Capturing Method Results
+
+```php
+#[Context(
+    ['key' => 'personRawData', 'class' => 'person.data_source', 'method' => 'fetchData', 'args' => ['#id']],
+)]
+class Person
+{
+    #[Property(
+        configCandidates: [
+            ['id' => 'premium', 'when' => "expr(context('personRawData')['type'] === 'premium')"],
+        ],
+        defaultConfigCandidate: 'standard'
+    )]
+    private ?object $subscription = null;
+}
+```
+
+### Chaining Context Dependencies
+
+Context entries are evaluated in order, so later entries can depend on earlier ones:
+
+```php
+#[Context(
+    ['key' => 'baseData', 'class' => 'base.source', 'method' => 'fetch', 'args' => ['#id']],
+    ['key' => 'derivedData', 'class' => 'other.source', 'method' => 'process', 'args' => ["expr(context('baseData'))"]],
+)]
+class Entity
+{
+    // Both 'baseData' and 'derivedData' are available in expressions
+}
+```
+
+## Using MethodAlias for Custom Functions
+
+The `MethodAlias` attribute allows defining reusable method references that can be used in expressions:
+
+```php
+#[MethodAlias(name: 'personDataKeyExists', class: '##object', method: 'checkKeyExists')]
+#[Context(
+    ['key' => 'personData', 'class' => 'person.service', 'method' => 'fetchData', 'args' => ['#id']],
+)]
+class Person
+{
+    #[Property(
+        configCandidates: [
+            ['id' => 'personal', 'when' => "expr(personDataKeyExists(context('personData'), 'personal-email'))"],
+            ['id' => 'professional', 'when' => "expr(personDataKeyExists(context('personData'), 'professional-email'))"],
+        ],
+        defaultConfigCandidate: []
+    )]
+    private ?string $email = null;
+    
+    private function checkKeyExists(array $data, string $key): bool
+    {
+        return isset($data[$key]);
+    }
+}
+```
+
+### Using MethodAlias in DataSource
+
+```php
+#[MethodAlias(name: 'fetchPerson', class: 'person.data_source', method: 'fetch')]
+class Person
+{
+    #[DataSource(methodAlias: 'fetchPerson', args: ['#id'])]
+    private ?string $email = null;
+}
+```
+
+## Context Levels
+
+DataMapper supports three context levels:
+
+1. **Application Context**: Shared across all hydration sessions
+2. **Hydration Context**: Shared within one hydration session  
+3. **Object Instance Context**: Specific to one object instance (values may depend on object data)
+
+The object instance context is particularly useful when context values depend on the specific object being hydrated, such as data fetched based on an object's ID.
+
+## Expression Evaluation Order
+
+1. Expressions are evaluated lazily when the property is accessed (for lazy loading) or during hydration (for eager loading)
+2. Context entries in `#[Context(...)]` are evaluated in the order they are declared
+3. Property references (`#propertyName`) trigger loading of that property if needed
+4. `when` expressions are evaluated in order until one returns `true`
+
+## Best Practices
+
+1. **Keep expressions simple**: Complex logic should be in your data source methods, not in expressions
+2. **Use MethodAlias for complex checks**: Instead of complex inline expressions, define methods on your class
+3. **Order context entries carefully**: Ensure dependencies are declared before their dependents
+4. **Use meaningful alias names**: `fetchPersonData` is clearer than `fpd`
+5. **Document your expressions**: Add PHPDoc comments explaining what expressions do
+6. **Test expressions**: Write tests for different context/data scenarios
+
+## Migration from `rule` to `when`
+
+In previous versions, conditional expressions used the `rule` key. This has been renamed to `when` for clarity:
+
+```php
+// Old (deprecated)
+['id' => 'config', 'rule' => "expr(...)"]
+
+// New
+['id' => 'config', 'when' => "expr(...)"]
+```

--- a/docs/history/pull-requests/PR-2026_01_01---00_00_00.md
+++ b/docs/history/pull-requests/PR-2026_01_01---00_00_00.md
@@ -1,0 +1,167 @@
+# Pull Request: Major Feature Enhancements
+
+## Summary
+
+This PR introduces several significant enhancements to the DataMapper library, improving configurability, expressiveness, and developer experience.
+
+## Changes
+
+### 1. Configurable Attribute Cascading (`cascade` field)
+
+All PHP 8 attributes now include a boolean `cascade` field (default: `true`) that controls whether the attribute is inherited by child classes.
+
+**Affected Attributes:**
+- `Property`, `DataSource`, `SinglePropDataSource`, `MultiPropDataSource`
+- `DataSourcesStore`, `PropertyConfig`, `PropertyConfigStore`
+- `DataSourceRef`, `Context`, `MethodAlias`
+- `Getter`, `Setter`, `Loading`, `Needs`
+- `CustomHydrator`, `Param`
+- `PropertySettingHook`, `PropertyHydratingHook`, `PropertyInstantiatingHook`
+- `SkipAllProperties`, `KeepAllProperties`, `SkipProperty`, `KeepProperty`
+
+**Example:**
+```php
+#[DataSourcesStore([
+    new SinglePropDataSource(id: 'parentSource', class: ParentDataSource::class, method: 'getData', cascade: false),
+])]
+abstract class BaseEntity
+{
+    // parentSource will NOT be available in child classes
+}
+```
+
+### 2. Renamed `rule` to `when`
+
+The field `rule` has been renamed to `when` in all candidate-based expressions for better clarity:
+
+**Before:**
+```php
+['id' => 'config', 'rule' => "expr(rawDataItemExists('key'))"]
+```
+
+**After:**
+```php
+['id' => 'config', 'when' => "expr(rawDataItemExists('key'))"]
+```
+
+**Affected areas:**
+- `Property.configCandidates`
+- `DataSourceRef.candidates`
+
+### 3. MethodAlias Attribute
+
+New `#[MethodAlias]` attribute for defining reusable method references at class level:
+
+```php
+#[MethodAlias(name: 'fetchPersonData', class: 'person.data_source', method: 'fetchData')]
+class Person
+{
+    #[DataSource(methodAlias: 'fetchPersonData', args: ['#id'])]
+    private ?string $email = null;
+}
+```
+
+**Features:**
+- Class-level attribute, repeatable
+- Supports `##object` to reference methods on the current object
+- `methodAlias` is mutually exclusive with `class`/`method` in DataSource attributes
+- Throws `MethodAliasNotFoundException` when referenced alias doesn't exist
+- Methods become available in expression language
+
+### 4. Enhanced Context Attribute
+
+The `Context` attribute has been redesigned to support:
+
+**Simple key-value pairs:**
+```php
+#[Context(['key' => 'myKey', 'value' => 'myValue'])]
+```
+
+**Method result capture:**
+```php
+#[Context(
+    ['key' => 'personData', 'class' => 'person.service', 'method' => 'fetchData', 'args' => ['#id']],
+)]
+```
+
+**Chained dependencies:**
+```php
+#[Context(
+    ['key' => 'baseData', 'class' => 'base.source', 'method' => 'fetch', 'args' => ['#id']],
+    ['key' => 'derivedData', 'class' => 'other.source', 'method' => 'process', 'args' => ["expr(context('baseData'))"]],
+)]
+```
+
+**Context Levels:**
+- Application context: Shared across all hydration sessions
+- Hydration context: Shared within one hydration session
+- Object instance context: Specific to one object instance
+
+### 5. No-Op Default Config Candidate
+
+`defaultConfigCandidate` now accepts an empty array `[]` to indicate "do nothing" when no candidate matches:
+
+```php
+#[Property(
+    configCandidates: [
+        ['id' => 'premium', 'when' => "expr(context('is_premium'))"],
+    ],
+    defaultConfigCandidate: []  // No-op: intentionally do nothing
+)]
+```
+
+The validation message now includes guidance: *"Set defaultConfigCandidate to an empty array [] if you intentionally want no default action."*
+
+### 6. Expression Language Documentation
+
+Created comprehensive documentation at `docs/concepts/ExpressionLanguage.md` covering:
+- Basic property references (`#propertyName`, `##object`)
+- Expression functions (`expr()`, `context()`, `source()`, etc.)
+- Conditional expressions with `when`
+- Context with method results
+- MethodAlias integration
+- Best practices
+
+## Breaking Changes
+
+1. **Context API changed**: Named arguments syntax is no longer supported. Use the new array-based format.
+2. **`rule` renamed to `when`**: All `configCandidates` and `candidates` arrays must use `when` instead of `rule`.
+
+## Files Changed
+
+### New Files
+- `src/Attribute/MethodAlias.php`
+- `src/Exception/MethodAliasNotFoundException.php`
+- `docs/attributes/MethodAlias.md`
+- `docs/concepts/ExpressionLanguage.md`
+
+### Modified Attributes
+- All attribute classes in `src/Attribute/`
+
+### Updated Documentation
+- `README.md`
+- `EXAMPLE.md`
+- `docs/attributes/Context.md`
+- `docs/attributes/Property.md`
+- `docs/attributes/PropertyConfig.md`
+- `docs/attributes/PropertyConfigStore.md`
+- `docs/attributes/DataSourceRef.md`
+- `docs/concepts/AttributeCascading.md`
+
+### Updated Tests
+- `tests/Unit/Attribute/ContextTest.php`
+- `tests/Unit/Attribute/DataSourceRefValidationTest.php`
+- `tests/Integration/ContextIntegrationTest.php`
+- `tests/Integration/DataSourceRefCandidatesTest.php`
+- `tests/Fixtures/Cascade/ChildContainer.php`
+- `tests/Fixtures/Garage.php`
+
+## Testing
+
+All 288 tests pass successfully.
+
+## Backward Compatibility
+
+**Not maintained** - This is an alpha version, and changes are not backward compatible. Users must:
+1. Replace `rule` with `when` in all candidate arrays
+2. Update Context usage to the new array-based format

--- a/docs/history/summaries/SUMMARY-2026_01_01---00_00_00.md
+++ b/docs/history/summaries/SUMMARY-2026_01_01---00_00_00.md
@@ -1,0 +1,175 @@
+# Work Summary: Major Feature Enhancements
+
+**Date:** January 1, 2026  
+**Branch:** feat/OptionalCascading_ContextAttrWithMethodResult_AndMore
+
+## Overview
+
+This work session implemented six major features to enhance the DataMapper library's flexibility and developer experience.
+
+## Completed Tasks
+
+### 1. Configurable Attribute Cascading
+
+**Objective:** Allow developers to control whether attributes are inherited by child classes.
+
+**Implementation:**
+- Added `public bool $cascade = true` field to all 20+ PHP 8 attributes
+- Default behavior remains unchanged (cascading enabled)
+- Setting `cascade: false` prevents child classes from inheriting the attribute
+
+**Files Modified:**
+- All attribute classes in `src/Attribute/`
+- Updated documentation in `docs/concepts/AttributeCascading.md`
+
+---
+
+### 2. Renamed `rule` to `when`
+
+**Objective:** Improve semantic clarity in conditional expressions.
+
+**Implementation:**
+- Renamed the `rule` key to `when` in:
+  - `Property.configCandidates` arrays
+  - `DataSourceRef.candidates` arrays
+- Updated all validation messages
+
+**Files Modified:**
+- `src/Attribute/Property.php`
+- `src/Attribute/DataSourceRef.php`
+- Test fixtures and integration tests
+- Documentation files
+
+---
+
+### 3. MethodAlias Attribute
+
+**Objective:** Enable reusable method references at class level.
+
+**Implementation:**
+- Created `#[MethodAlias]` attribute with:
+  - `name`: Unique alias identifier
+  - `class`: Service class or ID (optional, use `##object` for current object)
+  - `method`: Method name to call
+  - `cascade`: Inheritance control (default: true)
+- Added `methodAlias` field to `DataSource`, `SinglePropDataSource`, `MultiPropDataSource`
+- Created `MethodAliasNotFoundException` for error handling
+- Extended `AttributeReader` with:
+  - `readMethodAliases()` method
+  - `getMethodAliasMap()` method
+
+**Files Created:**
+- `src/Attribute/MethodAlias.php`
+- `src/Exception/MethodAliasNotFoundException.php`
+- `docs/attributes/MethodAlias.md`
+
+---
+
+### 4. Enhanced Context Attribute
+
+**Objective:** Support method result capture in context.
+
+**Implementation:**
+- Completely redesigned Context API to use variadic array entries
+- Each entry supports:
+  - Static values: `['key' => 'name', 'value' => 'staticValue']`
+  - Method results: `['key' => 'name', 'class' => 'service', 'method' => 'fetch', 'args' => [...]]`
+- Updated `Loader.php` with:
+  - `handleContextAttribute()` now accepts object parameter
+  - `processContextEntries()` method
+  - `evaluateContextMethodEntry()` method
+
+**Files Modified:**
+- `src/Attribute/Context.php` (complete rewrite)
+- `src/Loader/Loader.php`
+- `tests/Unit/Attribute/ContextTest.php`
+- `tests/Integration/ContextIntegrationTest.php`
+- `docs/attributes/Context.md`
+
+---
+
+### 5. No-Op Default Config Candidate
+
+**Objective:** Allow explicit "do nothing" behavior for unmatched candidates.
+
+**Implementation:**
+- Changed `defaultConfigCandidate` type from `?string|array` to `null|string|array`
+- Empty array `[]` now represents intentional no-op
+- Updated validation message to guide developers
+
+**Files Modified:**
+- `src/Attribute/Property.php`
+- `docs/attributes/Property.md`
+
+---
+
+### 6. Expression Language Documentation
+
+**Objective:** Provide comprehensive documentation for the expression system.
+
+**Implementation:**
+- Created new documentation file covering:
+  - Property references (`#prop`, `##object`)
+  - Core functions (`expr()`, `context()`, `source()`, etc.)
+  - Conditional expressions with `when`
+  - Context integration
+  - MethodAlias in expressions
+  - Best practices and common patterns
+
+**Files Created:**
+- `docs/concepts/ExpressionLanguage.md`
+
+---
+
+## Additional Documentation Updates
+
+Updated the following documentation files:
+- `README.md` - Added sections for new features
+- `EXAMPLE.md` - Added practical examples
+- `docs/attributes/Context.md`
+- `docs/attributes/Property.md`
+- `docs/attributes/PropertyConfig.md`
+- `docs/attributes/PropertyConfigStore.md`
+- `docs/attributes/DataSourceRef.md`
+- `docs/concepts/AttributeCascading.md`
+
+---
+
+## Testing Results
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | 288 |
+| Assertions | 669 |
+| Status | ✅ All Passing |
+| Skipped | 2 |
+| Deprecation Warnings | 1 (PHPUnit) |
+
+---
+
+## Breaking Changes
+
+This release includes breaking changes (acceptable for alpha version):
+
+1. **Context API**: New array-based format required
+2. **`rule` → `when`**: All candidate arrays must be updated
+
+---
+
+## Technical Notes
+
+### PHP 8.1 Union Type Syntax
+- Fixed syntax error: `?string|array` is invalid in PHP 8.1
+- Correct syntax: `null|string|array`
+
+### Context Processing Flow
+1. `Loader::handleContextAttribute()` receives the object being hydrated
+2. `processContextEntries()` iterates over context entries
+3. `evaluateContextMethodEntry()` resolves services and invokes methods
+4. Results are stored in appropriate context level (application, hydration, or object)
+
+### MethodAlias Resolution
+1. `AttributeReader::readMethodAliases()` collects all `#[MethodAlias]` from class hierarchy
+2. `getMethodAliasMap()` builds lookup map by alias name
+3. DataSource validation checks `methodAlias` exists when referenced
+4. `MethodAliasNotFoundException` thrown for missing aliases

--- a/src/Attribute/Context.php
+++ b/src/Attribute/Context.php
@@ -16,37 +16,99 @@ namespace Kassko\DataMapper\Attribute;
 use Attribute;
 
 /**
- * Adds key-value pairs to the hydration context.
+ * Adds context entries for hydration.
  * 
- * Context values accumulate as hydration descends into nested objects.
- * Later values for the same key override earlier ones (last writer wins).
- * Context values are set AFTER the property is hydrated but BEFORE 
- * any PropertyCandidate discriminators are evaluated on child objects.
+ * Context supports three levels:
+ * - Application context: Shared across all hydration sessions
+ * - Hydration context: Shared within one hydration session
+ * - Object instance context: Specific to one object instance (values may depend on object data)
+ * 
+ * Each entry can be:
+ * - A simple key-value pair: ['key' => 'myKey', 'value' => 'myValue']
+ * - A method result capture: ['key' => 'myData', 'class' => 'my.service', 'method' => 'getData', 'args' => ['#id']]
+ * 
+ * Context entries are evaluated in order, so a later entry can reference an earlier one via expressions.
  * 
  * Usage:
  * ```php
  * #[Context(
- *     key1: 'value1',
- *     key2: 'value2',
+ *     ['key' => 'staticValue', 'value' => 'hello'],
+ *     ['key' => 'personData', 'class' => 'person.service', 'method' => 'fetchData', 'args' => ['#id']],
+ *     ['key' => 'derivedData', 'class' => 'other.service', 'method' => 'process', 'args' => ["expr(context('personData'))"]],
  * )]
- * private Chief $chief;
+ * class Person
+ * {
+ *     // ...
+ * }
  * ```
  * 
  * Access in expressions:
- * - `context('key1')` - returns the value or null if not found (logs warning)
- * - `contextKeyExists('key1')` - returns true/false
+ * - `context('key')` - returns the value or null if not found (logs warning)
+ * - `contextKeyExists('key')` - returns true/false
+ * 
+ * Using ##object in class to reference a method on the current object:
+ * ```php
+ * #[MethodAlias(name: 'checkKey', class: '##object', method: 'keyExists')]
+ * #[Context(
+ *     ['key' => 'rawData', 'class' => 'data.source', 'method' => 'fetch', 'args' => ['#id']],
+ * )]
+ * class Person
+ * {
+ *     private function keyExists(array $data, string $key): bool
+ *     {
+ *         return isset($data[$key]);
+ *     }
+ * }
+ * ```
  */
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class Context
 {
-    /** @var array<string, mixed> Key-value pairs to add to context */
-    public readonly array $values;
+    /** @var array<array{key: string, value?: mixed, class?: string, method?: string, args?: array}> Context entries */
+    public readonly array $entries;
+    public readonly bool $cascade;  // Whether this attribute cascades to child classes
 
     /**
-     * @param mixed ...$values Named arguments become key-value pairs
+     * @param array ...$entries Each entry must have a 'key' and either 'value' or 'class'+'method'
      */
-    public function __construct(mixed ...$values)
+    public function __construct(array ...$entries)
     {
-        $this->values = $values;
+        $lastEntry = end($entries);
+        $cascade = true;
+        
+        // Check if the last entry is a cascade configuration
+        if ($lastEntry !== false && isset($lastEntry['cascade']) && count($lastEntry) === 1) {
+            $cascade = (bool) $lastEntry['cascade'];
+            array_pop($entries);
+        }
+        
+        // Validate each entry
+        foreach ($entries as $index => $entry) {
+            if (!isset($entry['key'])) {
+                throw new \InvalidArgumentException(
+                    sprintf('Context: entry at index %d must have a "key"', $index)
+                );
+            }
+            
+            $hasValue = array_key_exists('value', $entry);
+            $hasClass = isset($entry['class']);
+            $hasMethod = isset($entry['method']);
+            
+            if (!$hasValue && !($hasClass && $hasMethod)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Context: entry "%s" must have either "value" or both "class" and "method"', $entry['key'])
+                );
+            }
+            
+            if ($hasValue && ($hasClass || $hasMethod)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Context: entry "%s" cannot have both "value" and "class"/"method"', $entry['key'])
+                );
+            }
+        }
+        
+        $this->entries = $entries;
+        $this->cascade = $cascade;
     }
 }
+

--- a/src/Attribute/CustomHydrator.php
+++ b/src/Attribute/CustomHydrator.php
@@ -21,5 +21,6 @@ final class CustomHydrator
     public function __construct(
         public readonly string $key,             // Key to identify the custom hydrator
         public readonly ?string $objectClass = null,  // Optional: expected class for type checking
+        public readonly bool $cascade = true,    // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/DataSource.php
+++ b/src/Attribute/DataSource.php
@@ -34,5 +34,14 @@ final class DataSource
         public readonly int $priority = 0,
         /** @var array<string, SensitiveLevel> Keys to mark as sensitive (exact name or regex pattern) */
         public readonly array $sensitiveKeys = [],
-    ) {}
+        public readonly ?string $methodAlias = null,  // Reference to a MethodAlias by name
+        public readonly bool $cascade = true,         // Whether this attribute cascades to child classes
+    ) {
+        // Validation: methodAlias is mutually exclusive with class and method
+        if ($methodAlias !== null && ($class !== null || $method !== '')) {
+            throw new \InvalidArgumentException(
+                'DataSource: methodAlias is mutually exclusive with class and method'
+            );
+        }
+    }
 }

--- a/src/Attribute/DataSourceRef.php
+++ b/src/Attribute/DataSourceRef.php
@@ -26,18 +26,20 @@ final class DataSourceRef
     public readonly ?string $exceptionOnNoValidFallback;
     public readonly bool $ignoreProviderOnNotFound;
     public readonly int $priority;
+    public readonly bool $cascade;  // Whether this attribute cascades to child classes
 
     /**
      * @param string|null $id Single source ID (with optional fallbacks)
      * @param array|null $fallbacks Fallback source IDs (requires id)
      * @param array|null $providers Aggregation providers
-     * @param array|null $candidates Candidates with rule expressions.
-     *                               Each candidate: ['id' => string, 'rule' => string, 'priority' => int (optional)]
-     * @param array|null $defaultCandidate Default candidate if no rule matches.
+     * @param array|null $candidates Candidates with 'when' expressions.
+     *                               Each candidate: ['id' => string, 'when' => string, 'priority' => int (optional)]
+     * @param array|null $defaultCandidate Default candidate if no expression matches.
      *                                      Structure: ['id' => string, 'priority' => int (optional)]
      * @param string|null $exceptionOnNoValidFallback Exception class for fallbacks (thrown when all fallbacks fail)
      * @param bool $ignoreProviderOnNotFound If true, missing providers are silently skipped (requires providers)
      * @param int $priority Base priority for hydration
+     * @param bool $cascade Whether this attribute cascades to child classes
      */
     public function __construct(
         ?string $id = null,
@@ -47,7 +49,8 @@ final class DataSourceRef
         ?array $defaultCandidate = null,
         ?string $exceptionOnNoValidFallback = null,
         bool $ignoreProviderOnNotFound = false,
-        int $priority = 0
+        int $priority = 0,
+        bool $cascade = true
     ) {
         // Count how many "modes" are set
         $modesSet = 0;
@@ -102,8 +105,8 @@ final class DataSourceRef
                 if (!isset($candidate['id'])) {
                     throw new \InvalidArgumentException(sprintf('DataSourceRef: candidate at index %d must have an "id" key', $index));
                 }
-                if (!isset($candidate['rule'])) {
-                    throw new \InvalidArgumentException(sprintf('DataSourceRef: candidate at index %d must have a "rule" key', $index));
+                if (!isset($candidate['when'])) {
+                    throw new \InvalidArgumentException(sprintf('DataSourceRef: candidate at index %d must have a "when" key', $index));
                 }
             }
         }
@@ -126,5 +129,6 @@ final class DataSourceRef
         $this->exceptionOnNoValidFallback = $exceptionOnNoValidFallback;
         $this->ignoreProviderOnNotFound = $ignoreProviderOnNotFound;
         $this->priority = $priority;
+        $this->cascade = $cascade;
     }
 }

--- a/src/Attribute/DataSourcesStore.php
+++ b/src/Attribute/DataSourcesStore.php
@@ -20,8 +20,10 @@ final class DataSourcesStore
 {
     /**
      * @param array<SinglePropDataSource|DataSource|MultiPropDataSource> $sources
+     * @param bool $cascade Whether this attribute cascades to child classes
      */
     public function __construct(
         public readonly array $sources = [],
+        public readonly bool $cascade = true,
     ) {}
 }

--- a/src/Attribute/Getter.php
+++ b/src/Attribute/Getter.php
@@ -25,5 +25,6 @@ final class Getter
     public function __construct(
         public readonly ?string $name = null,  // Method name
         public readonly string $type = self::TYPE_GETTER,  // 'getter', 'isser', 'haser'
+        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/KeepAllProperties.php
+++ b/src/Attribute/KeepAllProperties.php
@@ -18,4 +18,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class KeepAllProperties
 {
+    public function __construct(
+        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
+    ) {}
 }

--- a/src/Attribute/KeepProperty.php
+++ b/src/Attribute/KeepProperty.php
@@ -23,4 +23,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class KeepProperty
 {
+    public function __construct(
+        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
+    ) {}
 }

--- a/src/Attribute/Loading.php
+++ b/src/Attribute/Loading.php
@@ -24,5 +24,6 @@ final class Loading
     public function __construct(
         public readonly string $type = self::TYPE_LAZY,  // 'lazy' or 'eager'
         public readonly ?int $depth = null,              // Max recursion depth
+        public readonly bool $cascade = true,            // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/MethodAlias.php
+++ b/src/Attribute/MethodAlias.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DataMapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\DataMapper\Attribute;
+
+use Attribute;
+
+/**
+ * Defines a method alias that can be referenced by DataSource, SinglePropDataSource, or MultiPropDataSource.
+ * 
+ * This allows defining reusable method references at class level that can be used via the methodAlias
+ * parameter in data source attributes.
+ * 
+ * Usage:
+ * ```php
+ * #[MethodAlias(name: 'fetchPersonData', class: 'person.data_source', method: 'fetchData')]
+ * class Person
+ * {
+ *     #[DataSource(methodAlias: 'fetchPersonData', args: ['#id'])]
+ *     private ?string $email = null;
+ * }
+ * ```
+ * 
+ * The method also becomes available in expressions as `expr('fetchPersonData()')`.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class MethodAlias
+{
+    public function __construct(
+        public readonly string $name,            // Alias name to reference this method
+        public readonly string $class,           // Service class or service ID
+        public readonly string $method,          // Method name to call
+        public readonly bool $cascade = true,    // Whether this attribute cascades to child classes
+    ) {}
+}

--- a/src/Attribute/MultiPropDataSource.php
+++ b/src/Attribute/MultiPropDataSource.php
@@ -47,5 +47,14 @@ final class MultiPropDataSource
         public readonly int $priority = 0,
         /** @var array<string, SensitiveLevel> Keys to mark as sensitive (exact name or regex pattern) */
         public readonly array $sensitiveKeys = [],
-    ) {}
+        public readonly ?string $methodAlias = null,     // Reference to a MethodAlias by name
+        public readonly bool $cascade = true,            // Whether this attribute cascades to child classes
+    ) {
+        // Validation: methodAlias is mutually exclusive with class and method
+        if ($methodAlias !== null && ($class !== null || $method !== '')) {
+            throw new \InvalidArgumentException(
+                'MultiPropDataSource: methodAlias is mutually exclusive with class and method'
+            );
+        }
+    }
 }

--- a/src/Attribute/Needs.php
+++ b/src/Attribute/Needs.php
@@ -24,8 +24,10 @@ final class Needs
 {
     /**
      * @param string[] $properties List of property names to load first
+     * @param bool $cascade Whether this attribute cascades to child classes
      */
     public function __construct(
         public readonly array $properties = [],
+        public readonly bool $cascade = true,
     ) {}
 }

--- a/src/Attribute/Param.php
+++ b/src/Attribute/Param.php
@@ -67,9 +67,11 @@ final class Param
      *                      - A service expression: "expr(service('serviceId'))"
      *                      - A source expression: "expr(source('sourceId'))"
      *                      Note: For constructor params, property references are forbidden.
+     * @param bool $cascade Whether this attribute cascades to child classes
      */
     public function __construct(
-        public readonly string $value
+        public readonly string $value,
+        public readonly bool $cascade = true,
     ) {
     }
 }

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -26,10 +26,11 @@ final class Property
         public readonly ?string $noExpand = null,  // Comma-separated props to NOT expand
         public readonly ?array $mapping = null,    // Instance-specific key mapping
         public readonly ?string $config = null,    // Reference to PropertyConfig by ID
-        /** @var array<array{id: string, rule: string}>|null Config candidates with rules */
+        /** @var array<array{id: string, when: string}>|null Config candidates with expressions */
         public readonly ?array $configCandidates = null,
-        public readonly ?string $defaultConfigCandidate = null,  // Default config ID when no rule matches
+        public readonly null|string|array $defaultConfigCandidate = null,  // Default config ID when no rule matches (empty array for no-op)
         public readonly ?SensitiveLevel $sensitiveLevel = null,  // Sensitivity level for lineage collection
+        public readonly bool $cascade = true,      // Whether this attribute cascades to child classes
     ) {
         // Validation: mapping requires class to be set
         if ($mapping !== null && $class === null) {
@@ -53,16 +54,17 @@ final class Property
         // Validation: configCandidates and defaultConfigCandidate must both be present or both absent
         if (($configCandidates === null) !== ($defaultConfigCandidate === null)) {
             throw new \InvalidArgumentException(
-                'Property: configCandidates and defaultConfigCandidate must both be present or both absent'
+                'Property: configCandidates and defaultConfigCandidate must both be present or both absent. '
+                . 'Set defaultConfigCandidate to an empty array [] if you intentionally want no default action.'
             );
         }
 
-        // Validation: each configCandidate must have 'id' and 'rule' keys
+        // Validation: each configCandidate must have 'id' and 'when' keys
         if ($configCandidates !== null) {
             foreach ($configCandidates as $index => $candidate) {
-                if (!is_array($candidate) || !isset($candidate['id']) || !isset($candidate['rule'])) {
+                if (!is_array($candidate) || !isset($candidate['id']) || !isset($candidate['when'])) {
                     throw new \InvalidArgumentException(
-                        sprintf('Property: each configCandidate must be an array with "id" and "rule" keys (index %d)', $index)
+                        sprintf('Property: each configCandidate must be an array with "id" and "when" keys (index %d)', $index)
                     );
                 }
             }

--- a/src/Attribute/PropertyConfig.php
+++ b/src/Attribute/PropertyConfig.php
@@ -29,6 +29,7 @@ final class PropertyConfig
         public readonly ?string $noExpand = null,
         public readonly ?array $mapping = null,
         public readonly ?SensitiveLevel $sensitiveLevel = null,  // Sensitivity level for lineage collection
+        public readonly bool $cascade = true,                    // Whether this config cascades to child classes
     ) {
         // Validation: mapping requires class to be set
         if ($mapping !== null && $class === null) {

--- a/src/Attribute/PropertyConfigStore.php
+++ b/src/Attribute/PropertyConfigStore.php
@@ -24,11 +24,13 @@ final class PropertyConfigStore
 {
     /** @var array<string, PropertyConfig> Indexed by config ID */
     public readonly array $configs;
+    public readonly bool $cascade;  // Whether this store cascades to child classes
 
     /**
      * @param PropertyConfig[] $configs Array of PropertyConfig instances
+     * @param bool $cascade Whether this store cascades to child classes
      */
-    public function __construct(array $configs)
+    public function __construct(array $configs, bool $cascade = true)
     {
         $indexed = [];
         foreach ($configs as $config) {
@@ -41,5 +43,6 @@ final class PropertyConfigStore
             $indexed[$config->id] = $config;
         }
         $this->configs = $indexed;
+        $this->cascade = $cascade;
     }
 }

--- a/src/Attribute/PropertyHydratingHook.php
+++ b/src/Attribute/PropertyHydratingHook.php
@@ -23,5 +23,6 @@ final class PropertyHydratingHook
         public readonly string $after_hydrate_object = '',   // Method to call after hydration (receives ?object $object, array $rawData)
         public readonly ?string $class = null,               // Optional: external class/service to call
         public readonly array $args = [],                    // Arguments to pass (supports ##object, expr())
+        public readonly bool $cascade = true,                // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/PropertyInstantiatingHook.php
+++ b/src/Attribute/PropertyInstantiatingHook.php
@@ -22,5 +22,6 @@ final class PropertyInstantiatingHook
         public readonly string $after_instantiating = '', // Method to call after object instantiation
         public readonly ?string $class = null,            // Optional: external class/service to call
         public readonly array $args = [],                 // Arguments to pass (supports ##object, expr())
+        public readonly bool $cascade = true,             // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/PropertySettingHook.php
+++ b/src/Attribute/PropertySettingHook.php
@@ -23,5 +23,6 @@ final class PropertySettingHook
         public readonly string $after_set_property = '',   // Method to call after setting property
         public readonly ?string $class = null,             // Optional: external class/service to call
         public readonly array $args = [],                  // Arguments to pass (supports ##object, #property, expr())
+        public readonly bool $cascade = true,              // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/Setter.php
+++ b/src/Attribute/Setter.php
@@ -24,5 +24,6 @@ final class Setter
     public function __construct(
         public readonly ?string $name = null,  // Method name
         public readonly string $type = self::TYPE_SETTER,  // 'setter' or 'adder'
+        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
     ) {}
 }

--- a/src/Attribute/SinglePropDataSource.php
+++ b/src/Attribute/SinglePropDataSource.php
@@ -35,6 +35,15 @@ final class SinglePropDataSource
         public readonly int $priority = 0,
         /** @var array<string, SensitiveLevel> Keys to mark as sensitive (exact name or regex pattern) */
         public readonly array $sensitiveKeys = [],
+        public readonly ?string $methodAlias = null,  // Reference to a MethodAlias by name
+        public readonly bool $cascade = true,         // Whether this attribute cascades to child classes
         // NO loadingScope/loadingScopeKeys - single property only
-    ) {}
+    ) {
+        // Validation: methodAlias is mutually exclusive with class and method
+        if ($methodAlias !== null && ($class !== null || $method !== '')) {
+            throw new \InvalidArgumentException(
+                'SinglePropDataSource: methodAlias is mutually exclusive with class and method'
+            );
+        }
+    }
 }

--- a/src/Attribute/SkipAllProperties.php
+++ b/src/Attribute/SkipAllProperties.php
@@ -18,4 +18,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class SkipAllProperties
 {
+    public function __construct(
+        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
+    ) {}
 }

--- a/src/Attribute/SkipProperty.php
+++ b/src/Attribute/SkipProperty.php
@@ -18,4 +18,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class SkipProperty
 {
+    public function __construct(
+        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
+    ) {}
 }

--- a/src/Exception/MethodAliasNotFoundException.php
+++ b/src/Exception/MethodAliasNotFoundException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of DataMapper.
+ *
+ * Copyright 2025 kassko 
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE and NOTICE files that were distributed with this source code.
+ */
+
+namespace Kassko\DataMapper\Exception;
+
+/**
+ * Exception thrown when a referenced MethodAlias is not found.
+ */
+class MethodAliasNotFoundException extends \RuntimeException
+{
+    public function __construct(string $aliasName, string $className)
+    {
+        parent::__construct(sprintf(
+            'MethodAlias "%s" not found in class "%s" or its parent classes. '
+            . 'Make sure to define the MethodAlias attribute on the class.',
+            $aliasName,
+            $className
+        ));
+    }
+}

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -692,10 +692,10 @@ class Loader implements LoaderInterface
     }
 
     /**
-     * Load a property with candidates (rule-based source selection)
+     * Load a property with candidates (expression-based source selection)
      *
-     * Evaluates each candidate's rule expression and uses the first matching source.
-     * If no rule matches, uses defaultCandidate.
+     * Evaluates each candidate's 'when' expression and uses the first matching source.
+     * If no expression matches, uses defaultCandidate.
      * If a candidate defines its own priority, it takes precedence over the base priority.
      *
      * @param object $object
@@ -710,7 +710,7 @@ class Loader implements LoaderInterface
         $defaultCandidate = $dataSourceRef->defaultCandidate;
         $dataSourceMap = $this->attributeReader->getDataSourceMap($object);
         
-        // Create expression parser for evaluating rules
+        // Create expression parser for evaluating expressions
         $expressionParser = new ExpressionParser(
             $this->sourceFunctionProviders[$object] ?? new SourceFunctionProvider(
                 fn(string $sourceId) => $this->executeDataSourceById($object, $sourceId)
@@ -725,10 +725,10 @@ class Loader implements LoaderInterface
         // Find the first matching candidate
         $electedCandidate = null;
         foreach ($candidates as $candidate) {
-            $rule = $candidate['rule'];
+            $when = $candidate['when'];
             
-            // Evaluate the rule expression
-            $result = $expressionParser->resolveArgs([$rule], $object, $propertyLoader)[0];
+            // Evaluate the 'when' expression
+            $result = $expressionParser->resolveArgs([$when], $object, $propertyLoader)[0];
             
             if ($result === true || $result === 'true' || $result === 1 || $result === '1') {
                 $electedCandidate = $candidate;
@@ -950,7 +950,7 @@ class Loader implements LoaderInterface
         $this->setPropertyValue($object, $property, $data);
         $this->registerPropertyHydration($object, $propertyName, $sourcePriority, $sourceSignature);
         $this->loadedProperties[$object][$propertyName] = true;
-        $this->handleContextAttribute($property, $data);
+        $this->handleContextAttribute($property, $data, $object);
         
         // Record property hydration for lineage
         $this->lineageCollector?->recordPropertyHydration(
@@ -1313,7 +1313,7 @@ class Loader implements LoaderInterface
             if (!empty($mappedData)) {
                 $value = $this->applyRecursiveHydration($property, $mappedData, $currentDepth, $object);
                 $this->setPropertyValue($object, $property, $value);
-                $this->handleContextAttribute($property, $value);
+                $this->handleContextAttribute($property, $value, $object);
             }
             return;
         }
@@ -1340,7 +1340,7 @@ class Loader implements LoaderInterface
         $this->setPropertyValue($object, $property, $value);
         
         // Handle Context attribute
-        $this->handleContextAttribute($property, $value);
+        $this->handleContextAttribute($property, $value, $object);
     }
 
     /**
@@ -1368,7 +1368,7 @@ class Loader implements LoaderInterface
         $this->setPropertyValue($object, $property, $value);
         
         // Handle Context attribute
-        $this->handleContextAttribute($property, $value);
+        $this->handleContextAttribute($property, $value, $object);
     }
 
     /**
@@ -1523,26 +1523,26 @@ class Loader implements LoaderInterface
     }
 
     /**
-     * Resolve property configuration from configCandidates based on rule evaluation
+     * Resolve property configuration from configCandidates based on 'when' expression evaluation
      *
      * @param Property $propertyAttr The Property attribute with configCandidates
      * @param PropertyConfigStore $configStore The store containing all configs
-     * @param array $rawDataItem Raw data to evaluate rules against
-     * @return PropertyConfig|null
+     * @param array $rawDataItem Raw data to evaluate expressions against
+     * @return PropertyConfig|null Returns null for no-op (empty array defaultConfigCandidate)
      */
     private function resolvePropertyConfig(Property $propertyAttr, PropertyConfigStore $configStore, array $rawDataItem): ?PropertyConfig
     {
-        // Create a temporary expression parser for rule evaluation
+        // Create a temporary expression parser for expression evaluation
         $sourceFunctionProvider = new SourceFunctionProvider(fn() => null);
         $expressionParser = new ExpressionParser($sourceFunctionProvider, $this->serviceResolver);
         $expressionParser->setRawData($rawDataItem);
         
         foreach ($propertyAttr->configCandidates as $candidate) {
-            $rule = $candidate['rule'];
+            $when = $candidate['when'];
             $configId = $candidate['id'];
             
             // Check if it's an expression
-            if (preg_match('/^expr\((.+)\)$/s', $rule, $matches)) {
+            if (preg_match('/^expr\((.+)\)$/s', $when, $matches)) {
                 $expression = $matches[1];
                 
                 // Parse and evaluate the expression
@@ -1587,9 +1587,16 @@ class Loader implements LoaderInterface
             }
         }
         
-        // No rule matched, use defaultConfigCandidate
+        // No expression matched, use defaultConfigCandidate
         if ($propertyAttr->defaultConfigCandidate !== null) {
-            return $configStore->configs[$propertyAttr->defaultConfigCandidate] ?? null;
+            // Handle no-op: empty array means intentionally do nothing
+            if (is_array($propertyAttr->defaultConfigCandidate) && empty($propertyAttr->defaultConfigCandidate)) {
+                return null;  // No-op: don't apply any config
+            }
+            // String config ID
+            if (is_string($propertyAttr->defaultConfigCandidate)) {
+                return $configStore->configs[$propertyAttr->defaultConfigCandidate] ?? null;
+            }
         }
         
         return null;
@@ -1681,7 +1688,7 @@ class Loader implements LoaderInterface
             $this->setPropertyValue($object, $property, $value);
             
             // Handle Context attribute
-            $this->handleContextAttribute($property, $value);
+            $this->handleContextAttribute($property, $value, $object);
         }
         
         // Execute after_hydrate_object hooks (after hydration, before property setting hooks)
@@ -1759,8 +1766,9 @@ class Loader implements LoaderInterface
      *
      * @param ReflectionProperty $property
      * @param mixed $value
+     * @param object|null $object The current object being hydrated (for evaluating method-based context)
      */
-    private function handleContextAttribute(ReflectionProperty $property, mixed $value): void
+    private function handleContextAttribute(ReflectionProperty $property, mixed $value, ?object $object = null): void
     {
         $contexts = $this->attributeReader->readAllContexts($property);
         
@@ -1773,18 +1781,82 @@ class Loader implements LoaderInterface
         
         // Set all context values from all Context attributes
         foreach ($contexts as $context) {
-            foreach ($context->values as $key => $contextValue) {
-                ContextRegistry::set($key, $contextValue);
-                
-                // Record context set for lineage
-                $this->lineageCollector?->recordContextSet(
-                    $objectClass,
-                    $propertyName,
-                    $key,
-                    $contextValue
-                );
-            }
+            $this->processContextEntries($context->entries, $objectClass, $propertyName, $object);
         }
+    }
+
+    /**
+     * Process context entries and set them in the ContextRegistry.
+     * 
+     * @param array $entries The context entries to process
+     * @param string $objectClass The class name for lineage tracking
+     * @param string $propertyName The property name for lineage tracking
+     * @param object|null $object The current object for method-based context
+     */
+    private function processContextEntries(array $entries, string $objectClass, string $propertyName, ?object $object = null): void
+    {
+        foreach ($entries as $entry) {
+            $key = $entry['key'];
+            $contextValue = null;
+            
+            if (array_key_exists('value', $entry)) {
+                // Simple key-value entry
+                $contextValue = $entry['value'];
+            } elseif (isset($entry['class']) && isset($entry['method'])) {
+                // Method-based entry - call the method to get the value
+                $contextValue = $this->evaluateContextMethodEntry($entry, $object);
+            }
+            
+            ContextRegistry::set($key, $contextValue);
+            
+            // Record context set for lineage
+            $this->lineageCollector?->recordContextSet(
+                $objectClass,
+                $propertyName,
+                $key,
+                $contextValue
+            );
+        }
+    }
+
+    /**
+     * Evaluate a method-based context entry.
+     * 
+     * @param array $entry The context entry with 'class', 'method', and optionally 'args'
+     * @param object|null $object The current object being hydrated
+     * @return mixed The result of the method call
+     */
+    private function evaluateContextMethodEntry(array $entry, ?object $object): mixed
+    {
+        $class = $entry['class'];
+        $method = $entry['method'];
+        $args = $entry['args'] ?? [];
+        
+        // Handle ##object reference
+        if ($class === '##object') {
+            if ($object === null) {
+                throw new \RuntimeException('Context entry uses ##object but no object is available');
+            }
+            $service = $object;
+        } else {
+            // Resolve the service
+            $service = $this->serviceResolver->resolve($class);
+        }
+        
+        // Resolve arguments
+        if (!empty($args) && $object !== null) {
+            $expressionParser = new ExpressionParser(
+                $this->sourceFunctionProviders[$object] ?? new SourceFunctionProvider(
+                    fn(string $sourceId) => $this->executeDataSourceById($object, $sourceId)
+                ),
+                $this->serviceResolver
+            );
+            $expressionParser->setCurrentObject($object);
+            $propertyLoader = fn(string $propName) => $this->loadProperty($object, $propName);
+            $args = $expressionParser->resolveArgs($args, $object, $propertyLoader);
+        }
+        
+        return $service->$method(...$args);
     }
 
     /**

--- a/src/Metadata/AttributeReader.php
+++ b/src/Metadata/AttributeReader.php
@@ -18,6 +18,7 @@ use Kassko\DataMapper\Attribute\DataSource;
 use Kassko\DataMapper\Attribute\DataSourceRef;
 use Kassko\DataMapper\Attribute\DataSourcesStore;
 use Kassko\DataMapper\Attribute\Getter;
+use Kassko\DataMapper\Attribute\MethodAlias;
 use Kassko\DataMapper\Attribute\PropertySettingHook;
 use Kassko\DataMapper\Attribute\PropertyInstantiatingHook;
 use Kassko\DataMapper\Attribute\PropertyHydratingHook;
@@ -184,6 +185,71 @@ class AttributeReader
         }
         
         return array_map(fn($attr) => $attr->newInstance(), $attributes);
+    }
+
+    /**
+     * Read all Context attributes from a class (supports IS_REPEATABLE)
+     *
+     * @param ReflectionClass $reflectionClass
+     * @return Context[]
+     */
+    public function readClassContexts(ReflectionClass $reflectionClass): array
+    {
+        $attributes = $reflectionClass->getAttributes(Context::class);
+        
+        if (empty($attributes)) {
+            return [];
+        }
+        
+        return array_map(fn($attr) => $attr->newInstance(), $attributes);
+    }
+
+    /**
+     * Read all MethodAlias attributes from a class (supports IS_REPEATABLE)
+     *
+     * @param ReflectionClass $reflectionClass
+     * @return MethodAlias[]
+     */
+    public function readMethodAliases(ReflectionClass $reflectionClass): array
+    {
+        $attributes = $reflectionClass->getAttributes(MethodAlias::class);
+        
+        if (empty($attributes)) {
+            return [];
+        }
+        
+        return array_map(fn($attr) => $attr->newInstance(), $attributes);
+    }
+
+    /**
+     * Get MethodAlias map indexed by alias name (with cascading from parent classes)
+     *
+     * @param ReflectionClass $reflectionClass
+     * @return array<string, MethodAlias>
+     */
+    public function getMethodAliasMap(ReflectionClass $reflectionClass): array
+    {
+        $allAliases = [];
+        $classHierarchy = $this->getClassHierarchy($reflectionClass);
+        
+        // Process from top (oldest ancestor) to bottom (current class)
+        // so that child classes override parent aliases with same name
+        $classHierarchy = array_reverse($classHierarchy);
+        
+        foreach ($classHierarchy as $classInfo) {
+            $class = $classInfo['class'];
+            
+            $aliases = $this->readMethodAliases($class);
+            foreach ($aliases as $alias) {
+                // Check cascade for parent classes
+                if (!$classInfo['isCurrent'] && !$alias->cascade) {
+                    continue;  // Skip non-cascading aliases from parent classes
+                }
+                $allAliases[$alias->name] = $alias;
+            }
+        }
+        
+        return $allAliases;
     }
 
     /**

--- a/tests/Fixtures/Cascade/ChildContainer.php
+++ b/tests/Fixtures/Cascade/ChildContainer.php
@@ -31,9 +31,9 @@ class ChildContainer extends BaseContainer
     
     #[Property(
         configCandidates: [
-            ['id' => 'childConfig', 'rule' => "expr(rawDataItemExists('childType'))"],
-            ['id' => 'parentConfig', 'rule' => "expr(rawDataItemExists('parentType'))"],
-            ['id' => 'traitConfig', 'rule' => "expr(rawDataItemExists('traitType'))"],
+            ['id' => 'childConfig', 'when' => "expr(rawDataItemExists('childType'))"],
+            ['id' => 'parentConfig', 'when' => "expr(rawDataItemExists('parentType'))"],
+            ['id' => 'traitConfig', 'when' => "expr(rawDataItemExists('traitType'))"],
         ],
         defaultConfigCandidate: 'sharedConfig'
     )]

--- a/tests/Fixtures/Garage.php
+++ b/tests/Fixtures/Garage.php
@@ -37,8 +37,8 @@ class Garage
     #[SinglePropDataSource(class: GarageDataSource::class, method: 'getCars', args: ['#id'])]
     #[Property(
         configCandidates: [
-            ['id' => 'gasolineCar', 'rule' => "expr(rawDataItemExists('gasolineKind'))"],
-            ['id' => 'electricCar', 'rule' => "expr(rawDataItemExists('energyProvider'))"],
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasolineKind'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energyProvider'))"],
         ],
         defaultConfigCandidate: 'gasolineCar'
     )]

--- a/tests/Integration/ContextIntegrationTest.php
+++ b/tests/Integration/ContextIntegrationTest.php
@@ -66,7 +66,7 @@ class ContextIntegrationTest extends TestCase
         class {
             use LoadableTrait;
 
-            #[Context(role: 'admin', level: 'high')]
+            #[Context(['key' => 'role', 'value' => 'admin'], ['key' => 'level', 'value' => 'high'])]
             #[DataSourceRef(id: 'source')]
             private ?string $name = null;
 

--- a/tests/Integration/DataSourceRefCandidatesTest.php
+++ b/tests/Integration/DataSourceRefCandidatesTest.php
@@ -71,7 +71,7 @@ class DataSourceRefCandidatesTest extends TestCase
 
             #[DataSourceRef(
                 candidates: [
-                    ['id' => 'newFeatureSource', 'rule' => "expr(context('new_feature_enabled'))"],
+                    ['id' => 'newFeatureSource', 'when' => "expr(context('new_feature_enabled'))"],
                 ],
                 defaultCandidate: ['id' => 'oldFeatureSource']
             )]
@@ -123,7 +123,7 @@ class DataSourceRefCandidatesTest extends TestCase
 
             #[DataSourceRef(
                 candidates: [
-                    ['id' => 'newFeatureSource', 'rule' => "expr(context('new_feature_enabled'))"],
+                    ['id' => 'newFeatureSource', 'when' => "expr(context('new_feature_enabled'))"],
                 ],
                 defaultCandidate: ['id' => 'oldFeatureSource']
             )]
@@ -167,7 +167,7 @@ class DataSourceRefCandidatesTest extends TestCase
 
             #[DataSourceRef(
                 candidates: [
-                    ['id' => 'testSource', 'rule' => "expr(context('use_high_priority'))", 'priority' => 50],
+                    ['id' => 'testSource', 'when' => "expr(context('use_high_priority'))", 'priority' => 50],
                 ],
                 defaultCandidate: ['id' => 'fallbackSource'],
                 priority: 10
@@ -222,7 +222,7 @@ class DataSourceRefCandidatesTest extends TestCase
 
             #[DataSourceRef(
                 candidates: [
-                    ['id' => 'primarySource', 'rule' => "expr(context('never_matches'))"],
+                    ['id' => 'primarySource', 'when' => "expr(context('never_matches'))"],
                 ],
                 defaultCandidate: ['id' => 'fallbackSource']
             )]
@@ -267,7 +267,7 @@ class DataSourceRefCandidatesTest extends TestCase
 
             #[DataSourceRef(
                 candidates: [
-                    ['id' => 'sourceA', 'rule' => "expr(context('feature_flag'))"],
+                    ['id' => 'sourceA', 'when' => "expr(context('feature_flag'))"],
                 ],
                 defaultCandidate: ['id' => 'sourceB']
             )]

--- a/tests/Unit/Attribute/ContextTest.php
+++ b/tests/Unit/Attribute/ContextTest.php
@@ -36,10 +36,10 @@ class ContextTest extends TestCase
         ContextRegistry::clear();
     }
 
-    public function testContextAttributeWithNamedArguments(): void
+    public function testContextAttributeWithArrayEntries(): void
     {
         $testClass = new class {
-            #[Context(key1: 'value1', key2: 'value2')]
+            #[Context(['key' => 'key1', 'value' => 'value1'], ['key' => 'key2', 'value' => 'value2'])]
             private ?string $name = null;
         };
 
@@ -49,7 +49,11 @@ class ContextTest extends TestCase
         $context = $this->reader->readContext($property);
 
         $this->assertInstanceOf(Context::class, $context);
-        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], $context->values);
+        $this->assertCount(2, $context->entries);
+        $this->assertEquals('key1', $context->entries[0]['key']);
+        $this->assertEquals('value1', $context->entries[0]['value']);
+        $this->assertEquals('key2', $context->entries[1]['key']);
+        $this->assertEquals('value2', $context->entries[1]['value']);
     }
 
     public function testContextAttributeNotPresentReturnsNull(): void

--- a/tests/Unit/Attribute/DataSourceRefValidationTest.php
+++ b/tests/Unit/Attribute/DataSourceRefValidationTest.php
@@ -106,8 +106,8 @@ class DataSourceRefValidationTest extends TestCase
     {
         $ref = new DataSourceRef(
             candidates: [
-                ['id' => 'sourceA', 'rule' => 'expr(true)'],
-                ['id' => 'sourceB', 'rule' => 'expr(false)', 'priority' => 15],
+                ['id' => 'sourceA', 'when' => 'expr(true)'],
+                ['id' => 'sourceB', 'when' => 'expr(false)', 'priority' => 15],
             ],
             defaultCandidate: ['id' => 'sourceC']
         );
@@ -124,7 +124,7 @@ class DataSourceRefValidationTest extends TestCase
         $this->expectExceptionMessage('DataSourceRef: candidates and defaultCandidate must both be present or both absent');
 
         new DataSourceRef(candidates: [
-            ['id' => 'sourceA', 'rule' => 'expr(true)'],
+            ['id' => 'sourceA', 'when' => 'expr(true)'],
         ]);
     }
 
@@ -146,7 +146,7 @@ class DataSourceRefValidationTest extends TestCase
 
         new DataSourceRef(
             id: 'sourceA',
-            candidates: [['id' => 'sourceB', 'rule' => 'expr(true)']],
+            candidates: [['id' => 'sourceB', 'when' => 'expr(true)']],
             defaultCandidate: ['id' => 'sourceC']
         );
     }
@@ -158,7 +158,7 @@ class DataSourceRefValidationTest extends TestCase
 
         new DataSourceRef(
             providers: ['providerA'],
-            candidates: [['id' => 'sourceB', 'rule' => 'expr(true)']],
+            candidates: [['id' => 'sourceB', 'when' => 'expr(true)']],
             defaultCandidate: ['id' => 'sourceC']
         );
     }
@@ -170,7 +170,7 @@ class DataSourceRefValidationTest extends TestCase
 
         new DataSourceRef(
             candidates: [
-                ['rule' => 'expr(true)'],
+                ['when' => 'expr(true)'],
             ],
             defaultCandidate: ['id' => 'sourceB']
         );
@@ -179,7 +179,7 @@ class DataSourceRefValidationTest extends TestCase
     public function testCandidatesMustHaveRule(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('candidate at index 0 must have a "rule" key');
+        $this->expectExceptionMessage('candidate at index 0 must have a "when" key');
 
         new DataSourceRef(
             candidates: [
@@ -196,7 +196,7 @@ class DataSourceRefValidationTest extends TestCase
 
         new DataSourceRef(
             candidates: [
-                ['id' => 'sourceA', 'rule' => 'expr(true)'],
+                ['id' => 'sourceA', 'when' => 'expr(true)'],
             ],
             defaultCandidate: ['priority' => 10]
         );
@@ -206,7 +206,7 @@ class DataSourceRefValidationTest extends TestCase
     {
         $ref = new DataSourceRef(
             candidates: [
-                ['id' => 'sourceA', 'rule' => 'expr(true)', 'priority' => 20],
+                ['id' => 'sourceA', 'when' => 'expr(true)', 'priority' => 20],
             ],
             defaultCandidate: ['id' => 'sourceB'],
             priority: 5
@@ -222,7 +222,7 @@ class DataSourceRefValidationTest extends TestCase
 
         new DataSourceRef(
             candidates: [
-                ['id' => 'sourceA', 'rule' => 'expr(true)'],
+                ['id' => 'sourceA', 'when' => 'expr(true)'],
             ],
             defaultCandidate: ['id' => 'sourceB'],
             fallbacks: ['sourceC']
@@ -236,7 +236,7 @@ class DataSourceRefValidationTest extends TestCase
 
         new DataSourceRef(
             candidates: [
-                ['id' => 'sourceA', 'rule' => 'expr(true)'],
+                ['id' => 'sourceA', 'when' => 'expr(true)'],
             ],
             defaultCandidate: ['id' => 'sourceB'],
             exceptionOnNoValidFallback: 'SomeException'


### PR DESCRIPTION
# Pull Request: Major Feature Enhancements

## Summary

This PR introduces several significant enhancements to the DataMapper library, improving configurability, expressiveness, and developer experience.

## Changes

### 1. Configurable Attribute Cascading (`cascade` field)

All PHP 8 attributes now include a boolean `cascade` field (default: `true`) that controls whether the attribute is inherited by child classes.

**Affected Attributes:**
- `Property`, `DataSource`, `SinglePropDataSource`, `MultiPropDataSource`
- `DataSourcesStore`, `PropertyConfig`, `PropertyConfigStore`
- `DataSourceRef`, `Context`, `MethodAlias`
- `Getter`, `Setter`, `Loading`, `Needs`
- `CustomHydrator`, `Param`
- `PropertySettingHook`, `PropertyHydratingHook`, `PropertyInstantiatingHook`
- `SkipAllProperties`, `KeepAllProperties`, `SkipProperty`, `KeepProperty`

**Example:**
```php
#[DataSourcesStore([
    new SinglePropDataSource(id: 'parentSource', class: ParentDataSource::class, method: 'getData', cascade: false),
])]
abstract class BaseEntity
{
    // parentSource will NOT be available in child classes
}
```

### 2. Renamed `rule` to `when`

The field `rule` has been renamed to `when` in all candidate-based expressions for better clarity:

**Before:**
```php
['id' => 'config', 'rule' => "expr(rawDataItemExists('key'))"]
```

**After:**
```php
['id' => 'config', 'when' => "expr(rawDataItemExists('key'))"]
```

**Affected areas:**
- `Property.configCandidates`
- `DataSourceRef.candidates`

### 3. MethodAlias Attribute

New `#[MethodAlias]` attribute for defining reusable method references at class level:

```php
#[MethodAlias(name: 'fetchPersonData', class: 'person.data_source', method: 'fetchData')]
class Person
{
    #[DataSource(methodAlias: 'fetchPersonData', args: ['#id'])]
    private ?string $email = null;
}
```

**Features:**
- Class-level attribute, repeatable
- Supports `##object` to reference methods on the current object
- `methodAlias` is mutually exclusive with `class`/`method` in DataSource attributes
- Throws `MethodAliasNotFoundException` when referenced alias doesn't exist
- Methods become available in expression language

### 4. Enhanced Context Attribute

The `Context` attribute has been redesigned to support:

**Simple key-value pairs:**
```php
#[Context(['key' => 'myKey', 'value' => 'myValue'])]
```

**Method result capture:**
```php
#[Context(
    ['key' => 'personData', 'class' => 'person.service', 'method' => 'fetchData', 'args' => ['#id']],
)]
```

**Chained dependencies:**
```php
#[Context(
    ['key' => 'baseData', 'class' => 'base.source', 'method' => 'fetch', 'args' => ['#id']],
    ['key' => 'derivedData', 'class' => 'other.source', 'method' => 'process', 'args' => ["expr(context('baseData'))"]],
)]
```

**Context Levels:**
- Application context: Shared across all hydration sessions
- Hydration context: Shared within one hydration session
- Object instance context: Specific to one object instance

### 5. No-Op Default Config Candidate

`defaultConfigCandidate` now accepts an empty array `[]` to indicate "do nothing" when no candidate matches:

```php
#[Property(
    configCandidates: [
        ['id' => 'premium', 'when' => "expr(context('is_premium'))"],
    ],
    defaultConfigCandidate: []  // No-op: intentionally do nothing
)]
```

The validation message now includes guidance: *"Set defaultConfigCandidate to an empty array [] if you intentionally want no default action."*

### 6. Expression Language Documentation

Created comprehensive documentation at `docs/concepts/ExpressionLanguage.md` covering:
- Basic property references (`#propertyName`, `##object`)
- Expression functions (`expr()`, `context()`, `source()`, etc.)
- Conditional expressions with `when`
- Context with method results
- MethodAlias integration
- Best practices

## Breaking Changes

1. **Context API changed**: Named arguments syntax is no longer supported. Use the new array-based format.
2. **`rule` renamed to `when`**: All `configCandidates` and `candidates` arrays must use `when` instead of `rule`.

## Files Changed

### New Files
- `src/Attribute/MethodAlias.php`
- `src/Exception/MethodAliasNotFoundException.php`
- `docs/attributes/MethodAlias.md`
- `docs/concepts/ExpressionLanguage.md`

### Modified Attributes
- All attribute classes in `src/Attribute/`

### Updated Documentation
- `README.md`
- `EXAMPLE.md`
- `docs/attributes/Context.md`
- `docs/attributes/Property.md`
- `docs/attributes/PropertyConfig.md`
- `docs/attributes/PropertyConfigStore.md`
- `docs/attributes/DataSourceRef.md`
- `docs/concepts/AttributeCascading.md`

### Updated Tests
- `tests/Unit/Attribute/ContextTest.php`
- `tests/Unit/Attribute/DataSourceRefValidationTest.php`
- `tests/Integration/ContextIntegrationTest.php`
- `tests/Integration/DataSourceRefCandidatesTest.php`
- `tests/Fixtures/Cascade/ChildContainer.php`
- `tests/Fixtures/Garage.php`

## Testing

All 288 tests pass successfully.

## Backward Compatibility

**Not maintained** - This is an alpha version, and changes are not backward compatible. Users must:
1. Replace `rule` with `when` in all candidate arrays
2. Update Context usage to the new array-based format
