### PR TITLE
improv / code / rename Property and PropertyConfig attributes field 'name' to 'key'

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -9,10 +9,10 @@ use Kassko\DataMapper\Attribute\Property;
 
 class Person
 {
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
     
-    #[Property(name: 'last_name')]
+    #[Property(key: 'last_name')]
     private ?string $lastName = null;
 }
 
@@ -82,11 +82,11 @@ class Person
     private int $id;
     
     #[DataSourceRef(id: 'personData')]
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
     
     #[DataSourceRef(id: 'personData')]
-    #[Property(name: 'last_name')]
+    #[Property(key: 'last_name')]
     private ?string $lastName = null;
     
     #[DataSourceRef(id: 'personData')]

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ And `Property.keepWhen` to conditionally enable the Property attribute:
 #[SkipAllProperties]
 class Entity
 {
-    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    #[Property(key: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
     private ?string $name = null;  // Only hydrated if 'include_name' context key exists
 }
 ```

--- a/docs/attributes/MultiPropDataSource.md
+++ b/docs/attributes/MultiPropDataSource.md
@@ -32,11 +32,11 @@ class Person
     private int $id;
     
     #[DataSourceRef(id: 'personData')]
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
     
     #[DataSourceRef(id: 'personData')]
-    #[Property(name: 'last_name')]
+    #[Property(key: 'last_name')]
     private ?string $lastName = null;
     
     #[DataSourceRef(id: 'personData')]

--- a/docs/attributes/Property.md
+++ b/docs/attributes/Property.md
@@ -11,11 +11,11 @@ use Kassko\DataMapper\Attribute\Property;
 
 class Person
 {
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
     
     #[Property(
-        name: 'address_data',
+        key: 'address_data',
         class: Address::class,
         mapping: ['billing_street' => 'street', 'billing_city' => 'city']
     )]
@@ -68,7 +68,7 @@ class Garage
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | `?string` | No | Key in raw data array |
+| `key` | `?string` | No | Key in raw data array |
 | `class` | `?string` | No | Class for nested object hydration |
 | `mapping` | `?array` | No | Instance-specific key mapping (requires `class`) |
 | `expand` | `?string` | No | Comma-separated fields to expand |
@@ -90,7 +90,7 @@ use Kassko\DataMapper\Attribute\SkipAllProperties;
 #[SkipAllProperties]
 class Entity
 {
-    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    #[Property(key: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
     private ?string $name = null;  // Only hydrated if 'include_name' context key exists
     
     private ?string $temp = null;  // Never hydrated (no Property attribute)

--- a/docs/attributes/PropertyConfig.md
+++ b/docs/attributes/PropertyConfig.md
@@ -41,7 +41,7 @@ class Garage
 |-----------|------|----------|-------------|
 | `id` | `string` | Yes | Unique identifier for this configuration |
 | `class` | `string` | No | Fully qualified class name for nested object hydration |
-| `name` | `string` | No | Key name in data array |
+| `key` | `string` | No | Key in raw data array |
 | `expand` | `string` | No | Comma-separated properties to expand |
 | `noExpand` | `string` | No | Comma-separated properties to NOT expand |
 | `mapping` | `array` | No | Instance-specific key mapping (requires `class`) |

--- a/docs/attributes/SkipAllProperties.md
+++ b/docs/attributes/SkipAllProperties.md
@@ -15,7 +15,7 @@ class Entity
     #[KeepProperty]
     private ?string $id = null;  // Hydrated (explicitly kept)
     
-    #[Property(name: 'user_name')]
+    #[Property(key: 'user_name')]
     private ?string $name = null;  // Hydrated (has Property attribute)
     
     private ?string $temp = null;  // NOT hydrated

--- a/docs/classes/Hydrator.md
+++ b/docs/classes/Hydrator.md
@@ -112,10 +112,10 @@ use Kassko\DataMapper\Attribute\PropertyInstantiatingHook;
 
 class Person
 {
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     public string $firstName;
     
-    #[Property(name: 'last_name')]
+    #[Property(key: 'last_name')]
     public string $lastName;
     
     public ?string $fullName = null;

--- a/docs/concepts/AttributeCascading.md
+++ b/docs/concepts/AttributeCascading.md
@@ -143,7 +143,7 @@ abstract class BaseEntity
 ```php
 class ParentClass
 {
-    #[Property(name: 'parent_name', cascade: false)]
+    #[Property(key: 'parent_name', cascade: false)]
     private ?string $name = null;
     // Child classes will NOT inherit this Property configuration
 }
