### PR TITLE
Feat/conditional property keeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,8 +562,8 @@ class Garage
 {
     #[Property(
         configCandidates: [
-            ['id' => 'gasolineCar', 'rule' => "expr(rawDataItemExists('gasoline_kind'))"],
-            ['id' => 'electricCar', 'rule' => "expr(rawDataItemExists('energy_provider'))"],
+            ['id' => 'gasolineCar', 'when' => "expr(rawDataItemExists('gasoline_kind'))"],
+            ['id' => 'electricCar', 'when' => "expr(rawDataItemExists('energy_provider'))"],
         ],
         defaultConfigCandidate: 'gasolineCar'
     )]
@@ -573,16 +573,44 @@ class Garage
 
 #### KeepAllProperties, SkipAllProperties, SkipProperty, KeepProperty
 
-Control property inclusion:
+Control property inclusion with optional conditional expressions:
 
 ```php
 #[SkipAllProperties]
 class Person
 {
-    #[KeepProperty]  // Explicitly include
+    #[KeepProperty]  // Always include
     private ?string $name = null;
     
+    #[KeepProperty(when: "expr(contextKeyExists('show_email'))")]  // Conditionally include
+    private ?string $email = null;
+    
     private ?string $internal = null;  // Excluded
+}
+```
+
+You can also use `SkipProperty` with `when` expression to conditionally skip:
+
+```php
+#[KeepAllProperties]  // Default behavior
+class Entity
+{
+    private ?string $firstName = null;   // Hydrated
+    private ?string $lastName = null;    // Hydrated
+    
+    #[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
+    private ?string $email = null;  // Skipped only if 'hide_email' context key exists
+}
+```
+
+And `Property.keepWhen` to conditionally enable the Property attribute:
+
+```php
+#[SkipAllProperties]
+class Entity
+{
+    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    private ?string $name = null;  // Only hydrated if 'include_name' context key exists
 }
 ```
 
@@ -607,8 +635,8 @@ class Container
 {
     #[Property(
         configCandidates: [
-            ['id' => 'premium', 'rule' => "expr(context('shop_quality') === 'premium')"],
-            ['id' => 'regional', 'rule' => "expr(contextKeyExists('region'))"],
+            ['id' => 'premium', 'when' => "expr(context('shop_quality') === 'premium')"],
+            ['id' => 'regional', 'when' => "expr(contextKeyExists('region'))"],
         ],
         defaultConfigCandidate: 'default'
     )]
@@ -640,10 +668,11 @@ See [Context](docs/attributes/Context.md) for detailed usage.
 | Function | Description |
 |----------|-------------|
 | `source('id')` | Get DataSource result |
-| `service('id')` | Resolve service |
+| `service('id')` or `serviceId('id')` | Resolve service |
 | `context('key')` | Get context value (null if missing, logs warning) |
 | `contextKeyExists('key')` | Check if context key exists |
-| `envVar('KEY')` | Environment variable |
+| `envVar('KEY')` | Get environment variable |
+| `envVarExists('KEY')` | Check if environment variable exists |
 | `object()` | Current object |
 | `parentObject()` | Parent object |
 | `rawDataItem('key')` | Raw data value |

--- a/docs/attributes/KeepProperty.md
+++ b/docs/attributes/KeepProperty.md
@@ -2,7 +2,16 @@
 
 Marks a property for hydration even when the class has `SkipAllProperties`.
 
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `when` | `string\|null` | `null` | Optional expression to conditionally keep the property. If null, property is always kept. If expression evaluates to true, property is kept. If false, property is not kept. |
+| `cascade` | `bool` | `true` | Whether this attribute cascades to child classes |
+
 ## Usage
+
+### Basic Usage
 
 ```php
 use Kassko\DataMapper\Attribute\SkipAllProperties;
@@ -18,8 +27,55 @@ class Entity
 }
 ```
 
+### Conditional Keep with Expression
+
+```php
+use Kassko\DataMapper\Attribute\SkipAllProperties;
+use Kassko\DataMapper\Attribute\KeepProperty;
+
+#[SkipAllProperties]
+class Entity
+{
+    #[KeepProperty]
+    private ?string $id = null;  // Always hydrated
+    
+    #[KeepProperty(when: "expr(contextKeyExists('include_email'))")]
+    private ?string $email = null;  // Hydrated only if 'include_email' context key exists
+    
+    private ?string $temp = null;  // Never hydrated
+}
+```
+
+### Expression Examples
+
+```php
+// Keep based on context key existence
+#[KeepProperty(when: "expr(contextKeyExists('detailed_mode'))")]
+private ?string $details = null;
+
+// Keep based on context value
+#[KeepProperty(when: "expr(context('user_role') === 'admin')")]
+private ?string $adminNotes = null;
+
+// Keep based on environment variable
+#[KeepProperty(when: "expr(envVarExists('DEBUG_MODE'))")]
+private ?string $debugInfo = null;
+
+// Keep based on raw data
+#[KeepProperty(when: "expr(rawDataItemExists('extended_info'))")]
+private ?string $extendedInfo = null;
+```
+
+## Behavior
+
+- If `when` is null (default), the property is **always kept** for hydration
+- If `when` expression evaluates to `true`, the property is kept
+- If `when` expression evaluates to `false`, the `KeepProperty` attribute is treated as absent
+- Non-boolean expression results are coerced to boolean with a warning logged
+
 ## See Also
 
 - [SkipAllProperties](SkipAllProperties.md)
 - [SkipProperty](SkipProperty.md)
 - [KeepAllProperties](KeepAllProperties.md)
+- [Property](Property.md) - for `keepWhen` field

--- a/docs/attributes/Property.md
+++ b/docs/attributes/Property.md
@@ -76,6 +76,32 @@ class Garage
 | `config` | `?string` | No | Reference to a PropertyConfig by ID |
 | `configCandidates` | `?array` | No | Array of config candidates with `when` expressions |
 | `defaultConfigCandidate` | `?string` | No | Default config ID if no rule matches |
+| `keepWhen` | `?string` | No | Expression to conditionally include this Property |
+| `cascade` | `bool` | No (default: true) | Whether this attribute cascades to child classes |
+
+## Conditional Property Inclusion (keepWhen)
+
+Use `keepWhen` to conditionally enable the Property attribute based on runtime context:
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\Attribute\SkipAllProperties;
+
+#[SkipAllProperties]
+class Entity
+{
+    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    private ?string $name = null;  // Only hydrated if 'include_name' context key exists
+    
+    private ?string $temp = null;  // Never hydrated (no Property attribute)
+}
+```
+
+**Behavior:**
+- If `keepWhen` is null (default), Property is always considered present
+- If `keepWhen` expression evaluates to `true`, Property is active
+- If `keepWhen` expression evaluates to `false`, Property is treated as absent
+- Non-boolean results are coerced with a warning logged
 
 ## Validation Rules
 

--- a/docs/attributes/SkipProperty.md
+++ b/docs/attributes/SkipProperty.md
@@ -1,8 +1,17 @@
 # SkipProperty
 
-Excludes a property from hydration.
+Excludes a property from hydration, optionally with a conditional expression.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `when` | `string\|null` | `null` | Optional expression to conditionally skip the property. If null, property is always skipped. If expression evaluates to true, property is skipped. If false, property is not skipped. |
+| `cascade` | `bool` | `true` | Whether this attribute cascades to child classes |
 
 ## Usage
+
+### Basic Usage
 
 ```php
 use Kassko\DataMapper\Attribute\SkipProperty;
