### PR TITLE
feat: code: add collection item class field attribute

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -240,6 +240,47 @@ class Order
 }
 ```
 
+### Collection Hydration with itemClass
+
+Use `itemClass` to hydrate collections of objects:
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class Person
+{
+    private ?string $firstName = null;
+    private ?string $lastName = null;
+    
+    // Each item in the addresses array will be hydrated as an Address object
+    #[Property(itemClass: Address::class)]
+    private ?array $addresses = null;
+}
+
+$rawData = [
+    'firstName' => 'John',
+    'lastName' => 'Doe',
+    'addresses' => [
+        ['street' => '123 Main St', 'city' => 'NYC', 'postalCode' => '10001'],
+        ['street' => '456 Oak Ave', 'city' => 'LA', 'postalCode' => '90001'],
+    ],
+];
+// Results in Person with addresses as [Address, Address]
+```
+
+### PHP Typehint Fallback
+
+When `class` is not specified, the hydrator uses the PHP typehint as a fallback:
+
+```php
+class Person
+{
+    // Will use Address class from typehint (no need to specify class: Address::class)
+    #[Property(sourceField: 'main_address')]
+    private ?Address $mainAddress = null;
+}
+```
+
 ### Polymorphic Collections
 
 ```php

--- a/README.md
+++ b/README.md
@@ -382,12 +382,27 @@ Map and configure properties:
 
 ```php
 #[Property(
-    name: 'first_name',           // Key in data array
-    class: Address::class,        // For nested objects
+    sourceField: 'first_name',    // Key in data array
+    class: Address::class,        // For single object hydration
+    itemClass: Address::class,    // For collection item hydration
     mapping: ['src_key' => 'dest_key'],  // Instance mapping
     expand: 'field1,field2',      // Fields to expand
     noExpand: 'field3'            // Fields to skip
 )]
+```
+
+**class vs itemClass:**
+- `class`: Use for single object properties (e.g., `?Address $address`)
+- `itemClass`: Use for collection properties (e.g., `?array $addresses`)
+
+```php
+// Single object
+#[Property(class: Address::class)]
+private ?Address $address = null;
+
+// Collection of objects
+#[Property(itemClass: Address::class)]
+private ?array $addresses = null;
 ```
 
 See [docs/attributes/Property.md](docs/attributes/Property.md) for details.

--- a/docs/attributes/Property.md
+++ b/docs/attributes/Property.md
@@ -23,6 +23,62 @@ class Person
 }
 ```
 