@@ -158,13 +158,13 @@ When a child class shadows a parent's private property with its own property of 
 ```php
 class ParentClass
 {
-    #[Property(name: 'parent_name')] // This mapping is ignored when shadowed
+    #[Property(key: 'parent_name')] // This mapping is ignored when shadowed
     private ?string $name = null;
 }
 
 class ChildClass extends ParentClass
 {
-    #[Property(name: 'child_name')] // This mapping is used
+    #[Property(key: 'child_name')] // This mapping is used
     private ?string $name = null;
 }
 

--- a/docs/concepts/ExpressionLanguage.md
+++ b/docs/concepts/ExpressionLanguage.md
@@ -211,7 +211,7 @@ class Entity
 #[SkipAllProperties]
 class Entity
 {
-    #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
+    #[Property(key: 'user_name', keepWhen: "expr(contextKeyExists('include_name'))")]
     private ?string $name = null;  // Property is active only if condition is true
 }
 ```

--- a/docs/history/pull-requests/PR-2026_01_03---15_30_00.md
+++ b/docs/history/pull-requests/PR-2026_01_03---15_30_00.md
@@ -1,0 +1,106 @@
+# PR: Rename Property and PropertyConfig `name` field to `key`
+
+**Date:** 2026-01-03
+**Branch:** `improv/dev/propertyFieldNameRenamingToKey`
+
+## Summary
+
+This PR renames the `name` field to `key` in both `Property` and `PropertyConfig` attributes to better reflect its purpose as the raw data key mapping.
+
+## Motivation
+
+The `name` field was semantically confusing because:
+- It could be mistaken for the property's name
+- It actually represents the **key** in the raw data array
+- The new name `key` is more explicit and descriptive
+
+### Before
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class Person
+{
+    #[Property(name: 'first_name')]
+    private ?string $firstName = null;
+}
+```
+
+### After
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class Person
+{
+    #[Property(key: 'first_name')]
+    private ?string $firstName = null;
+}
+```
+
+## Changes
+
+### Source Code
+
+| File | Change |
+|------|--------|
+| `src/Attribute/Property.php` | Renamed `$name` to `$key` |
+| `src/Attribute/PropertyConfig.php` | Renamed `$name` to `$key` |
+| `src/Loader/Loader.php` | Updated `getPropertyNameMapping()` and `mergePropertyConfig()` to use `->key` |
+
+### Test Files Updated
+
+All test files using `Property(name:` or `PropertyConfig(...name:` have been updated:
+
+- `tests/Unit/Hydrator/Fixtures/SimpleHydratable.php`
+- `tests/Unit/Hydrator/Fixtures/HydratableWithHooks.php`
+- `tests/Unit/AttributeCascade/Fixtures/ParentWithAttributes.php`
+- `tests/Unit/AttributeCascade/Fixtures/ChildWithAttributes.php`
+- `tests/Integration/Features/ExpressionLanguage/Fixtures/PersonWithCar.php`
+- `tests/Integration/Features/AttributeCascade/AttributeCascadeIntegrationTest.php`
+- `tests/Integration/Features/AttributeCascade/Fixtures/ParentWithAttributes.php`
+- `tests/Integration/Features/AttributeCascade/Fixtures/ChildWithAttributes.php`
+- `tests/Integration/Features/PropertyNamePrecedence/PropertyNamePrecedenceTest.php`
+- `tests/Integration/AttributeSets/KeepAndSkipAndKeepAllAndSkipAll/PropertyInclusionTest.php`
+- `tests/Integration/Attributes/PropertyCheckMapping/Fixtures/PersonWithStore.php`
+- `tests/Integration/Attributes/DataSourceCheckLoadingScope/LoadingScopeTest.php`
+- `tests/Integration/Attributes/DataSourceRefCheckProviders/DataSourceAggregationTest.php`
+- `tests/Integration/Attributes/DataSourceStore/Fixtures/PersonWithStore.php`
+
+### Documentation Updated
+
+| File | Change |
+|------|--------|
+| `docs/attributes/Property.md` | Updated parameter table and examples |
+| `docs/attributes/PropertyConfig.md` | Updated parameter table |
+| `docs/attributes/MultiPropDataSource.md` | Updated examples |
+| `docs/attributes/SkipAllProperties.md` | Updated examples |
+| `docs/classes/Hydrator.md` | Updated examples |
+| `docs/concepts/AttributeCascading.md` | Updated examples |
+| `docs/concepts/ExpressionLanguage.md` | Updated examples |
+| `EXAMPLE.md` | Updated examples |
+| `README.md` | Updated examples |
+
+## Breaking Changes
+
+**Yes, this is a breaking change.**
+
+Any code using `Property(name: ...)` or `PropertyConfig(..., name: ...)` must be updated to use `key:` instead.
+
+### Migration Guide
+
+Find and replace in your codebase:
+- `Property(name:` → `Property(key:`
+- `PropertyConfig(..., name:` → `PropertyConfig(..., key:`
+
+## Test Results
+
+```
+Tests: 344, Assertions: 811, Skipped: 3
+OK
+```
+
+## Related
+
+- [Property](docs/attributes/Property.md)
+- [PropertyConfig](docs/attributes/PropertyConfig.md)