@@ -15,6 +24,48 @@ class Entity
     private ?string $internal = null;  // Will NOT be hydrated
 }
 ```
+
+### Conditional Skip with Expression
+
+```php
+use Kassko\DataMapper\Attribute\SkipProperty;
+
+class Entity
+{
+    private ?string $firstName = null;  // Always hydrated
+    private ?string $lastName = null;   // Always hydrated
+    
+    #[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
+    private ?string $email = null;  // Skipped only if 'hide_email' context key exists
+}
+```
+
+### Expression Examples
+
+```php
+// Skip based on context key existence
+#[SkipProperty(when: "expr(contextKeyExists('minimal_mode'))")]
+private ?string $details = null;
+
+// Skip based on context value
+#[SkipProperty(when: "expr(context('user_role') !== 'admin')")]
+private ?string $adminNotes = null;
+
+// Skip based on environment variable
+#[SkipProperty(when: "expr(envVarExists('PRODUCTION'))")]
+private ?string $debugInfo = null;
+
+// Skip based on raw data
+#[SkipProperty(when: "expr(rawDataItemExists('skip_extended'))")]
+private ?string $extendedInfo = null;
+```
+
+## Behavior
+
+- If `when` is null (default), the property is **always skipped**
+- If `when` expression evaluates to `true`, the property is skipped
+- If `when` expression evaluates to `false`, the property is **not skipped** and continues with normal hydration
+- Non-boolean expression results are coerced to boolean with a warning logged
 
 ## See Also
 

--- a/docs/concepts/ExpressionLanguage.md
+++ b/docs/concepts/ExpressionLanguage.md
@@ -107,12 +107,16 @@ Access values from the raw data being used for hydration:
 private array $cars = [];
 ```
 
-### Service Access: `service('service_id')`
+### Service Access: `service('service_id')` or `serviceId('service_id')`
 
 Get a service from the service locator:
 
 ```php
 #[DataSource(args: ["expr(service('my.service'))"])]
+private ?string $data = null;
+
+// Alternative syntax
+#[DataSource(args: ["expr(serviceId('my.service'))"])]
 private ?string $data = null;
 ```
 
@@ -131,13 +135,18 @@ class Person
 }
 ```
 
-### Environment Variables: `envVar('KEY')`
+### Environment Variables: `envVar('KEY')` and `envVarExists('KEY')`
 
 Access environment variables:
 
 ```php
+// Get environment variable value
 #[DataSource(args: ["expr(envVar('API_KEY'))"])]
 private ?string $apiKey = null;