+### Collection Hydration with itemClass
+
+Use `itemClass` to specify the class for collection items:
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class Person
+{
+    #[Property(itemClass: Address::class)]
+    private ?array $addresses = null;
+}
+```
+
+This will hydrate each item in the `addresses` array as an `Address` object.
+
+### Single Object Hydration with class
+
+Use `class` for single object properties:
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class Person
+{
+    #[Property(class: Address::class)]
+    private ?Address $address = null;
+}
+```
+
+### PHP Typehint Fallback
+
+When `class` is not specified, the hydrator will use the PHP typehint as a fallback:
+
+```php
+class Person
+{
+    #[Property(sourceField: 'main_address')]
+    private ?Address $mainAddress = null;  // Will use Address class from typehint
+}
+```
+
+### Using class and itemClass Together
+
+Use both when you need a specific container class with typed items:
+
+```php
+use Kassko\DataMapper\Attribute\Property;
+
+class Person
+{
+    #[Property(class: ArrayCollection::class, itemClass: Address::class)]
+    private Collection $addresses;
+}
+```
+
 ### Using PropertyConfigStore Reference
 
 ```php
@@ -68,9 +124,10 @@ class Garage
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `key` | `?string` | No | Key in raw data array |
-| `class` | `?string` | No | Class for nested object hydration |
-| `mapping` | `?array` | No | Instance-specific key mapping (requires `class`) |
+| `sourceField` | `?string` | No | Key in raw data array |
+| `class` | `?string` | No | Class for single object hydration (container type) |
+| `itemClass` | `?string` | No | Class for collection item hydration (element type) |
+| `mapping` | `?array` | No | Instance-specific key mapping (requires `class` or `itemClass`) |
 | `expand` | `?string` | No | Comma-separated fields to expand |
 | `noExpand` | `?string` | No | Comma-separated fields to skip |
 | `config` | `?string` | No | Reference to a PropertyConfig by ID |
@@ -79,6 +136,29 @@ class Garage
 | `handleWhen` | `?string` | No | Expression to conditionally include this Property |
 | `cascade` | `bool` | No (default: true) | Whether this attribute cascades to child classes |
 | `enabled` | `bool` | No (default: true) | Whether this attribute is active |
+
+## class vs itemClass
+
+| Attribute | Purpose | Use Case |
+|-----------|---------|----------|
+| `class` | Class for single object hydration | Properties with a single nested object |
+| `itemClass` | Class for collection item hydration | Properties with arrays/collections of objects |
+
+**Examples:**
+
+```php
+// Single object - use class
+#[Property(class: Address::class)]
+private ?Address $address = null;
+
+// Collection - use itemClass
+#[Property(itemClass: Address::class)]
+private ?array $addresses = null;
+
+// Collection with specific container - use both
+#[Property(class: ArrayCollection::class, itemClass: Address::class)]
+private Collection $addresses;
+```
 
 ## Conditional Property Inclusion (handleWhen)
 
@@ -106,11 +186,24 @@ class Entity
 
 ## Validation Rules
 
-- `mapping` can only be set when `class` is also specified
-- `config` is mutually exclusive with `class`, `expand`, `noExpand`, and `mapping`
-- `configCandidates` is mutually exclusive with `class`, `expand`, `noExpand`, `mapping`, and `config`
+- `mapping` can only be set when `class` or `itemClass` is also specified
+- `itemClass` cannot be used with scalar built-in types (string, int, float, bool). Use array, object, or class types.
+- `class` must be compatible with the PHP typehint (same class or subclass)
+- `class` cannot be used with scalar built-in types
+- `config` is mutually exclusive with `class`, `itemClass`, `expand`, `noExpand`, and `mapping`
+- `configCandidates` is mutually exclusive with `class`, `itemClass`, `expand`, `noExpand`, `mapping`, and `config`
 - `configCandidates` and `defaultConfigCandidate` must both be present or both absent
 - Each configCandidate must have `id` and `when` keys
+
+## Type Resolution
+
+1. For single objects:
+   - If `class` is set, use it
+   - Otherwise, fall back to PHP typehint class
+
+2. For collections:
+   - If `itemClass` is set, use it for each item
+   - Otherwise, fall back to `class` for backward compatibility
 
 ## Modes
 

--- a/docs/attributes/PropertyConfig.md
+++ b/docs/attributes/PropertyConfig.md
@@ -40,16 +40,41 @@ class Garage
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | `string` | Yes | Unique identifier for this configuration |
-| `class` | `string` | No | Fully qualified class name for nested object hydration |
+| `class` | `string` | No | Class for single object hydration (container type) |
+| `itemClass` | `string` | No | Class for collection item hydration (element type) |
 | `sourceField` | `string` | No | Field name in raw data (array key or DTO property) |
 | `expand` | `string` | No | Comma-separated properties to expand |
 | `noExpand` | `string` | No | Comma-separated properties to NOT expand |
-| `mapping` | `array` | No | Instance-specific key mapping (requires `class`) |
+| `mapping` | `array` | No | Instance-specific key mapping (requires `class` or `itemClass`) |
+
+## class vs itemClass
+
+| Attribute | Purpose | Use Case |
+|-----------|---------|----------|
+| `class` | Class for single object hydration | Configs for single nested objects |
+| `itemClass` | Class for collection item hydration | Configs for arrays/collections of objects |
+
+### Using itemClass for Collections
+
+```php
+use Kassko\DataMapper\Attribute\PropertyConfig;
+use Kassko\DataMapper\Attribute\PropertyConfigStore;
+use Kassko\DataMapper\Attribute\Property;
+
+#[PropertyConfigStore([
+    new PropertyConfig(id: 'addressCollection', itemClass: Address::class),
+])]
+class Person
+{
+    #[Property(config: 'addressCollection')]
+    private array $addresses = [];
+}
+```
 
 ## Validation
 
 - `id` is required and must be unique within the `PropertyConfigStore`
-- `mapping` can only be set when `class` is also specified
+- `mapping` can only be set when `class` or `itemClass` is also specified
 
 ## See Also
 

--- a/docs/history/pull-requests/PR-2026_01_20---21_53_53.md
+++ b/docs/history/pull-requests/PR-2026_01_20---21_53_53.md
@@ -1,0 +1,95 @@
+# PR: Add itemClass Property for Collection Item Hydration
+
+## Summary
+
+This PR introduces the `itemClass` parameter for `Property` and `PropertyConfig` attributes, providing a dedicated way to specify the class for collection item hydration. This separates the concerns of container type (`class`) from element type (`itemClass`) in collection properties.
+
+## Breaking Changes
+
+- `Property::class` is now dedicated to **single objects** or **container types**
+- `Property::itemClass` is the new dedicated parameter for **collection item types**
+- Error message for mapping validation now mentions "class or itemClass"
+
+## Migration Guide
+
+### Before (using class for collections)
+```php
+#[Property(class: Address::class)]
+private ?array $addresses = null;
+```
+
+### After (using itemClass for collections)
+```php
+#[Property(itemClass: Address::class)]
+private ?array $addresses = null;
+```
+
+**Note:** The previous pattern still works for backward compatibility, but `itemClass` is the recommended approach.
+
+## New Features
+
+### 1. itemClass Parameter
+
+Use `itemClass` to specify the class for collection items:
+
+```php
+class Person
+{
+    #[Property(itemClass: Address::class)]
+    private ?array $addresses = null;
+}
+```
+
+### 2. class + itemClass Together
+
+Use both when you need a specific container class with typed items:
+
+```php
+#[Property(class: ArrayCollection::class, itemClass: Address::class)]
+private Collection $addresses;
+```
+
+### 3. PHP Typehint Fallback
+
+When `class` is not specified, the hydrator uses the PHP typehint as a fallback:
+
+```php
+class Person
+{
+    #[Property(sourceField: 'main_address')]
+    private ?Address $mainAddress = null;  // Uses Address from typehint
+}
+```
+
+### 4. Validation
+
+- `itemClass` cannot be used with scalar built-in types (string, int, float, bool)
+- `class` must be compatible with PHP typehint (same class or subclass)
+- `mapping` now works with either `class` or `itemClass`
+
+## Files Changed
+
+### Source Files
+- `src/Attribute/Property.php` - Added `itemClass` parameter
+- `src/Attribute/PropertyConfig.php` - Added `itemClass` parameter
+- `src/Loader/Loader.php` - Added type validation and fallback logic
+
+### Test Files
+- `tests/Integration/Attributes/PropertyCheckItemClass/` - New test suite for itemClass
+- `tests/Integration/Attributes/PropertyCheckInstanceMapping/InstanceMappingTest.php` - Updated error message
+
+### Documentation
+- `README.md` - Updated Property section with itemClass
+- `EXAMPLE.md` - Added itemClass and typehint fallback examples
+- `docs/attributes/Property.md` - Comprehensive itemClass documentation
+- `docs/attributes/PropertyConfig.md` - Added itemClass support
+
+## Testing
+
+All 489 tests pass, including 6 new tests for itemClass functionality:
+- `testItemClassHydratesCollectionItems`
+- `testClassHydratesSingleObject`
+- `testTypehintFallbackForSingleObject`
+- `testItemClassWithScalarTypeThrowsException`
+- `testPropertyItemClassCanBeUsedWithMappingValidation`
+- `testPropertyAllowsClassAndItemClassTogether`

--- a/docs/history/summaries/SUMMARY-2026_01_20---21_53_53.md
+++ b/docs/history/summaries/SUMMARY-2026_01_20---21_53_53.md
@@ -1,0 +1,120 @@
+# Summary: Collection Item Class Support (itemClass)
+
+**Date:** January 20, 2026  
+**Branch:** feat/code/collection_item_class  
+**Tag Reference:** 2.54.0-rc
+
+## Overview
+
+This work introduces a new `itemClass` parameter to the `Property` and `PropertyConfig` attributes, providing a clear separation between container class types and collection item types. This enhancement improves the semantic clarity of collection hydration configuration.
+
+## Changes Made
+
+### 1. Property Attribute Enhancement
+
+Added `itemClass` parameter to `Property` attribute:
+
+```php
+#[Property(itemClass: Address::class)]
+private ?array $addresses = null;
+```
+
+**Key behaviors:**
+- `class` is now dedicated to single objects or container types
+- `itemClass` is dedicated to collection item types
+- Both can be used together for advanced scenarios
+- PHP typehint fallback when `class` is not specified
+
+### 2. PropertyConfig Attribute Enhancement
+
+Added `itemClass` parameter to `PropertyConfig` attribute for reusable collection configurations:
+
+```php
+new PropertyConfig(id: 'addressCollection', itemClass: Address::class)
+```
+
+### 3. Type Validation
+
+Added validation to prevent incorrect usage:
+- `itemClass` cannot be used with scalar types (string, int, float, bool)
+- `class` must be compatible with PHP typehint (instanceof check)
+- `class` cannot be used with scalar types
+
+### 4. PHP Typehint Fallback
+
+When `Property::class` is not specified, the hydrator now uses the PHP typehint class as a fallback:
+
+```php
+#[Property(sourceField: 'main_address')]
+private ?Address $mainAddress = null;  // Uses Address from typehint
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/Attribute/Property.php` | Added `itemClass` parameter, updated validation |
+| `src/Attribute/PropertyConfig.php` | Added `itemClass` parameter, updated validation |
+| `src/Loader/Loader.php` | Added helper methods for type resolution and validation |
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `tests/Integration/Attributes/PropertyCheckItemClass/ItemClassTest.php` | Test suite for itemClass |
+| `tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/Address.php` | Test fixture |
+| `tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithItemClass.php` | Test fixture |
+| `tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithClassForSingleObject.php` | Test fixture |
+| `tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithTypehintFallback.php` | Test fixture |
+| `tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithScalarItemClass.php` | Test fixture |
+| `docs/history/pull-requests/PR-2026_01_20---21_53_53.md` | PR description |
+
+## Documentation Updated
+
+- `README.md` - Property section with itemClass usage
+- `EXAMPLE.md` - Collection hydration and typehint fallback examples
+- `docs/attributes/Property.md` - Comprehensive itemClass documentation
+- `docs/attributes/PropertyConfig.md` - itemClass support
+
+## Test Results
+
+```
+Tests: 489, Assertions: 1305
+Status: OK
+New tests: 6
+```
+
+## New Helper Methods in Loader
+
+| Method | Purpose |
+|--------|---------|
+| `isScalarBuiltinType()` | Check if type is scalar built-in |
+| `resolveContainerClass()` | Resolve container class with typehint fallback |
+| `validateItemClassNotWithScalar()` | Validate itemClass not used with scalars |
+| `validateClassWithTypehint()` | Validate class compatibility with typehint |
+
+## Usage Examples
+
+### Single Object
+```php
+#[Property(class: Address::class)]
+private ?Address $address = null;
+```
+
+### Collection
+```php
+#[Property(itemClass: Address::class)]
+private ?array $addresses = null;
+```
+
+### Container + Items
+```php
+#[Property(class: ArrayCollection::class, itemClass: Address::class)]
+private Collection $addresses;
+```
+
+### Typehint Fallback
+```php
+#[Property(sourceField: 'main_address')]
+private ?Address $mainAddress = null;  // Uses Address from typehint
+```

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -21,7 +21,8 @@ final class Property
 {
     public function __construct(
         public readonly ?string $sourceField = null,  // Field name in raw data (array key or DTO property)
-        public readonly ?string $class = null,        // Class for nested object hydration
+        public readonly ?string $class = null,        // Class for single object hydration (container type)
+        public readonly ?string $itemClass = null,    // Class for collection item hydration (element type)
         public readonly ?string $expand = null,    // Comma-separated props to expand
         public readonly ?string $noExpand = null,  // Comma-separated props to NOT expand
         public readonly ?array $mapping = null,    // Instance-specific key mapping
@@ -40,22 +41,22 @@ final class Property
         public readonly ?string $handleWhen = null,
         public readonly bool $enabled = true,      // Whether this attribute is active (disabled attributes are ignored)
     ) {
-        // Validation: mapping requires class to be set
-        if ($mapping !== null && $class === null) {
-            throw new \InvalidArgumentException('Property: mapping can only be set when class is also specified');
+        // Validation: mapping requires class or itemClass to be set
+        if ($mapping !== null && $class === null && $itemClass === null) {
+            throw new \InvalidArgumentException('Property: mapping can only be set when class or itemClass is also specified');
         }
 
-        // Validation: config is mutually exclusive with class, expand, noExpand, mapping
-        if ($config !== null && ($class !== null || $expand !== null || $noExpand !== null || $mapping !== null)) {
+        // Validation: config is mutually exclusive with class, itemClass, expand, noExpand, mapping
+        if ($config !== null && ($class !== null || $itemClass !== null || $expand !== null || $noExpand !== null || $mapping !== null)) {
             throw new \InvalidArgumentException(
-                'Property: config is mutually exclusive with class, expand, noExpand, and mapping'
+                'Property: config is mutually exclusive with class, itemClass, expand, noExpand, and mapping'
             );
         }
 
-        // Validation: configCandidates is mutually exclusive with class, expand, noExpand, mapping, config
-        if ($configCandidates !== null && ($class !== null || $expand !== null || $noExpand !== null || $mapping !== null || $config !== null)) {
+        // Validation: configCandidates is mutually exclusive with class, itemClass, expand, noExpand, mapping, config
+        if ($configCandidates !== null && ($class !== null || $itemClass !== null || $expand !== null || $noExpand !== null || $mapping !== null || $config !== null)) {
             throw new \InvalidArgumentException(
-                'Property: configCandidates is mutually exclusive with class, expand, noExpand, mapping, and config'
+                'Property: configCandidates is mutually exclusive with class, itemClass, expand, noExpand, mapping, and config'
             );
         }
 

--- a/src/Attribute/PropertyConfig.php
+++ b/src/Attribute/PropertyConfig.php
@@ -23,7 +23,8 @@ final class PropertyConfig
 {
     public function __construct(
         public readonly string $id,
-        public readonly ?string $class = null,
+        public readonly ?string $class = null,        // Class for single object hydration (container type)
+        public readonly ?string $itemClass = null,    // Class for collection item hydration (element type)
         public readonly ?string $sourceField = null,  // Field name in raw data (array key or DTO property)
         public readonly ?string $expand = null,
         public readonly ?string $noExpand = null,
@@ -32,9 +33,9 @@ final class PropertyConfig
         public readonly bool $cascade = true,                    // Whether this config cascades to child classes
         public readonly bool $enabled = true,                    // Whether this config is active (disabled configs are ignored)
     ) {
-        // Validation: mapping requires class to be set
-        if ($mapping !== null && $class === null) {
-            throw new \InvalidArgumentException('PropertyConfig: mapping can only be set when class is also specified');
+        // Validation: mapping requires class or itemClass to be set
+        if ($mapping !== null && $class === null && $itemClass === null) {
+            throw new \InvalidArgumentException('PropertyConfig: mapping can only be set when class or itemClass is also specified');
         }
     }
 }

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -1811,6 +1811,12 @@ class Loader implements LoaderInterface
             return $value;
         }
         
+        // Validate itemClass is not used with scalar types
+        $this->validateItemClassNotWithScalar($property, $propertyAttr);
+        
+        // Validate class is compatible with typehint
+        $this->validateClassWithTypehint($property, $propertyAttr);
+        
         // Check depth limit
         $loading = $this->attributeReader->readLoading($property);
         if ($loading !== null && $loading->depth !== null && $currentDepth >= $loading->depth) {
@@ -1855,14 +1861,19 @@ class Loader implements LoaderInterface
                     }
                 }
                 
+                // Determine the class for collection items:
+                // 1. Use itemClass if defined (preferred for collections)
+                // 2. Fall back to class for backward compatibility
+                $itemClassName = $itemPropertyAttr->itemClass ?? $itemPropertyAttr->class ?? null;
+                
                 // If still no class defined, skip this item
-                if ($itemPropertyAttr === null || $itemPropertyAttr->class === null) {
+                if ($itemClassName === null) {
                     $result[] = $itemData;
                     continue;
                 }
                 
                 // Instantiate the nested object with Param attribute support
-                $nestedObject = $this->instantiateWithParams($itemPropertyAttr->class);
+                $nestedObject = $this->instantiateWithParams($itemClassName);
                 
                 // Track parent-child relationship
                 if ($parentObject !== null) {
@@ -1897,13 +1908,15 @@ class Loader implements LoaderInterface
             }
         }
         
+        // Resolve the class to instantiate:
+        // 1. Use Property::class if defined
+        // 2. Fall back to PHP typehint class if available
+        $className = $effectivePropertyAttr->class ?? $this->resolveContainerClass($property, $effectivePropertyAttr);
+        
         // If no class defined, return as-is
-        if ($effectivePropertyAttr === null || $effectivePropertyAttr->class === null) {
+        if ($className === null) {
             return $value;
         }
-        
-        // Get the actual class to instantiate
-        $className = $effectivePropertyAttr->class;
         
         // Instantiate the nested object with Param attribute support
         $nestedObject = $this->instantiateWithParams($className);
@@ -2018,6 +2031,7 @@ class Loader implements LoaderInterface
             // Property.sourceField takes precedence over PropertyConfig.sourceField
             sourceField: $propertyAttr->sourceField ?? $config->sourceField,
             class: $propertyAttr->class ?? $config->class,
+            itemClass: $propertyAttr->itemClass ?? $config->itemClass,
             expand: $propertyAttr->expand ?? $config->expand,
             noExpand: $propertyAttr->noExpand ?? $config->noExpand,
             mapping: $propertyAttr->mapping ?? $config->mapping,
@@ -2211,6 +2225,167 @@ class Loader implements LoaderInterface
     private function isListArray(array $array): bool
     {
         return array_is_list($array);
+    }
+
+    /**
+     * Check if a PHP type is a scalar built-in type
+     *
+     * @param string $typeName
+     * @return bool
+     */
+    private function isScalarBuiltinType(string $typeName): bool
+    {
+        return in_array($typeName, ['string', 'int', 'float', 'bool', 'null', 'false', 'true', 'mixed'], true);
+    }
+
+    /**
+     * Get the container class (Property::class or typehint class) for a property
+     * Falls back to PHP typehint if Property::class is not set
+     *
+     * @param ReflectionProperty $property
+     * @param Property|null $propertyAttr
+     * @return string|null
+     */
+    private function resolveContainerClass(ReflectionProperty $property, ?Property $propertyAttr): ?string
+    {
+        // If Property::class is explicitly set, use it
+        if ($propertyAttr !== null && $propertyAttr->class !== null) {
+            return $propertyAttr->class;
+        }
+        
+        // Try to get class from PHP typehint
+        $type = $property->getType();
+        if ($type === null) {
+            return null;
+        }
+        
+        // Handle union types - take first non-null type
+        if ($type instanceof \ReflectionUnionType) {
+            foreach ($type->getTypes() as $unionType) {
+                if ($unionType instanceof \ReflectionNamedType && !$unionType->isBuiltin() && $unionType->getName() !== 'null') {
+                    return $unionType->getName();
+                }
+            }
+            return null;
+        }
+        
+        // Handle named types
+        if ($type instanceof \ReflectionNamedType) {
+            $typeName = $type->getName();
+            // Skip built-in types like array, object, int, string, etc.
+            if (!$type->isBuiltin()) {
+                return $typeName;
+            }
+        }
+        
+        return null;
+    }
+
+    /**
+     * Validate that itemClass is not used with scalar built-in types
+     *
+     * @param ReflectionProperty $property
+     * @param Property $propertyAttr
+     * @throws \InvalidArgumentException if itemClass is used with a scalar type
+     */
+    private function validateItemClassNotWithScalar(ReflectionProperty $property, Property $propertyAttr): void
+    {
+        if ($propertyAttr->itemClass === null) {
+            return;
+        }
+        
+        $type = $property->getType();
+        if ($type === null) {
+            return; // No type constraint, allow itemClass
+        }
+        
+        // Handle named types
+        if ($type instanceof \ReflectionNamedType) {
+            $typeName = $type->getName();
+            if ($this->isScalarBuiltinType($typeName)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Property "%s" in class "%s" has itemClass defined but has scalar type "%s". ' .
+                    'itemClass can only be used with array, object, or class types.',
+                    $property->getName(),
+                    $property->getDeclaringClass()->getName(),
+                    $typeName
+                ));
+            }
+        }
+        
+        // Handle union types - check if all types are scalar
+        if ($type instanceof \ReflectionUnionType) {
+            $hasNonScalar = false;
+            foreach ($type->getTypes() as $unionType) {
+                if ($unionType instanceof \ReflectionNamedType) {
+                    $typeName = $unionType->getName();
+                    if (!$this->isScalarBuiltinType($typeName)) {
+                        $hasNonScalar = true;
+                        break;
+                    }
+                }
+            }
+            if (!$hasNonScalar) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Property "%s" in class "%s" has itemClass defined but has only scalar types. ' .
+                    'itemClass can only be used with array, object, or class types.',
+                    $property->getName(),
+                    $property->getDeclaringClass()->getName()
+                ));
+            }
+        }
+    }
+
+    /**
+     * Validate that Property::class is compatible with PHP typehint
+     *
+     * @param ReflectionProperty $property
+     * @param Property $propertyAttr
+     * @throws \InvalidArgumentException if class is incompatible with typehint
+     */
+    private function validateClassWithTypehint(ReflectionProperty $property, Property $propertyAttr): void
+    {
+        if ($propertyAttr->class === null) {
+            return;
+        }
+        
+        $type = $property->getType();
+        if ($type === null) {
+            return; // No type constraint, any class is allowed
+        }
+        
+        // Handle named types
+        if ($type instanceof \ReflectionNamedType) {
+            $typeName = $type->getName();
+            
+            // Skip built-in types like array, object
+            if ($type->isBuiltin()) {
+                // Cannot have Property::class with scalar typehint
+                if ($this->isScalarBuiltinType($typeName)) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Property "%s" in class "%s" has class "%s" defined but has scalar type "%s". ' .
+                        'Property::class cannot be used with scalar types.',
+                        $property->getName(),
+                        $property->getDeclaringClass()->getName(),
+                        $propertyAttr->class,
+                        $typeName
+                    ));
+                }
+                return;
+            }
+            
+            // Check if Property::class is compatible with typehint (must be same or subclass)
+            if (!is_a($propertyAttr->class, $typeName, true)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Property "%s" in class "%s" has class "%s" which is not compatible with typehint "%s". ' .
+                    'Property::class must be the same class or a subclass of the typehint.',
+                    $property->getName(),
+                    $property->getDeclaringClass()->getName(),
+                    $propertyAttr->class,
+                    $typeName
+                ));
+            }
+        }
     }
 
     /**

--- a/tests/Integration/Attributes/PropertyCheckInstanceMapping/InstanceMappingTest.php
+++ b/tests/Integration/Attributes/PropertyCheckInstanceMapping/InstanceMappingTest.php
@@ -125,7 +125,7 @@ class InstanceMappingTest extends TestCase
     public function testMappingRequiresClass(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Property: mapping can only be set when class is also specified');
+        $this->expectExceptionMessage('Property: mapping can only be set when class or itemClass is also specified');
         
         new Property(
             mapping: ['source' => 'target']

--- a/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/Address.php
+++ b/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/Address.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures;
+
+class Address
+{
+    private ?string $street = null;
+    private ?string $city = null;
+    private ?string $postalCode = null;
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): self
+    {
+        $this->street = $street;
+        return $this;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): self
+    {
+        $this->city = $city;
+        return $this;
+    }
+
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode;
+    }
+
+    public function setPostalCode(?string $postalCode): self
+    {
+        $this->postalCode = $postalCode;
+        return $this;
+    }
+}

--- a/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithClassForSingleObject.php
+++ b/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithClassForSingleObject.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures;
+
+use Kassko\DataMapper\Attribute\Property;
+
+class PersonWithClassForSingleObject
+{
+    private ?string $firstName = null;
+    private ?string $lastName = null;
+
+    #[Property(class: Address::class)]
+    private ?Address $address = null;
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->lastName = $lastName;
+        return $this;
+    }
+
+    public function getAddress(): ?Address
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?Address $address): self
+    {
+        $this->address = $address;
+        return $this;
+    }
+}

--- a/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithItemClass.php
+++ b/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithItemClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures;
+
+use Kassko\DataMapper\Attribute\Property;
+
+class PersonWithItemClass
+{
+    private ?string $firstName = null;
+    private ?string $lastName = null;
+
+    #[Property(itemClass: Address::class)]
+    private ?array $addresses = null;
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->lastName = $lastName;
+        return $this;
+    }
+
+    public function getAddresses(): ?array
+    {
+        return $this->addresses;
+    }
+
+    public function setAddresses(?array $addresses): self
+    {
+        $this->addresses = $addresses;
+        return $this;
+    }
+}

--- a/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithScalarItemClass.php
+++ b/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithScalarItemClass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures;
+
+use Kassko\DataMapper\Attribute\Property;
+
+class PersonWithScalarItemClass
+{
+    private ?string $firstName = null;
+
+    // This should throw an exception - itemClass cannot be used with scalar types
+    #[Property(itemClass: Address::class)]
+    private ?string $invalidProperty = null;
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    public function getInvalidProperty(): ?string
+    {
+        return $this->invalidProperty;
+    }
+
+    public function setInvalidProperty(?string $invalidProperty): self
+    {
+        $this->invalidProperty = $invalidProperty;
+        return $this;
+    }
+}

--- a/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithTypehintFallback.php
+++ b/tests/Integration/Attributes/PropertyCheckItemClass/Fixtures/PersonWithTypehintFallback.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures;
+
+use Kassko\DataMapper\Attribute\Property;
+
+class PersonWithTypehintFallback
+{
+    private ?string $firstName = null;
+    private ?string $lastName = null;
+
+    // Should use Address class from PHP typehint since Property::class is not set
+    #[Property(sourceField: 'main_address')]
+    private ?Address $mainAddress = null;
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->lastName = $lastName;
+        return $this;
+    }
+
+    public function getMainAddress(): ?Address
+    {
+        return $this->mainAddress;
+    }
+
+    public function setMainAddress(?Address $mainAddress): self
+    {
+        $this->mainAddress = $mainAddress;
+        return $this;
+    }
+}

--- a/tests/Integration/Attributes/PropertyCheckItemClass/ItemClassTest.php
+++ b/tests/Integration/Attributes/PropertyCheckItemClass/ItemClassTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass;
+
+use Kassko\DataMapper\Attribute\Property;
+use Kassko\DataMapper\DataMapper;
+use Kassko\DataMapper\DataMapperBuilder;
+use Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures\Address;
+use Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures\PersonWithItemClass;
+use Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures\PersonWithClassForSingleObject;
+use Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures\PersonWithTypehintFallback;
+use Kassko\DataMapper\Tests\Integration\Attributes\PropertyCheckItemClass\Fixtures\PersonWithScalarItemClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Property::itemClass and Property::class behavior.
+ */
+class ItemClassTest extends TestCase
+{
+    private DataMapper $dataMapper;
+
+    protected function setUp(): void
+    {
+        $this->dataMapper = (new DataMapperBuilder())->build();
+    }
+
+    /**
+     * Test that itemClass is used to hydrate collection items
+     */
+    public function testItemClassHydratesCollectionItems(): void
+    {
+        $rawData = [
+            'firstName' => 'John',
+            'lastName' => 'Doe',
+            'addresses' => [
+                [
+                    'street' => '123 Main St',
+                    'city' => 'New York',
+                    'postalCode' => '10001',
+                ],
+                [
+                    'street' => '456 Oak Ave',
+                    'city' => 'Los Angeles',
+                    'postalCode' => '90001',
+                ],
+            ],
+        ];
+
+        $person = $this->dataMapper->getHydrator()->hydrate(PersonWithItemClass::class, $rawData);
+
+        $this->assertEquals('John', $person->getFirstName());
+        $this->assertEquals('Doe', $person->getLastName());
+        
+        $addresses = $person->getAddresses();
+        $this->assertCount(2, $addresses);
+        
+        $this->assertInstanceOf(Address::class, $addresses[0]);
+        $this->assertEquals('123 Main St', $addresses[0]->getStreet());
+        $this->assertEquals('New York', $addresses[0]->getCity());
+        $this->assertEquals('10001', $addresses[0]->getPostalCode());
+        
+        $this->assertInstanceOf(Address::class, $addresses[1]);
+        $this->assertEquals('456 Oak Ave', $addresses[1]->getStreet());
+        $this->assertEquals('Los Angeles', $addresses[1]->getCity());
+        $this->assertEquals('90001', $addresses[1]->getPostalCode());
+    }
+
+    /**
+     * Test that class is used for single object hydration
+     */
+    public function testClassHydratesSingleObject(): void
+    {
+        $rawData = [
+            'firstName' => 'John',
+            'lastName' => 'Doe',
+            'address' => [
+                'street' => '123 Main St',
+                'city' => 'New York',
+                'postalCode' => '10001',
+            ],
+        ];
+
+        $person = $this->dataMapper->getHydrator()->hydrate(PersonWithClassForSingleObject::class, $rawData);
+
+        $this->assertEquals('John', $person->getFirstName());
+        $this->assertEquals('Doe', $person->getLastName());
+        
+        $address = $person->getAddress();
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('123 Main St', $address->getStreet());
+        $this->assertEquals('New York', $address->getCity());
+        $this->assertEquals('10001', $address->getPostalCode());
+    }
+
+    /**
+     * Test that PHP typehint is used when Property::class is not set
+     */
+    public function testTypehintFallbackForSingleObject(): void
+    {
+        $rawData = [
+            'firstName' => 'John',
+            'lastName' => 'Doe',
+            'main_address' => [
+                'street' => '789 Pine Rd',
+                'city' => 'Chicago',
+                'postalCode' => '60601',
+            ],
+        ];
+
+        $person = $this->dataMapper->getHydrator()->hydrate(PersonWithTypehintFallback::class, $rawData);
+
+        $this->assertEquals('John', $person->getFirstName());
+        $this->assertEquals('Doe', $person->getLastName());
+        
+        $address = $person->getMainAddress();
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('789 Pine Rd', $address->getStreet());
+        $this->assertEquals('Chicago', $address->getCity());
+        $this->assertEquals('60601', $address->getPostalCode());
+    }
+
+    /**
+     * Test that itemClass with scalar type throws an exception
+     */
+    public function testItemClassWithScalarTypeThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('has itemClass defined but has scalar type');
+        
+        $rawData = [
+            'firstName' => 'John',
+            'invalidProperty' => [
+                ['street' => 'test'],
+            ],
+        ];
+
+        $this->dataMapper->getHydrator()->hydrate(PersonWithScalarItemClass::class, $rawData);
+    }
+
+    /**
+     * Test that Property attribute validation works for itemClass
+     */
+    public function testPropertyItemClassCanBeUsedWithMappingValidation(): void
+    {
+        // Should not throw exception
+        $property = new Property(
+            itemClass: Address::class,
+            mapping: ['source' => 'target']
+        );
+        
+        $this->assertEquals(Address::class, $property->itemClass);
+    }
+
+    /**
+     * Test that Property attribute allows class and itemClass together
+     */
+    public function testPropertyAllowsClassAndItemClassTogether(): void
+    {
+        // Should not throw exception - class for container, itemClass for items
+        $property = new Property(
+            class: 'ArrayCollection',
+            itemClass: Address::class
+        );
+        
+        $this->assertEquals('ArrayCollection', $property->class);
+        $this->assertEquals(Address::class, $property->itemClass);
+    }
+}


### PR DESCRIPTION
# PR: Add itemClass Property for Collection Item Hydration

## Summary

This PR introduces the `itemClass` parameter for `Property` and `PropertyConfig` attributes, providing a dedicated way to specify the class for collection item hydration. This separates the concerns of container type (`class`) from element type (`itemClass`) in collection properties.

## Breaking Changes

- `Property::class` is now dedicated to **single objects** or **container types**
- `Property::itemClass` is the new dedicated parameter for **collection item types**
- Error message for mapping validation now mentions "class or itemClass"

## Migration Guide

### Before (using class for collections)
```php
#[Property(class: Address::class)]
private ?array $addresses = null;
```

### After (using itemClass for collections)
```php
#[Property(itemClass: Address::class)]
private ?array $addresses = null;
```

**Note:** The previous pattern still works for backward compatibility, but `itemClass` is the recommended approach.

## New Features

### 1. itemClass Parameter

Use `itemClass` to specify the class for collection items:

```php
class Person
{
    #[Property(itemClass: Address::class)]
    private ?array $addresses = null;
}
```

### 2. class + itemClass Together

Use both when you need a specific container class with typed items:

```php
#[Property(class: ArrayCollection::class, itemClass: Address::class)]
private Collection $addresses;
```

### 3. PHP Typehint Fallback

When `class` is not specified, the hydrator uses the PHP typehint as a fallback:

```php
class Person
{
    #[Property(sourceField: 'main_address')]
    private ?Address $mainAddress = null;  // Uses Address from typehint
}
```

### 4. Validation

- `itemClass` cannot be used with scalar built-in types (string, int, float, bool)
- `class` must be compatible with PHP typehint (same class or subclass)
- `mapping` now works with either `class` or `itemClass`

## Files Changed

### Source Files
- `src/Attribute/Property.php` - Added `itemClass` parameter
- `src/Attribute/PropertyConfig.php` - Added `itemClass` parameter
- `src/Loader/Loader.php` - Added type validation and fallback logic

### Test Files
- `tests/Integration/Attributes/PropertyCheckItemClass/` - New test suite for itemClass
- `tests/Integration/Attributes/PropertyCheckInstanceMapping/InstanceMappingTest.php` - Updated error message

### Documentation
- `README.md` - Updated Property section with itemClass
- `EXAMPLE.md` - Added itemClass and typehint fallback examples
- `docs/attributes/Property.md` - Comprehensive itemClass documentation
- `docs/attributes/PropertyConfig.md` - Added itemClass support

## Testing

All 489 tests pass, including 6 new tests for itemClass functionality:
- `testItemClassHydratesCollectionItems`
- `testClassHydratesSingleObject`
- `testTypehintFallbackForSingleObject`
- `testItemClassWithScalarTypeThrowsException`
- `testPropertyItemClassCanBeUsedWithMappingValidation`
- `testPropertyAllowsClassAndItemClassTogether`