--- a/docs/history/summaries/SUMMARY-2026_01_03---15_30_00.md
+++ b/docs/history/summaries/SUMMARY-2026_01_03---15_30_00.md
@@ -1,0 +1,67 @@
+# Summary: Rename Property/PropertyConfig `name` field to `key`
+
+**Date:** 2026-01-03
+**Branch:** `improv/dev/propertyFieldNameRenamingToKey`
+
+## Overview
+
+Renamed the `name` field to `key` in `Property` and `PropertyConfig` attributes for better semantic clarity. The field represents the raw data key, not the property name.
+
+## Changes Made
+
+### 1. Attribute Classes
+
+| File | Change |
+|------|--------|
+| `src/Attribute/Property.php` | `$name` → `$key` |
+| `src/Attribute/PropertyConfig.php` | `$name` → `$key` |
+
+### 2. Loader Updates
+
+| File | Methods Updated |
+|------|-----------------|
+| `src/Loader/Loader.php` | `getPropertyNameMapping()`, `mergePropertyConfig()` |
+
+### 3. Test Files
+
+Updated 14 test files to use `Property(key:` instead of `Property(name:`:
+- Unit test fixtures (4 files)
+- Integration test fixtures (10 files)
+
+### 4. Documentation
+
+Updated 9 documentation files:
+- `docs/attributes/Property.md` - Parameter table and examples
+- `docs/attributes/PropertyConfig.md` - Parameter table
+- `docs/attributes/MultiPropDataSource.md`
+- `docs/attributes/SkipAllProperties.md`
+- `docs/classes/Hydrator.md`
+- `docs/concepts/AttributeCascading.md`
+- `docs/concepts/ExpressionLanguage.md`
+- `EXAMPLE.md`
+- `README.md`
+
+**Note:** Historical documentation in `docs/history/` was preserved unchanged.
+
+## Test Results
+
+```
+PHPUnit 11.5.46
+
+Time: 00:00.927
+
+Tests: 344, Assertions: 811, Skipped: 3
+OK
+```
+
+## Breaking Change
+
+This is a breaking change. Users must update their code:
+
+```php
+// Before
+#[Property(name: 'first_name')]
+
+// After  
+#[Property(key: 'first_name')]
+```

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -20,7 +20,7 @@ use Kassko\DataMapper\Enum\SensitiveLevel;
 final class Property
 {
     public function __construct(
-        public readonly ?string $name = null,      // Key name in data array
+        public readonly ?string $key = null,       // Key name in raw data array
         public readonly ?string $class = null,     // Class for nested object hydration
         public readonly ?string $expand = null,    // Comma-separated props to expand
         public readonly ?string $noExpand = null,  // Comma-separated props to NOT expand

--- a/src/Attribute/PropertyConfig.php
+++ b/src/Attribute/PropertyConfig.php
@@ -24,7 +24,7 @@ final class PropertyConfig
     public function __construct(
         public readonly string $id,
         public readonly ?string $class = null,
-        public readonly ?string $name = null,
+        public readonly ?string $key = null,
         public readonly ?string $expand = null,
         public readonly ?string $noExpand = null,
         public readonly ?array $mapping = null,

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -1592,8 +1592,8 @@ class Loader implements LoaderInterface
     {
         // Use Property attribute
         $propertyAttr = $this->attributeReader->readProperty($property);
-        if ($propertyAttr !== null && $propertyAttr->name !== null) {
-            return $propertyAttr->name;
+        if ($propertyAttr !== null && $propertyAttr->key !== null) {
+            return $propertyAttr->key;
         }
         
         // Default to property name
@@ -1826,8 +1826,8 @@ class Loader implements LoaderInterface
     private function mergePropertyConfig(Property $propertyAttr, PropertyConfig $config): Property
     {
         return new Property(
-            // Property.name takes precedence over PropertyConfig.name
-            name: $propertyAttr->name ?? $config->name,
+            // Property.key takes precedence over PropertyConfig.key
+            key: $propertyAttr->key ?? $config->key,
             class: $propertyAttr->class ?? $config->class,
             expand: $propertyAttr->expand ?? $config->expand,
             noExpand: $propertyAttr->noExpand ?? $config->noExpand,

--- a/tests/Integration/AttributeSets/KeepAndSkipAndKeepAllAndSkipAll/PropertyInclusionTest.php
+++ b/tests/Integration/AttributeSets/KeepAndSkipAndKeepAllAndSkipAll/PropertyInclusionTest.php
@@ -211,7 +211,7 @@ class PropertyInclusionTest extends TestCase
         $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
         
         $entity = new #[SkipAllProperties] class {
-            #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('keep_name'))")]
+            #[Property(key: 'user_name', keepWhen: "expr(contextKeyExists('keep_name'))")]
             private ?string $name = null;
             private ?string $temp = null;
             
@@ -241,7 +241,7 @@ class PropertyInclusionTest extends TestCase
         $loader = new Loader(new \Kassko\DataMapper\ServiceResolver());
         
         $entity = new #[SkipAllProperties] class {
-            #[Property(name: 'user_name', keepWhen: "expr(contextKeyExists('keep_name'))")]
+            #[Property(key: 'user_name', keepWhen: "expr(contextKeyExists('keep_name'))")]
             private ?string $name = null;
             private ?string $temp = null;
             

--- a/tests/Integration/Attributes/DataSourceCheckLoadingScope/LoadingScopeTest.php
+++ b/tests/Integration/Attributes/DataSourceCheckLoadingScope/LoadingScopeTest.php
@@ -50,11 +50,11 @@ class LoadingScopeTest extends TestCase
             use LoadableTrait;
             
             #[DataSourceRef(id: 'personData')]
-            #[Property(name: 'first_name')]
+            #[Property(key: 'first_name')]
             private ?string $firstName = null;
             
             #[DataSourceRef(id: 'personData')]
-            #[Property(name: 'last_name')]
+            #[Property(key: 'last_name')]
             private ?string $lastName = null;
             
             #[DataSourceRef(id: 'personData')]
@@ -104,11 +104,11 @@ class LoadingScopeTest extends TestCase
             use LoadableTrait;
             
             #[DataSourceRef(id: 'personData')]
-            #[Property(name: 'first_name')]
+            #[Property(key: 'first_name')]
             private ?string $firstName = null;
             
             #[DataSourceRef(id: 'personData')]
-            #[Property(name: 'last_name')]
+            #[Property(key: 'last_name')]
             private ?string $lastName = null;
             
             #[DataSourceRef(id: 'personData')]
@@ -168,11 +168,11 @@ class LoadingScopeTest extends TestCase
             use LoadableTrait;
             
             #[DataSourceRef(id: 'personData')]
-            #[Property(name: 'first_name')]
+            #[Property(key: 'first_name')]
             private ?string $firstName = null;
             
             #[DataSourceRef(id: 'personData')]
-            #[Property(name: 'last_name')]
+            #[Property(key: 'last_name')]
             private ?string $lastName = null;
             
             #[DataSourceRef(id: 'personData')]

--- a/tests/Integration/Attributes/DataSourceRefCheckProviders/DataSourceAggregationTest.php
+++ b/tests/Integration/Attributes/DataSourceRefCheckProviders/DataSourceAggregationTest.php
@@ -45,15 +45,15 @@ class DataSourceAggregationTest extends TestCase
             use LoadableTrait;
             
             #[DataSourceRef(providers: ['providerA', 'providerB', 'providerC'])]
-            #[Property(name: 'name')]
+            #[Property(key: 'name')]
             private ?string $name = null;
             
             #[DataSourceRef(providers: ['providerA', 'providerB', 'providerC'])]
-            #[Property(name: 'age')]
+            #[Property(key: 'age')]
             private ?int $age = null;
             
             #[DataSourceRef(providers: ['providerA', 'providerB', 'providerC'])]
-            #[Property(name: 'city')]
+            #[Property(key: 'city')]
             private ?string $city = null;
             
             public function getName(): ?string
@@ -92,7 +92,7 @@ class DataSourceAggregationTest extends TestCase
             use LoadableTrait;
             
             #[DataSourceRef(providers: ['providerA', 'providerB'])]
-            #[Property(name: 'config')]
+            #[Property(key: 'config')]
             private ?array $config = null;
             
             public function getConfig(): ?array
@@ -125,7 +125,7 @@ class DataSourceAggregationTest extends TestCase
                 providers: ['providerA', 'providerX'], 
                 ignoreProviderOnNotFound: true
             )]
-            #[Property(name: 'name')]
+            #[Property(key: 'name')]
             private ?string $name = null;
             
             public function getName(): ?string

--- a/tests/Integration/Attributes/DataSourceStore/Fixtures/PersonWithStore.php
+++ b/tests/Integration/Attributes/DataSourceStore/Fixtures/PersonWithStore.php
@@ -34,7 +34,7 @@ class PersonWithStore
     private int $id;
 
     #[DataSourceRef(id: 'personSource')]
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
 
     #[DataSourceRef(id: 'personSource')]

--- a/tests/Integration/Attributes/PropertyCheckMapping/Fixtures/PersonWithStore.php
+++ b/tests/Integration/Attributes/PropertyCheckMapping/Fixtures/PersonWithStore.php
@@ -34,7 +34,7 @@ class PersonWithStore
     private int $id;
 
     #[DataSourceRef(id: 'personSource')]
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
 
     #[DataSourceRef(id: 'personSource')]

--- a/tests/Integration/Features/AttributeCascade/AttributeCascadeIntegrationTest.php
+++ b/tests/Integration/Features/AttributeCascade/AttributeCascadeIntegrationTest.php
@@ -226,8 +226,8 @@ class AttributeCascadeIntegrationTest extends TestCase
 
     public function testChildPropertyAttributesTakePrecedence(): void
     {
-        // Child has #[Property(name: 'child_name')]
-        // Parent has #[Property(name: 'parent_name')]
+        // Child has #[Property(key: 'child_name')]
+        // Parent has #[Property(key: 'parent_name')]
         // Child's attribute should be used
         
         $rawData = [

--- a/tests/Integration/Features/AttributeCascade/Fixtures/ChildWithAttributes.php
+++ b/tests/Integration/Features/AttributeCascade/Fixtures/ChildWithAttributes.php
@@ -21,7 +21,7 @@ use Kassko\DataMapper\Attribute\Property;
  */
 class ChildWithAttributes extends ParentWithAttributes
 {
-    #[Property(name: 'child_name')]
+    #[Property(key: 'child_name')]
     private ?string $name = null;
     
     public function getName(): ?string

--- a/tests/Integration/Features/AttributeCascade/Fixtures/ParentWithAttributes.php
+++ b/tests/Integration/Features/AttributeCascade/Fixtures/ParentWithAttributes.php
@@ -20,7 +20,7 @@ use Kassko\DataMapper\Attribute\Property;
  */
 class ParentWithAttributes
 {
-    #[Property(name: 'parent_name')]
+    #[Property(key: 'parent_name')]
     private ?string $name = null;
     
     private ?int $id = null;

--- a/tests/Integration/Features/ExpressionLanguage/Fixtures/PersonWithCar.php
+++ b/tests/Integration/Features/ExpressionLanguage/Fixtures/PersonWithCar.php
@@ -41,7 +41,7 @@ class PersonWithCar
     private int $id;
 
     #[DataSourceRef(id: 'personSource')]
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
 
     #[DataSourceRef(id: 'personSource')]

--- a/tests/Integration/Features/PropertyNamePrecedence/PropertyNamePrecedenceTest.php
+++ b/tests/Integration/Features/PropertyNamePrecedence/PropertyNamePrecedenceTest.php
@@ -35,9 +35,9 @@ class PropertyNamePrecedenceTest extends TestCase
      */
     public function testPropertyTakesPrecedenceOverPropertyConfigInMerge(): void
     {
-        // Create Property with name set
+        // Create Property with key set
         $property = new Property(
-            name: 'property_name',
+            key: 'property_key',
             class: null,
             expand: 'property_expand',
             noExpand: null,
@@ -48,7 +48,7 @@ class PropertyNamePrecedenceTest extends TestCase
         $config = new PropertyConfig(
             id: 'testConfig',
             class: 'SomeClass',
-            name: 'config_name',
+            key: 'config_key',
             expand: 'config_expand',
             noExpand: 'config_noExpand',
             mapping: null,
@@ -61,8 +61,8 @@ class PropertyNamePrecedenceTest extends TestCase
         
         $merged = $method->invoke($loader, $property, $config);
         
-        // Property.name takes precedence
-        $this->assertEquals('property_name', $merged->name);
+        // Property.key takes precedence
+        $this->assertEquals('property_key', $merged->key);
         
         // Property.expand takes precedence
         $this->assertEquals('property_expand', $merged->expand);
@@ -81,7 +81,7 @@ class PropertyNamePrecedenceTest extends TestCase
     {
         // Create Property with only config reference (most fields null)
         $property = new Property(
-            name: null,
+            key: null,
             class: null,
             expand: null,
             noExpand: null,
@@ -92,7 +92,7 @@ class PropertyNamePrecedenceTest extends TestCase
         $config = new PropertyConfig(
             id: 'testConfig',
             class: 'ConfigClass',
-            name: 'config_name',
+            key: 'config_key',
             expand: 'config_expand',
             noExpand: 'config_noExpand',
             mapping: ['a' => 'b'],
@@ -105,7 +105,7 @@ class PropertyNamePrecedenceTest extends TestCase
         $merged = $method->invoke($loader, $property, $config);
         
         // All PropertyConfig values should be used
-        $this->assertEquals('config_name', $merged->name);
+        $this->assertEquals('config_key', $merged->key);
         $this->assertEquals('ConfigClass', $merged->class);
         $this->assertEquals('config_expand', $merged->expand);
         $this->assertEquals('config_noExpand', $merged->noExpand);

--- a/tests/Unit/AttributeCascade/Fixtures/ChildWithAttributes.php
+++ b/tests/Unit/AttributeCascade/Fixtures/ChildWithAttributes.php
@@ -21,7 +21,7 @@ use Kassko\DataMapper\Attribute\Property;
  */
 class ChildWithAttributes extends ParentWithAttributes
 {
-    #[Property(name: 'child_name')]
+    #[Property(key: 'child_name')]
     private ?string $name = null;
     
     public function getName(): ?string

--- a/tests/Unit/AttributeCascade/Fixtures/ParentWithAttributes.php
+++ b/tests/Unit/AttributeCascade/Fixtures/ParentWithAttributes.php
@@ -20,7 +20,7 @@ use Kassko\DataMapper\Attribute\Property;
  */
 class ParentWithAttributes
 {
-    #[Property(name: 'parent_name')]
+    #[Property(key: 'parent_name')]
     private ?string $name = null;
     
     private ?int $id = null;

--- a/tests/Unit/Hydrator/Fixtures/HydratableWithHooks.php
+++ b/tests/Unit/Hydrator/Fixtures/HydratableWithHooks.php
@@ -27,7 +27,7 @@ class HydratableWithHooks
     private bool $beforeSetNameCalled = false;
     private bool $afterSetNameCalled = false;
 
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     #[PropertySettingHook(before_set_property: 'beforeSetName', args: ["expr(rawDataItem('first_name'))"])]
     #[PropertySettingHook(after_set_property: 'afterSetName', args: ['##object', '#firstName'])]
     private ?string $firstName = null;

--- a/tests/Unit/Hydrator/Fixtures/SimpleHydratable.php
+++ b/tests/Unit/Hydrator/Fixtures/SimpleHydratable.php
@@ -20,10 +20,10 @@ use Kassko\DataMapper\Attribute\Property;
  */
 class SimpleHydratable
 {
-    #[Property(name: 'first_name')]
+    #[Property(key: 'first_name')]
     private ?string $firstName = null;
 
-    #[Property(name: 'last_name')]
+    #[Property(key: 'last_name')]
     private ?string $lastName = null;
 
     private ?string $email = null;


### PR DESCRIPTION
# PR: Rename Property and PropertyConfig `name` field to `key`

**Date:** 2026-01-03
**Branch:** `improv/dev/propertyFieldNameRenamingToKey`

## Summary

This PR renames the `name` field to `key` in both `Property` and `PropertyConfig` attributes to better reflect its purpose as the raw data key mapping.

## Motivation

The `name` field was semantically confusing because:
- It could be mistaken for the property's name
- It actually represents the **key** in the raw data array
- The new name `key` is more explicit and descriptive

### Before

```php
use Kassko\DataMapper\Attribute\Property;

class Person
{
    #[Property(name: 'first_name')]
    private ?string $firstName = null;
}
```

### After

```php
use Kassko\DataMapper\Attribute\Property;

class Person
{
    #[Property(key: 'first_name')]
    private ?string $firstName = null;
}
```

## Changes

### Source Code

| File | Change |
|------|--------|
| `src/Attribute/Property.php` | Renamed `$name` to `$key` |
| `src/Attribute/PropertyConfig.php` | Renamed `$name` to `$key` |
| `src/Loader/Loader.php` | Updated `getPropertyNameMapping()` and `mergePropertyConfig()` to use `->key` |

### Test Files Updated

All test files using `Property(name:` or `PropertyConfig(...name:` have been updated:

- `tests/Unit/Hydrator/Fixtures/SimpleHydratable.php`
- `tests/Unit/Hydrator/Fixtures/HydratableWithHooks.php`
- `tests/Unit/AttributeCascade/Fixtures/ParentWithAttributes.php`
- `tests/Unit/AttributeCascade/Fixtures/ChildWithAttributes.php`
- `tests/Integration/Features/ExpressionLanguage/Fixtures/PersonWithCar.php`
- `tests/Integration/Features/AttributeCascade/AttributeCascadeIntegrationTest.php`
- `tests/Integration/Features/AttributeCascade/Fixtures/ParentWithAttributes.php`
- `tests/Integration/Features/AttributeCascade/Fixtures/ChildWithAttributes.php`
- `tests/Integration/Features/PropertyNamePrecedence/PropertyNamePrecedenceTest.php`
- `tests/Integration/AttributeSets/KeepAndSkipAndKeepAllAndSkipAll/PropertyInclusionTest.php`
- `tests/Integration/Attributes/PropertyCheckMapping/Fixtures/PersonWithStore.php`
- `tests/Integration/Attributes/DataSourceCheckLoadingScope/LoadingScopeTest.php`
- `tests/Integration/Attributes/DataSourceRefCheckProviders/DataSourceAggregationTest.php`
- `tests/Integration/Attributes/DataSourceStore/Fixtures/PersonWithStore.php`

### Documentation Updated

| File | Change |
|------|--------|
| `docs/attributes/Property.md` | Updated parameter table and examples |
| `docs/attributes/PropertyConfig.md` | Updated parameter table |
| `docs/attributes/MultiPropDataSource.md` | Updated examples |
| `docs/attributes/SkipAllProperties.md` | Updated examples |
| `docs/classes/Hydrator.md` | Updated examples |
| `docs/concepts/AttributeCascading.md` | Updated examples |
| `docs/concepts/ExpressionLanguage.md` | Updated examples |
| `EXAMPLE.md` | Updated examples |
| `README.md` | Updated examples |

## Breaking Changes

**Yes, this is a breaking change.**

Any code using `Property(name: ...)` or `PropertyConfig(..., name: ...)` must be updated to use `key:` instead.

### Migration Guide

Find and replace in your codebase:
- `Property(name:` → `Property(key:`
- `PropertyConfig(..., name:` → `PropertyConfig(..., key:`

## Test Results

```
Tests: 344, Assertions: 811, Skipped: 3
OK
```

## Related

- [Property](docs/attributes/Property.md)
- [PropertyConfig](docs/attributes/PropertyConfig.md)