+
+// Check if environment variable exists
+#[SkipProperty(when: "expr(envVarExists('PRODUCTION'))")]
+private ?string $debugInfo = null;
 ```
 
 ### Property Access: `property('propertyName')` and `strictProperty('propertyName')`
@@ -164,7 +173,48 @@ Explicit property access functions:
 
 ## Conditional Expressions with `when`
 
-The `when` key in `configCandidates` and `candidates` allows conditional configuration selection:
+The `when` key in `configCandidates`, `candidates`, and hydration control attributes allows conditional behavior:
+
+### Conditional Property Inclusion/Exclusion
+
+Use `when` in `SkipProperty` and `KeepProperty` to conditionally control hydration:
+
+```php
+use Kassko\DataMapper\Attribute\SkipProperty;
+use Kassko\DataMapper\Attribute\KeepProperty;
+use Kassko\DataMapper\Attribute\SkipAllProperties;
+
+#[KeepAllProperties]  // Default behavior
+class Entity
+{
+    private ?string $firstName = null;   // Always hydrated
+    
+    #[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
+    private ?string $email = null;  // Skipped only if 'hide_email' context key exists
+}
+```
+
+```php
+#[SkipAllProperties]
+class Entity
+{
+    #[KeepProperty(when: "expr(contextKeyExists('include_id'))")]
+    private ?string $id = null;  // Kept only if 'include_id' context key exists
+    
+    private ?string $temp = null;  // Never hydrated
+}
+```
+
+### Conditional Property Attribute with keepWhen
+
+```php
+#[SkipAllProperties]
+class Entity
+{
+    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    private ?string $name = null;  // Property is active only if condition is true
+}
+```
 
 ### PropertyConfig Candidates
 

--- a/docs/history/pull-requests/PR-2026_01_01---14_22_54.md
+++ b/docs/history/pull-requests/PR-2026_01_01---14_22_54.md
@@ -1,0 +1,152 @@
+# Pull Request: Expression Support in Property Hydration Control
+
+## Summary
+
+This PR adds expression support to `KeepProperty`, `SkipProperty`, and `Property` attributes for conditional hydration control. It also refactors the expression language functions for consistency and adds type coercion warnings.
+
+## Changes
+
+### 1. Expression Support in KeepProperty and SkipProperty
+
+Added optional `when` field to `KeepProperty` and `SkipProperty` attributes:
+
+**SkipProperty with conditional skipping:**
+```php
+#[KeepAllProperties]  // Default behavior
+class Entity
+{
+    private ?string $firstName = null;   // Hydrated
+    private ?string $lastName = null;    // Hydrated
+    
+    #[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
+    private ?string $email = null;  // Skipped only if 'hide_email' context key exists
+}
+```
+
+**KeepProperty with conditional keeping:**
+```php
+#[SkipAllProperties]
+class Entity
+{
+    #[KeepProperty(when: "expr(contextKeyExists('include_id'))")]
+    private ?string $id = null;  // Kept only if 'include_id' context key exists
+    
+    private ?string $temp = null;  // Never hydrated
+}
+```
+
+### 2. Property.keepWhen Field
+
+Added `keepWhen` field to `Property` attribute for conditional inclusion:
+
+```php
+#[SkipAllProperties]
+class Entity
+{
+    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    private ?string $name = null;  // Property active only if condition is true
+    
+    private ?string $temp = null;  // Never hydrated
+}
+```
+
+**Behavior:**
+- If `keepWhen` is null (default), Property is always considered present
+- If expression evaluates to `true`, Property is active
+- If expression evaluates to `false`, Property is treated as absent
+
+### 3. ExpressionParser Function Refactoring
+
+**Renamed:**
+- Added `serviceId('id')` as new function name (keeping `service('id')` for compatibility)
+
+**Removed:**
+- `env_var('KEY')` - Removed backward compatibility alias
+
+**Added:**
+- `envVarExists('KEY')` - Check if environment variable exists (returns boolean)
+
+### 4. Type Coercion Warning for `when` Expressions
+
+When a `when` expression returns a non-boolean value, the system:
+1. Logs a warning with severity level
+2. Collects the event in AttributeCascadeCollector if enabled
+3. Coerces the value to boolean and continues
+
+**Warning includes:**
+- Attribute name (SkipProperty, KeepProperty, Property.keepWhen)
+- Property name
+- Class name
+- Expression
+- Original type
+- Coerced boolean value
+
+### 5. New Hydration Decision Flow
+
+Added new methods in Loader:
+- `shouldHydratePropertyWithExpressions()` - Evaluates all `when` expressions
+- `evaluateWhenExpression()` - Evaluates single expression with logging
+
+Updated `AttributeReader.getHydrationDecisionInfo()` to return expression data for Loader evaluation.
+
+## Breaking Changes
+
+1. **`env_var()` removed** - Use `envVar()` instead
+2. No backward compatibility maintained (alpha version)
+
+## Files Changed
+
+### Modified Attributes
+- `src/Attribute/KeepProperty.php` - Added `when` field
+- `src/Attribute/SkipProperty.php` - Added `when` field
+- `src/Attribute/Property.php` - Added `keepWhen` field
+
+### Core Logic
+- `src/Metadata/AttributeReader.php` - Added `getHydrationDecisionInfo()` method
+- `src/Loader/Loader.php` - Added expression evaluation in hydration flow
+- `src/Expression/ExpressionParser.php` - Added `serviceId()`, `envVarExists()`, removed `env_var()`
+- `src/DataCollector/AttributeCascadeCollector.php` - Added `collectTypeCoercion()` method
+- `src/DataCollector/CascadeEvent.php` - Added `TYPE_WHEN_EXPRESSION_TYPE_COERCION` constant
+
+### Tests
+- `tests/Unit/Attribute/KeepPropertyTest.php` - Added tests for `when` expression
+- `tests/Integration/PropertyInclusionTest.php` - Added integration tests for conditional hydration
+- `tests/Integration/ExpressionLanguageExtendedTest.php` - Updated for new function names
+- `tests/Unit/Expression/StrictPropertyTest.php` - Updated for `envVarExists()`
+
+### Documentation
+- `README.md` - Updated expression language documentation
+- `docs/attributes/KeepProperty.md` - Complete rewrite with `when` examples
+- `docs/attributes/SkipProperty.md` - Complete rewrite with `when` examples
+- `docs/attributes/Property.md` - Added `keepWhen` documentation
+- `docs/concepts/ExpressionLanguage.md` - Added conditional hydration section
+
+## Testing
+
+All 300 tests pass successfully.
+
+## Migration Guide
+
+### From env_var() to envVar()
+
+**Before:**
+```php
+#[DataSource(args: ["expr(env_var('API_KEY'))"])]
+```
+
+**After:**
+```php
+#[DataSource(args: ["expr(envVar('API_KEY'))"])]
+```
+
+### Using New Conditional Hydration
+
+```php
+// Old: No conditional support
+#[SkipProperty]
+private ?string $email = null;
+
+// New: Conditional skipping
+#[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
+private ?string $email = null;
+```

--- a/docs/history/summaries/SUMMARY-2026_01_01---14_22_54.md
+++ b/docs/history/summaries/SUMMARY-2026_01_01---14_22_54.md
@@ -1,0 +1,176 @@
+# Work Summary: Expression Support in Property Hydration Control
+
+**Date:** January 1, 2026  
+**Branch:** new-features
+
+## Overview
+
+This work session implemented expression support for conditional property hydration control, refactored expression language functions, and added type coercion warnings for `when` expressions.
+
+## Completed Tasks
+
+### 1. Added `when` Field to KeepProperty and SkipProperty
+
+**Objective:** Enable conditional property inclusion/exclusion based on runtime expressions.
+
+**Implementation:**
+- Added optional `when` field to `KeepProperty` attribute
+- Added optional `when` field to `SkipProperty` attribute
+- Default behavior unchanged when `when` is null
+
+**Files Modified:**
+- `src/Attribute/KeepProperty.php`
+- `src/Attribute/SkipProperty.php`
+
+---
+
+### 2. Added `keepWhen` Field to Property
+
+**Objective:** Allow Property attribute to be conditionally active.
+
+**Implementation:**
+- Added optional `keepWhen` field to `Property` attribute
+- When expression is false, Property is treated as absent
+
+**Files Modified:**
+- `src/Attribute/Property.php`
+
+---
+
+### 3. Expression Evaluation in Loader
+
+**Objective:** Evaluate `when` expressions during hydration.
+
+**Implementation:**
+- Added `shouldHydratePropertyWithExpressions()` method to Loader
+- Added `evaluateWhenExpression()` method for single expression evaluation
+- Updated `AttributeReader.getHydrationDecisionInfo()` to return expression data
+
+**Files Modified:**
+- `src/Loader/Loader.php`
+- `src/Metadata/AttributeReader.php`
+
+---
+
+### 4. ExpressionParser Function Refactoring
+
+**Objective:** Improve function naming consistency.
+
+**Implementation:**
+- Added `serviceId('id')` function (alternative to `service()`)
+- Removed `env_var('KEY')` backward compatibility
+- Added `envVarExists('KEY')` function to check environment variable existence
+
+**Files Modified:**
+- `src/Expression/ExpressionParser.php`
+
+---
+
+### 5. Type Coercion Warning for Non-Boolean Results
+
+**Objective:** Warn when `when` expressions return non-boolean values.
+
+**Implementation:**
+- Added warning logging when type coercion occurs
+- Added `collectTypeCoercion()` method to AttributeCascadeCollector
+- Added `TYPE_WHEN_EXPRESSION_TYPE_COERCION` constant to CascadeEvent
+
+**Files Modified:**
+- `src/Loader/Loader.php`
+- `src/DataCollector/AttributeCascadeCollector.php`
+- `src/DataCollector/CascadeEvent.php`
+
+---
+
+### 6. Updated Tests
+
+**New Tests Added:**
+- `testKeepPropertyWithWhenExpression()` - Unit test for KeepProperty.when
+- `testSkipPropertyWithWhenExpression()` - Unit test for SkipProperty.when
+- `testGetHydrationDecisionInfo()` - Unit test for new AttributeReader method
+- `testSkipPropertyWithWhenExpressionTrue()` - Integration test
+- `testSkipPropertyWithWhenExpressionFalse()` - Integration test
+- `testKeepPropertyWithWhenExpressionTrue()` - Integration test
+- `testKeepPropertyWithWhenExpressionFalse()` - Integration test
+- `testPropertyKeepWhenTrue()` - Integration test
+- `testPropertyKeepWhenFalse()` - Integration test
+- `testEnvVarExistsFunction()` - Integration test
+
+**Updated Tests:**
+- Updated `testEnvVarFunction()` to use `envVar()` instead of `env_var()`
+- Updated `testMultipleExpressionFunctions()` to use `envVar()`
+- Updated `StrictPropertyTest` to test `envVarExists()` instead of backward compatibility
+
+**Files Modified:**
+- `tests/Unit/Attribute/KeepPropertyTest.php`
+- `tests/Integration/PropertyInclusionTest.php`
+- `tests/Integration/ExpressionLanguageExtendedTest.php`
+- `tests/Unit/Expression/StrictPropertyTest.php`
+
+---
+
+### 7. Updated Documentation
+
+**Files Updated:**
+- `README.md` - Expression language table, conditional hydration examples
+- `docs/attributes/KeepProperty.md` - Complete rewrite with `when` examples
+- `docs/attributes/SkipProperty.md` - Complete rewrite with `when` examples
+- `docs/attributes/Property.md` - Added `keepWhen` documentation
+- `docs/concepts/ExpressionLanguage.md` - Added conditional hydration section, updated function docs
+
+---
+
+## Testing Results
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | 300 |
+| Assertions | 704 |
+| Status | ✅ All Passing |
+| Skipped | 2 |
+| New Tests Added | 12 |
+
+---
+
+## Breaking Changes
+
+1. **`env_var()` removed** - Use `envVar()` instead
+2. No backward compatibility maintained (alpha version)
+
+---
+
+## Technical Notes
+
+### Expression Evaluation Flow
+
+1. `hydrateObject()` calls `shouldHydratePropertyWithExpressions()`
+2. `getHydrationDecisionInfo()` collects all `when` expressions
+3. `evaluateWhenExpression()` evaluates each expression
+4. Non-boolean results are coerced with warning logged
+5. Final boolean determines hydration decision
+
+### New Methods Added
+
+**AttributeReader:**
+- `getHydrationDecisionInfo()` - Returns array with all expression data
+
+**Loader:**
+- `shouldHydratePropertyWithExpressions()` - Main entry point
+- `evaluateWhenExpression()` - Evaluates and logs warnings
+
+**AttributeCascadeCollector:**
+- `collectTypeCoercion()` - Collects type coercion events
+
+### Expression Functions Summary
+
+| Function | Purpose |
+|----------|---------|
+| `service('id')` | Get service from locator |
+| `serviceId('id')` | Alias for service() |
+| `envVar('KEY')` | Get environment variable value |
+| `envVarExists('KEY')` | Check if env var exists |
+| `context('key')` | Get context value |
+| `contextKeyExists('key')` | Check if context key exists |
+| `rawDataItem('key')` | Get raw data value |
+| `rawDataItemExists('key')` | Check if raw data key exists |
+| `source('id')` | Get data source result |

--- a/docs/history/summaries/SUMMARY-2026_01_01---14_22_54.md
+++ b/docs/history/summaries/SUMMARY-2026_01_01---14_22_54.md
@@ -1,7 +1,7 @@
 # Work Summary: Expression Support in Property Hydration Control
 
 **Date:** January 1, 2026  
-**Branch:** new-features
+**Branch:** feat/ConditionalPropertyKeeping
 
 ## Overview
 

--- a/src/Attribute/KeepProperty.php
+++ b/src/Attribute/KeepProperty.php
@@ -23,7 +23,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class KeepProperty
 {
+    /**
+     * @param string|null $when Optional expression to conditionally keep the property. 
+     *                          If null (default), property is always kept.
+     *                          If expression evaluates to true, property is kept.
+     *                          If expression evaluates to false, property is not kept.
+     * @param bool $cascade Whether this attribute cascades to child classes
+     */
     public function __construct(
-        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
+        public readonly ?string $when = null,
+        public readonly bool $cascade = true,
     ) {}
 }

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -31,6 +31,13 @@ final class Property
         public readonly null|string|array $defaultConfigCandidate = null,  // Default config ID when no rule matches (empty array for no-op)
         public readonly ?SensitiveLevel $sensitiveLevel = null,  // Sensitivity level for lineage collection
         public readonly bool $cascade = true,      // Whether this attribute cascades to child classes
+        /**
+         * @var string|null Optional expression to conditionally include this Property attribute.
+         *                  If null (default), property is always considered for hydration.
+         *                  If expression evaluates to true, property is included in hydration.
+         *                  If expression evaluates to false, property attribute is ignored (treated as absent).
+         */
+        public readonly ?string $keepWhen = null,
     ) {
         // Validation: mapping requires class to be set
         if ($mapping !== null && $class === null) {

--- a/src/Attribute/SkipProperty.php
+++ b/src/Attribute/SkipProperty.php
@@ -18,7 +18,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class SkipProperty
 {
+    /**
+     * @param string|null $when Optional expression to conditionally skip the property.
+     *                          If null (default), property is always skipped.
+     *                          If expression evaluates to true, property is skipped.
+     *                          If expression evaluates to false, property is not skipped.
+     * @param bool $cascade Whether this attribute cascades to child classes
+     */
     public function __construct(
-        public readonly bool $cascade = true,  // Whether this attribute cascades to child classes
+        public readonly ?string $when = null,
+        public readonly bool $cascade = true,
     ) {}
 }

--- a/src/DataCollector/AttributeCascadeCollector.php
+++ b/src/DataCollector/AttributeCascadeCollector.php
@@ -234,6 +234,43 @@ final class AttributeCascadeCollector
     }
 
     /**
+     * Collect type coercion warning for 'when' expression that returned non-boolean.
+     * 
+     * @param string $className The class containing the property
+     * @param string $propertyName The property name
+     * @param string $attributeName The attribute name (SkipProperty, KeepProperty, Property.keepWhen)
+     * @param string $expression The expression that was evaluated
+     * @param string $originalType The original type of the result
+     * @param bool $coercedValue The boolean value after coercion
+     */
+    public function collectTypeCoercion(
+        string $className,
+        string $propertyName,
+        string $attributeName,
+        string $expression,
+        string $originalType,
+        bool $coercedValue
+    ): void {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $this->events[] = new CascadeEvent(
+            type: CascadeEvent::TYPE_WHEN_EXPRESSION_TYPE_COERCION,
+            targetClass: $className,
+            sourceClass: '',
+            sourceType: 'expression',
+            metadata: [
+                'propertyName' => $propertyName,
+                'attributeName' => $attributeName,
+                'expression' => $expression,
+                'originalType' => $originalType,
+                'coercedValue' => $coercedValue,
+            ]
+        );
+    }
+
+    /**
      * Get all collected cascade events.
      * 
      * @return CascadeEvent[]
@@ -271,6 +308,7 @@ final class AttributeCascadeCollector
      *     dataSourceIdConflicts: int,
      *     propertyConfigIdConflicts: int,
      *     propertyAttributeOverrides: int,
+     *     whenExpressionTypeCoercions: int,
      *     total: int
      * }
      */
@@ -282,6 +320,7 @@ final class AttributeCascadeCollector
             'dataSourceIdConflicts' => count($this->getEventsByType(CascadeEvent::TYPE_DATASOURCE_ID_CONFLICT)),
             'propertyConfigIdConflicts' => count($this->getEventsByType(CascadeEvent::TYPE_PROPERTY_CONFIG_ID_CONFLICT)),
             'propertyAttributeOverrides' => count($this->getEventsByType(CascadeEvent::TYPE_PROPERTY_ATTRIBUTE_OVERRIDE)),
+            'whenExpressionTypeCoercions' => count($this->getEventsByType(CascadeEvent::TYPE_WHEN_EXPRESSION_TYPE_COERCION)),
             'total' => count($this->events),
         ];
     }

--- a/src/DataCollector/CascadeEvent.php
+++ b/src/DataCollector/CascadeEvent.php
@@ -23,6 +23,7 @@ final class CascadeEvent
     public const TYPE_DATASOURCE_ID_CONFLICT = 'datasource_id_conflict';
     public const TYPE_PROPERTY_CONFIG_ID_CONFLICT = 'property_config_id_conflict';
     public const TYPE_PROPERTY_ATTRIBUTE_OVERRIDE = 'property_attribute_override';
+    public const TYPE_WHEN_EXPRESSION_TYPE_COERCION = 'when_expression_type_coercion';
 
     public readonly float $timestamp;
 

--- a/src/Expression/ExpressionParser.php
+++ b/src/Expression/ExpressionParser.php
@@ -224,7 +224,18 @@ class ExpressionParser
             return $result;
         }
         
-        // Parse service('service_id')
+        // Parse serviceId('service_id') - new name
+        if (preg_match("/serviceId\('([^']+)'\)/", $expression, $matches)) {
+            $serviceId = $matches[1];
+            
+            if ($this->serviceResolver === null) {
+                throw new \RuntimeException('ServiceResolver not available for serviceId() function');
+            }
+            
+            return $this->serviceResolver->resolve($serviceId);
+        }
+        
+        // Parse service('service_id') - kept for compatibility with documentation
         if (preg_match("/service\('([^']+)'\)/", $expression, $matches)) {
             $serviceId = $matches[1];
             
@@ -235,7 +246,7 @@ class ExpressionParser
             return $this->serviceResolver->resolve($serviceId);
         }
         
-        // Parse envVar('KEY') - new preferred name
+        // Parse envVar('KEY') - get environment variable
         if (preg_match("/envVar\('([^']+)'\)/", $expression, $matches)) {
             $key = $matches[1];
             
@@ -248,17 +259,16 @@ class ExpressionParser
             return $envValue !== false ? $envValue : null;
         }
         
-        // Parse env_var('KEY') - backward compatibility
-        if (preg_match("/env_var\('([^']+)'\)/", $expression, $matches)) {
+        // Parse envVarExists('KEY') - check if environment variable exists
+        if (preg_match("/envVarExists\('([^']+)'\)/", $expression, $matches)) {
             $key = $matches[1];
             
-            // Try $_ENV first, then getenv()
+            // Check $_ENV first, then getenv()
             if (isset($_ENV[$key])) {
-                return $_ENV[$key];
+                return true;
             }
             
-            $envValue = getenv($key);
-            return $envValue !== false ? $envValue : null;
+            return getenv($key) !== false;
         }
         
         // Parse strictProperty('propertyName')

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -482,6 +482,163 @@ class Loader implements LoaderInterface
     }
 
     /**
+     * Check if a property should be hydrated based on attributes and expressions.
+     * This method evaluates 'when' expressions in SkipProperty, KeepProperty, and Property.keepWhen.
+     *
+     * @param ReflectionClass $reflectionClass
+     * @param ReflectionProperty $property
+     * @param object $object
+     * @param array $rawData
+     * @return bool
+     */
+    private function shouldHydratePropertyWithExpressions(
+        ReflectionClass $reflectionClass,
+        ReflectionProperty $property,
+        object $object,
+        array $rawData
+    ): bool {
+        $decisionInfo = $this->attributeReader->getHydrationDecisionInfo($reflectionClass, $property);
+        
+        // Create an expression parser for evaluating 'when' expressions
+        $sourceFunctionProvider = $this->sourceFunctionProviders[$object] ?? new SourceFunctionProvider(
+            fn(string $sourceId) => $this->executeDataSourceById($object, $sourceId)
+        );
+        $expressionParser = new ExpressionParser($sourceFunctionProvider, $this->serviceResolver);
+        $expressionParser->setRawData($rawData);
+        $expressionParser->setCurrentObject($object);
+        
+        $propertyLoader = fn(string $propName) => $this->loadProperty($object, $propName);
+        
+        // 1. Check SkipProperty with optional 'when' expression
+        if ($decisionInfo['hasSkipProperty']) {
+            if ($decisionInfo['skipWhen'] !== null) {
+                // Evaluate the 'when' expression
+                $skipResult = $this->evaluateWhenExpression(
+                    $decisionInfo['skipWhen'],
+                    $expressionParser,
+                    $object,
+                    $propertyLoader,
+                    'SkipProperty',
+                    $property->getName()
+                );
+                if ($skipResult) {
+                    return false; // Skip this property
+                }
+                // If expression is false, don't skip - continue to other checks
+            } else {
+                // No 'when' expression means always skip
+                return false;
+            }
+        }
+        
+        // 2. If class has SkipAllProperties, check Property.keepWhen and KeepProperty.when
+        if ($decisionInfo['hasSkipAllProperties']) {
+            // Check Property with keepWhen
+            if ($decisionInfo['hasProperty']) {
+                if ($decisionInfo['propertyKeepWhen'] !== null) {
+                    $keepResult = $this->evaluateWhenExpression(
+                        $decisionInfo['propertyKeepWhen'],
+                        $expressionParser,
+                        $object,
+                        $propertyLoader,
+                        'Property.keepWhen',
+                        $property->getName()
+                    );
+                    if ($keepResult) {
+                        return true; // Keep this property
+                    }
+                    // If expression is false, Property is treated as absent
+                } else {
+                    // Property without keepWhen is always considered present
+                    return true;
+                }
+            }
+            
+            // Check KeepProperty with when
+            if ($decisionInfo['hasKeepProperty']) {
+                if ($decisionInfo['keepWhen'] !== null) {
+                    $keepResult = $this->evaluateWhenExpression(
+                        $decisionInfo['keepWhen'],
+                        $expressionParser,
+                        $object,
+                        $propertyLoader,
+                        'KeepProperty',
+                        $property->getName()
+                    );
+                    if ($keepResult) {
+                        return true; // Keep this property
+                    }
+                    // If expression is false, KeepProperty is treated as absent
+                } else {
+                    // KeepProperty without 'when' is always considered present
+                    return true;
+                }
+            }
+            
+            // Neither Property nor KeepProperty effectively present
+            return false;
+        }
+        
+        // Default behavior (KeepAllProperties or no class-level attribute): hydrate
+        return true;
+    }
+
+    /**
+     * Evaluate a 'when' expression and log warning if result is not boolean.
+     *
+     * @param string $expression
+     * @param ExpressionParser $expressionParser
+     * @param object $object
+     * @param callable $propertyLoader
+     * @param string $attributeName For logging purposes
+     * @param string $propertyName For logging purposes
+     * @return bool
+     */
+    private function evaluateWhenExpression(
+        string $expression,
+        ExpressionParser $expressionParser,
+        object $object,
+        callable $propertyLoader,
+        string $attributeName,
+        string $propertyName
+    ): bool {
+        $resolved = $expressionParser->resolveArgs([$expression], $object, $propertyLoader);
+        $result = $resolved[0] ?? false;
+        
+        // Check if result is boolean, log warning if not
+        if (!is_bool($result)) {
+            $originalType = gettype($result);
+            $boolResult = (bool) $result;
+            
+            $this->logger->warning('Non-boolean result in "when" expression, type coercion occurred', [
+                'attribute' => $attributeName,
+                'property' => $propertyName,
+                'class' => get_class($object),
+                'expression' => $expression,
+                'original_type' => $originalType,
+                'original_value' => is_scalar($result) ? $result : gettype($result),
+                'coerced_to' => $boolResult ? 'true' : 'false',
+            ]);
+            
+            // Collect via cascade collector if available
+            if ($this->cascadeCollector !== null) {
+                $this->cascadeCollector->collectTypeCoercion(
+                    get_class($object),
+                    $propertyName,
+                    $attributeName,
+                    $expression,
+                    $originalType,
+                    $boolResult
+                );
+            }
+            
+            return $boolResult;
+        }
+        
+        return $result;
+    }
+
+    /**
      * Load all eager properties on the given object
      *
      * @param object $object The object to load eager properties for
@@ -1661,8 +1818,8 @@ class Loader implements LoaderInterface
                 continue;
             }
             
-            // Check if property should be hydrated based on attributes
-            if (!$this->attributeReader->shouldHydrateProperty($reflectionClass, $property)) {
+            // Check if property should be hydrated based on attributes and expressions
+            if (!$this->shouldHydratePropertyWithExpressions($reflectionClass, $property, $object, $data)) {
                 continue;
             }
             

--- a/src/Metadata/AttributeReader.php
+++ b/src/Metadata/AttributeReader.php
@@ -623,30 +623,67 @@ class AttributeReader
 
     /**
      * Check if a property should be hydrated based on class and property attributes
+     * This method does NOT evaluate expressions in 'when' fields - that's the Loader's responsibility.
+     * Use this for static checks only.
      *
      * @param ReflectionClass $reflectionClass
      * @param ReflectionProperty $property
-     * @return bool
+     * @return bool|null Returns true/false for definitive answers, or null if expression evaluation is required
      */
     public function shouldHydrateProperty(ReflectionClass $reflectionClass, ReflectionProperty $property): bool
     {
-        $hasSkipProperty = $this->readSkipProperty($property) !== null;
-        $hasProperty = $this->readProperty($property) !== null;
-        $hasKeepProperty = $this->readKeepProperty($property) !== null;
+        $skipProperty = $this->readSkipProperty($property);
+        $propertyAttr = $this->readProperty($property);
+        $keepProperty = $this->readKeepProperty($property);
         $hasSkipAllProperties = $this->hasSkipAllProperties($reflectionClass);
         
-        // If property has SkipProperty, never hydrate
-        if ($hasSkipProperty) {
+        // If property has SkipProperty without 'when' expression, never hydrate
+        if ($skipProperty !== null && $skipProperty->when === null) {
             return false;
         }
         
+        // If property has SkipProperty with 'when' expression, defer to Loader
+        // For backward compatibility, we default to "not skipped" when expression needs evaluation
+        // The Loader will properly evaluate and decide
+        
         // If class has SkipAllProperties, only hydrate if property has Property or KeepProperty attribute
         if ($hasSkipAllProperties) {
-            return $hasProperty || $hasKeepProperty;
+            // If Property has keepWhen, defer to Loader for evaluation
+            // If KeepProperty has when, defer to Loader for evaluation
+            $hasPropertyWithoutKeepWhen = $propertyAttr !== null && $propertyAttr->keepWhen === null;
+            $hasKeepPropertyWithoutWhen = $keepProperty !== null && $keepProperty->when === null;
+            
+            return $hasPropertyWithoutKeepWhen || $hasKeepPropertyWithoutWhen;
         }
         
         // Default behavior (KeepAllProperties): hydrate unless SkipProperty
         return true;
+    }
+
+    /**
+     * Get hydration decision info including expressions that need evaluation
+     *
+     * @param ReflectionClass $reflectionClass
+     * @param ReflectionProperty $property
+     * @return array{shouldHydrate: bool|null, skipWhen: ?string, keepWhen: ?string, propertyKeepWhen: ?string}
+     */
+    public function getHydrationDecisionInfo(ReflectionClass $reflectionClass, ReflectionProperty $property): array
+    {
+        $skipProperty = $this->readSkipProperty($property);
+        $propertyAttr = $this->readProperty($property);
+        $keepProperty = $this->readKeepProperty($property);
+        $hasSkipAllProperties = $this->hasSkipAllProperties($reflectionClass);
+        
+        return [
+            'shouldHydrate' => null,  // Requires expression evaluation
+            'skipWhen' => $skipProperty?->when,
+            'keepWhen' => $keepProperty?->when,
+            'propertyKeepWhen' => $propertyAttr?->keepWhen,
+            'hasSkipProperty' => $skipProperty !== null,
+            'hasProperty' => $propertyAttr !== null,
+            'hasKeepProperty' => $keepProperty !== null,
+            'hasSkipAllProperties' => $hasSkipAllProperties,
+        ];
     }
 
     /**

--- a/tests/Integration/ExpressionLanguageExtendedTest.php
+++ b/tests/Integration/ExpressionLanguageExtendedTest.php
@@ -75,7 +75,7 @@ class ExpressionLanguageExtendedTest extends TestCase
             private ?string $value = null;
         };
         
-        $args = ["expr(env_var('TEST_VAR'))"];
+        $args = ["expr(envVar('TEST_VAR'))"];
         $resolved = $parser->resolveArgs($args, $testObject, fn($prop) => null);
         
         $this->assertCount(1, $resolved);
@@ -91,11 +91,39 @@ class ExpressionLanguageExtendedTest extends TestCase
             private ?string $value = null;
         };
         
-        $args = ["expr(env_var('NON_EXISTENT_VAR'))"];
+        $args = ["expr(envVar('NON_EXISTENT_VAR'))"];
         $resolved = $parser->resolveArgs($args, $testObject, fn($prop) => null);
         
         $this->assertCount(1, $resolved);
         $this->assertNull($resolved[0]);
+    }
+
+    public function testEnvVarExistsFunction(): void
+    {
+        $_ENV['TEST_VAR_EXISTS'] = 'some_value';
+        
+        $sourceFunctionProvider = new SourceFunctionProvider(fn($id) => []);
+        $parser = new ExpressionParser($sourceFunctionProvider);
+        
+        $testObject = new class {
+            private ?string $value = null;
+        };
+        
+        // Test existing variable
+        $args = ["expr(envVarExists('TEST_VAR_EXISTS'))"];
+        $resolved = $parser->resolveArgs($args, $testObject, fn($prop) => null);
+        
+        $this->assertCount(1, $resolved);
+        $this->assertTrue($resolved[0]);
+        
+        // Test non-existing variable
+        $args = ["expr(envVarExists('NON_EXISTENT_VAR'))"];
+        $resolved = $parser->resolveArgs($args, $testObject, fn($prop) => null);
+        
+        $this->assertCount(1, $resolved);
+        $this->assertFalse($resolved[0]);
+        
+        unset($_ENV['TEST_VAR_EXISTS']);
     }
 
     public function testContextFunction(): void
@@ -164,7 +192,7 @@ class ExpressionLanguageExtendedTest extends TestCase
         };
         
         $args = [
-            "expr(env_var('TEST_VAR'))",
+            "expr(envVar('TEST_VAR'))",
             "expr(context('ctx_key'))",
             "expr(source('test')['data'])",
         ];

--- a/tests/Integration/PropertyInclusionTest.php
+++ b/tests/Integration/PropertyInclusionTest.php
@@ -13,13 +13,22 @@ declare(strict_types=1);
 
 namespace Kassko\DataMapper\Tests\Integration;
 
+use Kassko\DataMapper\Attribute\KeepProperty;
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\Attribute\SkipAllProperties;
+use Kassko\DataMapper\Attribute\SkipProperty;
 use Kassko\DataMapper\Loader\Loader;
+use Kassko\DataMapper\Registry\ContextRegistry;
 use Kassko\Sample\ProductWithSkip;
 use Kassko\Sample\ProductWithSkipAll;
 use PHPUnit\Framework\TestCase;
 
 class PropertyInclusionTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        ContextRegistry::clear();
+    }
     public function testSkipPropertyIsNotHydrated(): void
     {
         $lazyLoader = new Loader(new \Kassko\DataMapper\ServiceResolver());
@@ -68,5 +77,186 @@ class PropertyInclusionTest extends TestCase
         // name and price should NOT be hydrated (class has SkipAllProperties)
         $this->assertNull($product->getName());
         $this->assertNull($product->getPrice());
+    }
+
+    public function testSkipPropertyWithWhenExpressionTrue(): void
+    {
+        // Set context so that the 'when' expression evaluates to true
+        ContextRegistry::set('skip_email', true);
+        
+        $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
+        
+        $entity = new class {
+            private ?string $firstName = null;
+            #[SkipProperty(when: "expr(contextKeyExists('skip_email'))")]
+            private ?string $email = null;
+            
+            public function getFirstName(): ?string { return $this->firstName; }
+            public function getEmail(): ?string { return $this->email; }
+        };
+        
+        $data = [
+            'firstName' => 'John',
+            'email' => 'john@example.com',
+        ];
+        
+        $reflection = new \ReflectionClass($loader);
+        $method = $reflection->getMethod('hydrateObject');
+        $method->invoke($loader, $entity, $data, null, 0);
+        
+        // firstName should be hydrated
+        $this->assertEquals('John', $entity->getFirstName());
+        // email should NOT be hydrated (when expression is true)
+        $this->assertNull($entity->getEmail());
+    }
+
+    public function testSkipPropertyWithWhenExpressionFalse(): void
+    {
+        // Do NOT set context so that the 'when' expression evaluates to false
+        // ContextRegistry::set('skip_email', true);  <- not set
+        
+        $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
+        
+        $entity = new class {
+            private ?string $firstName = null;
+            #[SkipProperty(when: "expr(contextKeyExists('skip_email'))")]
+            private ?string $email = null;
+            
+            public function getFirstName(): ?string { return $this->firstName; }
+            public function getEmail(): ?string { return $this->email; }
+        };
+        
+        $data = [
+            'firstName' => 'John',
+            'email' => 'john@example.com',
+        ];
+        
+        $reflection = new \ReflectionClass($loader);
+        $method = $reflection->getMethod('hydrateObject');
+        $method->invoke($loader, $entity, $data, null, 0);
+        
+        // Both should be hydrated (when expression is false)
+        $this->assertEquals('John', $entity->getFirstName());
+        $this->assertEquals('john@example.com', $entity->getEmail());
+    }
+
+    public function testKeepPropertyWithWhenExpressionTrue(): void
+    {
+        // Set context so that the 'when' expression evaluates to true
+        ContextRegistry::set('keep_id', true);
+        
+        $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
+        
+        $entity = new #[SkipAllProperties] class {
+            #[KeepProperty(when: "expr(contextKeyExists('keep_id'))")]
+            private ?string $id = null;
+            private ?string $temp = null;
+            
+            public function getId(): ?string { return $this->id; }
+            public function getTemp(): ?string { return $this->temp; }
+        };
+        
+        $data = [
+            'id' => '123',
+            'temp' => 'temporary',
+        ];
+        
+        $reflection = new \ReflectionClass($loader);
+        $method = $reflection->getMethod('hydrateObject');
+        $method->invoke($loader, $entity, $data, null, 0);
+        
+        // id should be hydrated (KeepProperty with when=true)
+        $this->assertEquals('123', $entity->getId());
+        // temp should NOT be hydrated (no KeepProperty, class has SkipAllProperties)
+        $this->assertNull($entity->getTemp());
+    }
+
+    public function testKeepPropertyWithWhenExpressionFalse(): void
+    {
+        // Do NOT set context so that the 'when' expression evaluates to false
+        
+        $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
+        
+        $entity = new #[SkipAllProperties] class {
+            #[KeepProperty(when: "expr(contextKeyExists('keep_id'))")]
+            private ?string $id = null;
+            private ?string $temp = null;
+            
+            public function getId(): ?string { return $this->id; }
+            public function getTemp(): ?string { return $this->temp; }
+        };
+        
+        $data = [
+            'id' => '123',
+            'temp' => 'temporary',
+        ];
+        
+        $reflection = new \ReflectionClass($loader);
+        $method = $reflection->getMethod('hydrateObject');
+        $method->invoke($loader, $entity, $data, null, 0);
+        
+        // Neither should be hydrated (KeepProperty when=false, class has SkipAllProperties)
+        $this->assertNull($entity->getId());
+        $this->assertNull($entity->getTemp());
+    }
+
+    public function testPropertyKeepWhenTrue(): void
+    {
+        // Set context so that the 'keepWhen' expression evaluates to true
+        ContextRegistry::set('keep_name', true);
+        
+        $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
+        
+        $entity = new #[SkipAllProperties] class {
+            #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('keep_name'))")]
+            private ?string $name = null;
+            private ?string $temp = null;
+            
+            public function getName(): ?string { return $this->name; }
+            public function getTemp(): ?string { return $this->temp; }
+        };
+        
+        $data = [
+            'user_name' => 'John',
+            'temp' => 'temporary',
+        ];
+        
+        $reflection = new \ReflectionClass($loader);
+        $method = $reflection->getMethod('hydrateObject');
+        $method->invoke($loader, $entity, $data, null, 0);
+        
+        // name should be hydrated (Property with keepWhen=true)
+        $this->assertEquals('John', $entity->getName());
+        // temp should NOT be hydrated (no Property, class has SkipAllProperties)
+        $this->assertNull($entity->getTemp());
+    }
+
+    public function testPropertyKeepWhenFalse(): void
+    {
+        // Do NOT set context so that the 'keepWhen' expression evaluates to false
+        
+        $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
+        
+        $entity = new #[SkipAllProperties] class {
+            #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('keep_name'))")]
+            private ?string $name = null;
+            private ?string $temp = null;
+            
+            public function getName(): ?string { return $this->name; }
+            public function getTemp(): ?string { return $this->temp; }
+        };
+        
+        $data = [
+            'user_name' => 'John',
+            'temp' => 'temporary',
+        ];
+        
+        $reflection = new \ReflectionClass($loader);
+        $method = $reflection->getMethod('hydrateObject');
+        $method->invoke($loader, $entity, $data, null, 0);
+        
+        // Neither should be hydrated (Property keepWhen=false, class has SkipAllProperties)
+        $this->assertNull($entity->getName());
+        $this->assertNull($entity->getTemp());
     }
 }

--- a/tests/Unit/Attribute/KeepPropertyTest.php
+++ b/tests/Unit/Attribute/KeepPropertyTest.php
@@ -15,6 +15,7 @@ namespace Kassko\DataMapper\Tests\Unit\Attribute;
 
 use Kassko\DataMapper\Attribute\KeepProperty;
 use Kassko\DataMapper\Attribute\SkipAllProperties;
+use Kassko\DataMapper\Attribute\SkipProperty;
 use Kassko\DataMapper\Metadata\AttributeReader;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -75,5 +76,94 @@ class KeepPropertyTest extends TestCase
         $excludedProperty = $reflection->getProperty('excluded');
         $shouldHydrateExcluded = $this->reader->shouldHydrateProperty($reflection, $excludedProperty);
         $this->assertFalse($shouldHydrateExcluded);
+    }
+
+    public function testKeepPropertyWithWhenExpression(): void
+    {
+        $testClass = new class {
+            #[KeepProperty(when: "expr(contextKeyExists('keep_me'))")]
+            private ?string $conditionalProp = null;
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $property = $reflection->getProperty('conditionalProp');
+
+        $keepProperty = $this->reader->readKeepProperty($property);
+
+        $this->assertInstanceOf(KeepProperty::class, $keepProperty);
+        $this->assertEquals("expr(contextKeyExists('keep_me'))", $keepProperty->when);
+    }
+
+    public function testKeepPropertyWithoutWhenExpression(): void
+    {
+        $testClass = new class {
+            #[KeepProperty]
+            private ?string $alwaysKept = null;
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $property = $reflection->getProperty('alwaysKept');
+
+        $keepProperty = $this->reader->readKeepProperty($property);
+
+        $this->assertInstanceOf(KeepProperty::class, $keepProperty);
+        $this->assertNull($keepProperty->when);
+    }
+
+    public function testSkipPropertyWithWhenExpression(): void
+    {
+        $testClass = new class {
+            #[SkipProperty(when: "expr(contextKeyExists('skip_me'))")]
+            private ?string $conditionalSkip = null;
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $property = $reflection->getProperty('conditionalSkip');
+
+        $skipProperty = $this->reader->readSkipProperty($property);
+
+        $this->assertInstanceOf(SkipProperty::class, $skipProperty);
+        $this->assertEquals("expr(contextKeyExists('skip_me'))", $skipProperty->when);
+    }
+
+    public function testSkipPropertyWithoutWhenExpression(): void
+    {
+        $testClass = new class {
+            #[SkipProperty]
+            private ?string $alwaysSkipped = null;
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $property = $reflection->getProperty('alwaysSkipped');
+
+        $skipProperty = $this->reader->readSkipProperty($property);
+
+        $this->assertInstanceOf(SkipProperty::class, $skipProperty);
+        $this->assertNull($skipProperty->when);
+    }
+
+    public function testGetHydrationDecisionInfo(): void
+    {
+        $testClass = new #[SkipAllProperties] class {
+            #[KeepProperty(when: "expr(contextKeyExists('keep'))")]
+            private ?string $conditionalKeep = null;
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $property = $reflection->getProperty('conditionalKeep');
+
+        $decisionInfo = $this->reader->getHydrationDecisionInfo($reflection, $property);
+
+        $this->assertArrayHasKey('skipWhen', $decisionInfo);
+        $this->assertArrayHasKey('keepWhen', $decisionInfo);
+        $this->assertArrayHasKey('propertyKeepWhen', $decisionInfo);
+        $this->assertArrayHasKey('hasSkipProperty', $decisionInfo);
+        $this->assertArrayHasKey('hasProperty', $decisionInfo);
+        $this->assertArrayHasKey('hasKeepProperty', $decisionInfo);
+        $this->assertArrayHasKey('hasSkipAllProperties', $decisionInfo);
+        
+        $this->assertEquals("expr(contextKeyExists('keep'))", $decisionInfo['keepWhen']);
+        $this->assertTrue($decisionInfo['hasKeepProperty']);
+        $this->assertTrue($decisionInfo['hasSkipAllProperties']);
     }
 }

--- a/tests/Unit/Expression/StrictPropertyTest.php
+++ b/tests/Unit/Expression/StrictPropertyTest.php
@@ -77,9 +77,13 @@ class StrictPropertyTest extends TestCase
         $result = $parser->resolveArgs(["expr(envVar('TEST_VAR'))"], $object, fn() => null);
         $this->assertEquals(['test-value'], $result);
         
-        // env_var() should still work for backward compatibility
-        $result2 = $parser->resolveArgs(["expr(env_var('TEST_VAR'))"], $object, fn() => null);
-        $this->assertEquals(['test-value'], $result2);
+        // envVarExists() should return true for existing variable
+        $result2 = $parser->resolveArgs(["expr(envVarExists('TEST_VAR'))"], $object, fn() => null);
+        $this->assertEquals([true], $result2);
+        
+        // envVarExists() should return false for non-existing variable
+        $result3 = $parser->resolveArgs(["expr(envVarExists('NON_EXISTENT_VAR'))"], $object, fn() => null);
+        $this->assertEquals([false], $result3);
         
         unset($_ENV['TEST_VAR']);
     }


### PR DESCRIPTION
# Pull Request: Expression Support in Property Hydration Control

## Summary

This PR adds expression support to `KeepProperty`, `SkipProperty`, and `Property` attributes for conditional hydration control. It also refactors the expression language functions for consistency and adds type coercion warnings.

## Changes

### 1. Expression Support in KeepProperty and SkipProperty

Added optional `when` field to `KeepProperty` and `SkipProperty` attributes:

**SkipProperty with conditional skipping:**
```php
#[KeepAllProperties]  // Default behavior
class Entity
{
    private ?string $firstName = null;   // Hydrated
    private ?string $lastName = null;    // Hydrated
    
    #[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
    private ?string $email = null;  // Skipped only if 'hide_email' context key exists
}
```

**KeepProperty with conditional keeping:**
```php
#[SkipAllProperties]
class Entity
{
    #[KeepProperty(when: "expr(contextKeyExists('include_id'))")]
    private ?string $id = null;  // Kept only if 'include_id' context key exists
    
    private ?string $temp = null;  // Never hydrated
}
```

### 2. Property.keepWhen Field

Added `keepWhen` field to `Property` attribute for conditional inclusion:

```php
#[SkipAllProperties]
class Entity
{
    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
    private ?string $name = null;  // Property active only if condition is true
    
    private ?string $temp = null;  // Never hydrated
}
```

**Behavior:**
- If `keepWhen` is null (default), Property is always considered present
- If expression evaluates to `true`, Property is active
- If expression evaluates to `false`, Property is treated as absent

### 3. ExpressionParser Function Refactoring

**Renamed:**
- Added `serviceId('id')` as new function name (keeping `service('id')` for compatibility)

**Removed:**
- `env_var('KEY')` - Removed backward compatibility alias

**Added:**
- `envVarExists('KEY')` - Check if environment variable exists (returns boolean)

### 4. Type Coercion Warning for `when` Expressions

When a `when` expression returns a non-boolean value, the system:
1. Logs a warning with severity level
2. Collects the event in AttributeCascadeCollector if enabled
3. Coerces the value to boolean and continues

**Warning includes:**
- Attribute name (SkipProperty, KeepProperty, Property.keepWhen)
- Property name
- Class name
- Expression
- Original type
- Coerced boolean value

### 5. New Hydration Decision Flow

Added new methods in Loader:
- `shouldHydratePropertyWithExpressions()` - Evaluates all `when` expressions
- `evaluateWhenExpression()` - Evaluates single expression with logging

Updated `AttributeReader.getHydrationDecisionInfo()` to return expression data for Loader evaluation.

## Breaking Changes

1. **`env_var()` removed** - Use `envVar()` instead
2. No backward compatibility maintained (alpha version)

## Files Changed

### Modified Attributes
- `src/Attribute/KeepProperty.php` - Added `when` field
- `src/Attribute/SkipProperty.php` - Added `when` field
- `src/Attribute/Property.php` - Added `keepWhen` field

### Core Logic
- `src/Metadata/AttributeReader.php` - Added `getHydrationDecisionInfo()` method
- `src/Loader/Loader.php` - Added expression evaluation in hydration flow
- `src/Expression/ExpressionParser.php` - Added `serviceId()`, `envVarExists()`, removed `env_var()`
- `src/DataCollector/AttributeCascadeCollector.php` - Added `collectTypeCoercion()` method
- `src/DataCollector/CascadeEvent.php` - Added `TYPE_WHEN_EXPRESSION_TYPE_COERCION` constant

### Tests
- `tests/Unit/Attribute/KeepPropertyTest.php` - Added tests for `when` expression
- `tests/Integration/PropertyInclusionTest.php` - Added integration tests for conditional hydration
- `tests/Integration/ExpressionLanguageExtendedTest.php` - Updated for new function names
- `tests/Unit/Expression/StrictPropertyTest.php` - Updated for `envVarExists()`

### Documentation
- `README.md` - Updated expression language documentation
- `docs/attributes/KeepProperty.md` - Complete rewrite with `when` examples
- `docs/attributes/SkipProperty.md` - Complete rewrite with `when` examples
- `docs/attributes/Property.md` - Added `keepWhen` documentation
- `docs/concepts/ExpressionLanguage.md` - Added conditional hydration section

## Testing

All 300 tests pass successfully.

## Migration Guide

### From env_var() to envVar()

**Before:**
```php
#[DataSource(args: ["expr(env_var('API_KEY'))"])]
```

**After:**
```php
#[DataSource(args: ["expr(envVar('API_KEY'))"])]
```

### Using New Conditional Hydration

```php
// Old: No conditional support
#[SkipProperty]
private ?string $email = null;

// New: Conditional skipping
#[SkipProperty(when: "expr(contextKeyExists('hide_email'))")]
private ?string $email = null;
```
