### PR TITLE
feat: code: add mapping cache, rename existing cache to dataSourceCache, remove class usage as item class (old pattern) and more

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -564,6 +564,29 @@ class Person
 
 ## Mapping Strategy
 
+### ⚠️ Enable MappingStrategy First
+
+MappingStrategy is **disabled by default**. Enable it before using:
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+
+$dataMapper = (new DataMapperBuilder())
+    ->enableMappingStrategy()  // Required!
+    ->setMappingCache($cache)  // Optional: PSR-16 cache for performance
+    ->build();
+```
+
+Or in Symfony Bundle:
+```yaml
+kassko_data_mapper:
+    mapping_strategy:
+        enabled: true
+    mapping_cache:
+        enabled: true
+        service: 'cache.app'
+```
+
 ### Auto-Converting Source Field Cases
 
 Use `MappingStrategy` to automatically map source fields with different naming conventions to camelCase properties:

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -577,16 +577,6 @@ $dataMapper = (new DataMapperBuilder())
     ->build();
 ```
 
-Or in Symfony Bundle:
-```yaml
-kassko_data_mapper:
-    mapping_strategy:
-        enabled: true
-    mapping_cache:
-        enabled: true
-        service: 'cache.app'
-```
-
 ### Auto-Converting Source Field Cases
 
 Use `MappingStrategy` to automatically map source fields with different naming conventions to camelCase properties:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ $dataMapperbuilder = new DataMapperBuilder();
 // Optional: Add a PSR-3 logger
 $dataMapperbuilder->setLogger($yourLogger);
 
+// Optional: Add PSR-16 caches
+$dataMapperbuilder->setDataSourceCache($cache);    // Cache for data sources
+$dataMapperbuilder->setMappingCache($cache);       // Cache for MappingStrategy conversions
+
+// Optional: Enable MappingStrategy feature (disabled by default)
+$dataMapperbuilder->enableMappingStrategy();
+
 // Optional: Add custom hydrators
 $dataMapperbuilder->addCustomHydrator('my_parser', function(array $data): ?object {
     return new MyClass($data);

--- a/docs/attributes/MappingStrategy.md
+++ b/docs/attributes/MappingStrategy.md
@@ -6,7 +6,7 @@ Defines a mapping strategy for converting source field names (various cases) to 
 
 MappingStrategy feature is **disabled by default** for performance reasons. You must explicitly enable it before using MappingStrategy attributes.
 
-### Enabling via DataMapperBuilder
+### Enabling it
 
 ```php
 use Kassko\DataMapper\DataMapperBuilder;
@@ -14,20 +14,6 @@ use Kassko\DataMapper\DataMapperBuilder;
 $dataMapper = (new DataMapperBuilder())
     ->enableMappingStrategy()  // Required to use MappingStrategy
     ->build();
-```
-
-### Enabling via Symfony Bundle
-
-```yaml
-# config/packages/kassko_data_mapper.yaml
-kassko_data_mapper:
-    mapping_strategy:
-        enabled: true  # Enable MappingStrategy feature
-    
-    # Optional: Enable caching for better performance
-    mapping_cache:
-        enabled: true
-        service: 'cache.app'  # PSR-16 cache service
 ```
 
 > **Note:** Using MappingStrategy without enabling it will throw a `MappingStrategyException`.
@@ -219,17 +205,6 @@ $dataMapper = (new DataMapperBuilder())
     ->enableMappingStrategy()
     ->setMappingCache($cache)  // PSR-16 cache for conversions
     ->build();
-```
-
-### Bundle Configuration
-
-```yaml
-kassko_data_mapper:
-    mapping_strategy:
-        enabled: true
-    mapping_cache:
-        enabled: true
-        service: 'cache.app'  # Use Symfony's PSR-16 cache
 ```
 
 ### In-Memory Cache (Default)

--- a/docs/attributes/MappingStrategy.md
+++ b/docs/attributes/MappingStrategy.md
@@ -2,6 +2,36 @@
 
 Defines a mapping strategy for converting source field names (various cases) to property names (camelCase). Can be applied at class level or property level.
 
+## ⚠️ Important: Enabling MappingStrategy
+
+MappingStrategy feature is **disabled by default** for performance reasons. You must explicitly enable it before using MappingStrategy attributes.
+
+### Enabling via DataMapperBuilder
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+
+$dataMapper = (new DataMapperBuilder())
+    ->enableMappingStrategy()  // Required to use MappingStrategy
+    ->build();
+```
+
+### Enabling via Symfony Bundle
+
+```yaml
+# config/packages/kassko_data_mapper.yaml
+kassko_data_mapper:
+    mapping_strategy:
+        enabled: true  # Enable MappingStrategy feature
+    
+    # Optional: Enable caching for better performance
+    mapping_cache:
+        enabled: true
+        service: 'cache.app'  # PSR-16 cache service
+```
+
+> **Note:** Using MappingStrategy without enabling it will throw a `MappingStrategyException`.
+
 ## Overview
 
 When working with external data sources (APIs, databases, files), field names often use different naming conventions than PHP camelCase properties. `MappingStrategy` provides automatic conversion between these conventions.
@@ -169,6 +199,42 @@ private ?string $firstName = null;
 2. **Medium**: Property-level `MappingStrategy`
 3. **Lowest**: Class-level `MappingStrategy`
 4. **Default**: `from_common_cases_mix` (when no mapping defined)
+
+## Performance Considerations
+
+Case conversion operations can be expensive, especially with large datasets or frequently accessed objects. To optimize performance:
+
+### Using Mapping Cache
+
+Enable the mapping cache to cache case conversion results:
+
+```php
+use Kassko\DataMapper\DataMapperBuilder;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+$cache = new Psr16Cache(new FilesystemAdapter());
+
+$dataMapper = (new DataMapperBuilder())
+    ->enableMappingStrategy()
+    ->setMappingCache($cache)  // PSR-16 cache for conversions
+    ->build();
+```
+
+### Bundle Configuration
+
+```yaml
+kassko_data_mapper:
+    mapping_strategy:
+        enabled: true
+    mapping_cache:
+        enabled: true
+        service: 'cache.app'  # Use Symfony's PSR-16 cache
+```
+
+### In-Memory Cache (Default)
+
+When no external cache is provided, an in-memory array cache is used automatically. This provides good performance within a single request but doesn't persist across requests.
 
 ## See Also
 

--- a/docs/history/pull-requests/PR-2026_01_31---17_16_33.md
+++ b/docs/history/pull-requests/PR-2026_01_31---17_16_33.md
@@ -1,0 +1,186 @@
+# Pull Request: MappingCache and More
+
+**Branch:** `feat/code/mapping_cache_and_more`
+**Date:** 2026-01-31
+
+## Summary
+
+This PR introduces several enhancements to the DataMapper library focusing on cache management, MappingStrategy feature control, improved error messages, and cleanup of backward compatibility code.
+
+## Changes
+
+### 1. Removed Backward Compatibility Fallback for itemClass
+
+**File:** `src/Loader/Loader.php`
+
+Removed the BC fallback that allowed using `Property::class` for collection items. Now `itemClass` must be used explicitly for collections.
+
+```php
+// Before (BC fallback allowed)
+#[Property(class: Employee::class)]  // Also worked for arrays
+private array $employees = [];
+
+// After (correct usage)
+#[Property(itemClass: Employee::class)]
+private array $employees = [];
+```
+
+**Note:** The `class` attribute is still used for `configCandidates` (polymorphism) where `PropertyConfig::class` represents the element type.
+
+### 2. Renamed Cache to DataSourceCache
+
+**Files:**
+- `src/DataMapperBuilder.php`
+- `src/DataMapper.php`
+- `src/Expression/SourceFunctionProvider.php`
+
+Renamed `$cache` → `$dataSourceCache` and `setCache()` → `setDataSourceCache()` to clarify its purpose.
+
+### 3. Added Mapping Cache
+
+**Files:**
+- `src/DataMapperBuilder.php`
+- `src/DataMapper.php`
+- `src/Loader/Loader.php`
+
+Added a dedicated cache for MappingStrategy conversions:
+
+```php
+$builder = new DataMapperBuilder();
+$builder->setMappingCache($psr16Cache);  // Optional PSR-16 cache
+$dataMapper = $builder->build();
+```
+
+An in-memory array cache is used automatically as fallback when no external cache is provided.
+
+### 4. Added enableMappingStrategy() Option
+
+**Files:**
+- `src/DataMapperBuilder.php`
+- `src/DataMapper.php`
+- `src/Loader/Loader.php`
+- `src/Exception/MappingStrategyException.php`
+
+MappingStrategy is now **disabled by default** for performance. Users must explicitly enable it:
+
+```php
+$builder = new DataMapperBuilder();
+$builder->enableMappingStrategy();  // Required to use MappingStrategy attribute
+$dataMapper = $builder->build();
+```
+
+If MappingStrategy attributes are used without enabling the feature, a `MappingStrategyException` is thrown with a helpful message.
+
+### 5. Improved Setter Type Mismatch Error Messages
+
+**File:** `src/Loader/Loader.php`
+
+Added enhanced error messages when a setter or adder method receives an incorrect type (e.g., array instead of object):
+
+```
+TypeError: MyClass::setEmployee() expects Employee, array given.
+Consider adding #[Property(class: Employee::class)] attribute to 'employee' property
+to specify the object type and enable automatic hydration.
+```
+
+For collections:
+```
+TypeError: MyClass::addItem() expects Item, array given.
+Consider adding #[Property(itemClass: Item::class)] attribute to 'items' property
+to specify the collection item type and enable automatic hydration.
+```
+
+### 6. Updated data-mapper-bundle
+
+**Files:**
+- `config/services.yaml`
+- `src/DependencyInjection/Configuration.php`
+- `src/DependencyInjection/KasskoDataMapperExtension.php`
+- `src/Service/DataMapperFactory.php`
+
+Bundle configuration now supports:
+
+```yaml
+kassko_data_mapper:
+    data_source_cache:
+        enabled: true
+        service: 'cache.app'
+    
+    mapping_cache:
+        enabled: true
+        service: 'cache.app'
+    
+    mapping_strategy:
+        enabled: true
+```
+
+### 7. Updated Documentation
+
+**Files:**
+- `README.md`
+- `EXAMPLE.md`
+- `docs/attributes/MappingStrategy.md`
+- `data-mapper-bundle/README.md`
+
+Added documentation for:
+- New cache configuration options
+- MappingStrategy activation requirements
+- Performance considerations and caching recommendations
+
+## Breaking Changes
+
+1. **Cache method renamed:** `setCache()` → `setDataSourceCache()`
+2. **MappingStrategy disabled by default:** Must call `enableMappingStrategy()` to use MappingStrategy attributes
+3. **itemClass required for collections:** `Property::class` no longer works as fallback for array items
+
+## Migration Guide
+
+### From previous version
+
+1. **Update cache calls:**
+   ```php
+   // Before
+   $builder->setCache($cache);
+   
+   // After
+   $builder->setDataSourceCache($cache);
+   ```
+
+2. **Enable MappingStrategy if used:**
+   ```php
+   $builder->enableMappingStrategy();
+   ```
+
+3. **Update collection property attributes:**
+   ```php
+   // Before
+   #[Property(class: Item::class)]
+   private array $items = [];
+   
+   // After
+   #[Property(itemClass: Item::class)]
+   private array $items = [];
+   ```
+
+### Bundle configuration
+
+```yaml
+# Before
+kassko_data_mapper:
+    cache:
+        enabled: true
+        service: 'cache.app'
+
+# After
+kassko_data_mapper:
+    data_source_cache:
+        enabled: true
+        service: 'cache.app'
+    mapping_strategy:
+        enabled: true  # If using MappingStrategy
+```
+
+## Tests
+
+All 508 tests passing in data-mapper library.
+All 77 unit tests passing in data-mapper-bundle.

--- a/docs/history/pull-requests/PR-2026_01_31---17_16_33.md
+++ b/docs/history/pull-requests/PR-2026_01_31---17_16_33.md
@@ -90,37 +90,12 @@ Consider adding #[Property(itemClass: Item::class)] attribute to 'items' propert
 to specify the collection item type and enable automatic hydration.
 ```
 
-### 6. Updated data-mapper-bundle
-
-**Files:**
-- `config/services.yaml`
-- `src/DependencyInjection/Configuration.php`
-- `src/DependencyInjection/KasskoDataMapperExtension.php`
-- `src/Service/DataMapperFactory.php`
-
-Bundle configuration now supports:
-
-```yaml
-kassko_data_mapper:
-    data_source_cache:
-        enabled: true
-        service: 'cache.app'
-    
-    mapping_cache:
-        enabled: true
-        service: 'cache.app'
-    
-    mapping_strategy:
-        enabled: true
-```
-
-### 7. Updated Documentation
+### 6. Updated Documentation
 
 **Files:**
 - `README.md`
 - `EXAMPLE.md`
 - `docs/attributes/MappingStrategy.md`
-- `data-mapper-bundle/README.md`
 
 Added documentation for:
 - New cache configuration options
@@ -162,25 +137,7 @@ Added documentation for:
    private array $items = [];
    ```
 
-### Bundle configuration
-
-```yaml
-# Before
-kassko_data_mapper:
-    cache:
-        enabled: true
-        service: 'cache.app'
-
-# After
-kassko_data_mapper:
-    data_source_cache:
-        enabled: true
-        service: 'cache.app'
-    mapping_strategy:
-        enabled: true  # If using MappingStrategy
-```
-
 ## Tests
 
 All 508 tests passing in data-mapper library.
-All 77 unit tests passing in data-mapper-bundle.
+

--- a/docs/history/summaries/SUMMARY-2026_01_25---22_15_58.md
+++ b/docs/history/summaries/SUMMARY-2026_01_25---22_15_58.md
@@ -132,3 +132,20 @@ The implementation correctly handles the interaction:
 ## No Breaking Changes
 
 This is a bug fix. The `depth` parameter was previously accepted but never correctly applied. Existing code that didn't rely on depth behavior will continue to work unchanged.
+
+## Refactoring
+
+Moved the depth logic into `loadProperty()` - the common entry point for ALL loading variations:
+
+`loadSingleProperty()` - SinglePropDataSource
+`loadMultipleProperties()` - MultiPropDataSource
+`loadPropertyWithFallbacks()` - DataSourceRef with fallbacks
+`loadPropertyWithCandidates()` - DataSourceRef with candidates
+`loadPropertyWithProviders()` - DataSourceRef with providers
+Created `doLoadProperty()` - an internal method containing the loading logic, called by `loadProperty()` after setting the depth context
+
+Added tests:
+
+`LoadingCheckDepthMultiProp` - 2 tests verifying that depth works with MultiPropDataSource
+Modified files:
+`src/Loader/Loader.php` - Refactored to centralize depth management

--- a/docs/history/summaries/SUMMARY-2026_01_31---17_16_33.md
+++ b/docs/history/summaries/SUMMARY-2026_01_31---17_16_33.md
@@ -51,35 +51,12 @@ Nouvelles méthodes ajoutées:
 
 Messages explicatifs suggérant l'ajout de `#[Property(class: X::class)]` ou `#[Property(itemClass: X::class)]`.
 
-### 6. ✅ Updated data-mapper-bundle
-
-Fichiers modifiés:
-- `config/services.yaml` - Nouveaux arguments
-- `src/DependencyInjection/Configuration.php` - Nouvelles options
-- `src/DependencyInjection/KasskoDataMapperExtension.php` - Nouvelles méthodes de configuration
-- `src/Service/DataMapperFactory.php` - Nouveaux paramètres
-- Tests mis à jour
-
-Nouvelles options de configuration bundle:
-```yaml
-kassko_data_mapper:
-    data_source_cache:
-        enabled: true
-        service: 'cache.app'
-    mapping_cache:
-        enabled: true
-        service: 'cache.app'
-    mapping_strategy:
-        enabled: true
-```
-
-### 7. ✅ Updated Documentation
+### 6. ✅ Updated Documentation
 
 Fichiers mis à jour:
 - `README.md` - Nouvelles options DataMapperBuilder
 - `EXAMPLE.md` - Section MappingStrategy avec activation
 - `docs/attributes/MappingStrategy.md` - Section complète activation + performance
-- `data-mapper-bundle/README.md` - Nouvelle configuration
 
 ## Files Modified
 
@@ -97,32 +74,13 @@ Fichiers mis à jour:
 | `EXAMPLE.md` | MappingStrategy activation section |
 | `docs/attributes/MappingStrategy.md` | Activation and performance sections |
 
-### data-mapper-bundle
-| File | Changes |
-|------|---------|
-| `config/services.yaml` | New service arguments |
-| `src/DependencyInjection/Configuration.php` | New config nodes |
-| `src/DependencyInjection/KasskoDataMapperExtension.php` | New configure methods |
-| `src/Service/DataMapperFactory.php` | New parameters |
-| `tests/Unit/DependencyInjection/ConfigurationTest.php` | Updated for new config |
-| `tests/Unit/DependencyInjection/KasskoDataMapperExtensionTest.php` | Updated parameters |
-| `tests/Unit/Service/DataMapperFactoryTest.php` | Updated factory calls |
-| `README.md` | New configuration options |
 
 ## Test Results
 
 - **data-mapper:** 508 tests passing (9 skipped)
-- **data-mapper-bundle:** 77 tests passing (3 skipped)
 
 ## Breaking Changes Summary
 
 1. `setCache()` renamed to `setDataSourceCache()`
 2. MappingStrategy disabled by default - requires `enableMappingStrategy()`
 3. `Property::class` no longer works as fallback for array items - use `itemClass`
-4. Bundle config `cache:` renamed to `data_source_cache:`
-
-## Next Steps
-
-1. Merge PR to main branch
-2. Update version number if needed
-3. Update CHANGELOG.md

--- a/docs/history/summaries/SUMMARY-2026_01_31---17_16_33.md
+++ b/docs/history/summaries/SUMMARY-2026_01_31---17_16_33.md
@@ -1,0 +1,128 @@
+# Session Summary: MappingCache and More
+
+**Date:** 2026-01-31  
+**Branch:** `feat/code/mapping_cache_and_more`  
+**Duration:** Full session
+
+## Objectives Completed
+
+### 1. ✅ Removed BC Fallback for itemClass (Loader.php line 1929)
+
+Supprimé le fallback `$itemPropertyAttr->class` pour les collections. Désormais seul `itemClass` est utilisé pour les éléments de collection.
+
+**Exception:** Le fallback `class` est conservé pour les `configCandidates` (polymorphisme) où `PropertyConfig::class` est le type d'élément.
+
+### 2. ✅ Renamed Cache to DataSourceCache
+
+Renommé dans tous les fichiers concernés:
+- `$cache` → `$dataSourceCache`
+- `setCache()` → `setDataSourceCache()`
+- `getCache()` → `getDataSourceCache()`
+- `clearCache()` → `clearDataSourceCache()`
+- `isCached()` → `isDataSourceCached()`
+
+### 3. ✅ Added MappingCache
+
+Ajouté un nouveau cache dédié aux conversions MappingStrategy:
+- Interface publique: `DataMapperBuilder::setMappingCache($mappingCache)`
+- Cache PSR-16 optionnel
+- Fallback automatique sur un cache mémoire (array)
+
+Méthodes de cache ajoutées dans Loader:
+- `getCachedMappingConversion()`
+- `getCachedFindSourceField()`
+
+### 4. ✅ Added enableMappingStrategy() Option
+
+MappingStrategy est maintenant désactivé par défaut pour des raisons de performance.
+
+- Interface publique: `DataMapperBuilder::enableMappingStrategy()`
+- Exception `MappingStrategyException::mappingStrategyNotEnabled()` si utilisé sans activation
+- Message d'erreur explicatif guidant l'utilisateur
+
+### 5. ✅ Improved Setter Type Mismatch Errors
+
+Amélioré les messages d'erreur quand une propriété n'est pas typée mais son setter l'est:
+
+Nouvelles méthodes ajoutées:
+- `enhanceSetterTypeError()`
+- `enhancePropertyTypeError()`
+- `enhanceMethodTypeError()`
+
+Messages explicatifs suggérant l'ajout de `#[Property(class: X::class)]` ou `#[Property(itemClass: X::class)]`.
+
+### 6. ✅ Updated data-mapper-bundle
+
+Fichiers modifiés:
+- `config/services.yaml` - Nouveaux arguments
+- `src/DependencyInjection/Configuration.php` - Nouvelles options
+- `src/DependencyInjection/KasskoDataMapperExtension.php` - Nouvelles méthodes de configuration
+- `src/Service/DataMapperFactory.php` - Nouveaux paramètres
+- Tests mis à jour
+
+Nouvelles options de configuration bundle:
+```yaml
+kassko_data_mapper:
+    data_source_cache:
+        enabled: true
+        service: 'cache.app'
+    mapping_cache:
+        enabled: true
+        service: 'cache.app'
+    mapping_strategy:
+        enabled: true
+```
+
+### 7. ✅ Updated Documentation
+
+Fichiers mis à jour:
+- `README.md` - Nouvelles options DataMapperBuilder
+- `EXAMPLE.md` - Section MappingStrategy avec activation
+- `docs/attributes/MappingStrategy.md` - Section complète activation + performance
+- `data-mapper-bundle/README.md` - Nouvelle configuration
+
+## Files Modified
+
+### data-mapper library
+| File | Changes |
+|------|---------|
+| `src/Loader/Loader.php` | BC removal, mappingCache, enableMappingStrategy, error enhancement |
+| `src/DataMapper.php` | New parameters, renamed cache |
+| `src/DataMapperBuilder.php` | New methods, renamed cache |
+| `src/Expression/SourceFunctionProvider.php` | Renamed cache methods |
+| `src/Exception/MappingStrategyException.php` | New `mappingStrategyNotEnabled()` method |
+| `tests/Integration/Features/NamingConvention/NamingConventionTest.php` | `class:` → `itemClass:` |
+| `tests/Integration/Attributes/MappingStrategy/MappingStrategyTest.php` | Added enableMappingStrategy() |
+| `README.md` | New cache and MappingStrategy options |
+| `EXAMPLE.md` | MappingStrategy activation section |
+| `docs/attributes/MappingStrategy.md` | Activation and performance sections |
+
+### data-mapper-bundle
+| File | Changes |
+|------|---------|
+| `config/services.yaml` | New service arguments |
+| `src/DependencyInjection/Configuration.php` | New config nodes |
+| `src/DependencyInjection/KasskoDataMapperExtension.php` | New configure methods |
+| `src/Service/DataMapperFactory.php` | New parameters |
+| `tests/Unit/DependencyInjection/ConfigurationTest.php` | Updated for new config |
+| `tests/Unit/DependencyInjection/KasskoDataMapperExtensionTest.php` | Updated parameters |
+| `tests/Unit/Service/DataMapperFactoryTest.php` | Updated factory calls |
+| `README.md` | New configuration options |
+
+## Test Results
+
+- **data-mapper:** 508 tests passing (9 skipped)
+- **data-mapper-bundle:** 77 tests passing (3 skipped)
+
+## Breaking Changes Summary
+
+1. `setCache()` renamed to `setDataSourceCache()`
+2. MappingStrategy disabled by default - requires `enableMappingStrategy()`
+3. `Property::class` no longer works as fallback for array items - use `itemClass`
+4. Bundle config `cache:` renamed to `data_source_cache:`
+
+## Next Steps
+
+1. Merge PR to main branch
+2. Update version number if needed
+3. Update CHANGELOG.md

--- a/src/DataMapper.php
+++ b/src/DataMapper.php
@@ -24,7 +24,9 @@ use Psr\SimpleCache\CacheInterface;
 final class DataMapper
 {
     private ServiceResolver $serviceResolver;
-    private ?CacheInterface $cache;
+    private ?CacheInterface $dataSourceCache;
+    private ?CacheInterface $mappingCache;
+    private bool $mappingStrategyEnabled;
     private ?LoggerInterface $logger;
     private DataLineageCollector $lineageCollector;
     private Loader $loader;
@@ -37,7 +39,9 @@ final class DataMapper
 
     /**
      * @param ServiceResolver $serviceResolver
-     * @param CacheInterface|null $cache PSR-16 cache interface
+     * @param CacheInterface|null $dataSourceCache PSR-16 cache interface for data source results
+     * @param CacheInterface|null $mappingCache PSR-16 cache interface for mapping strategy conversions
+     * @param bool $mappingStrategyEnabled Whether MappingStrategy feature is enabled
      * @param LoggerInterface|null $logger PSR-3 logger interface
      * @param array<string, callable> $customHydrators Custom hydrators (key => callable)
      * @param array<string, callable> $customObjectMappers Custom object mappers (key => callable)
@@ -46,14 +50,18 @@ final class DataMapper
      */
     public function __construct(
         ServiceResolver $serviceResolver,
-        ?CacheInterface $cache = null,
+        ?CacheInterface $dataSourceCache = null,
+        ?CacheInterface $mappingCache = null,
+        bool $mappingStrategyEnabled = false,
         ?LoggerInterface $logger = null,
         array $customHydrators = [],
         array $customObjectMappers = [],
         array $sensitiveKeys = [],
         SensitiveLevel $defaultSensitiveLevel = SensitiveLevel::SHOW
     ) {
-        $this->cache = $cache;
+        $this->dataSourceCache = $dataSourceCache;
+        $this->mappingCache = $mappingCache;
+        $this->mappingStrategyEnabled = $mappingStrategyEnabled;
         $this->logger = $logger;
         $this->serviceResolver = $serviceResolver;
         $this->customHydrators = $customHydrators;
@@ -61,7 +69,15 @@ final class DataMapper
         $this->lineageCollector = new DataLineageCollector($sensitiveKeys, $defaultSensitiveLevel);
         
         // Register Loader in the registry
-        $this->loader = new Loader($this->serviceResolver, $this->logger, $customHydrators, $this->lineageCollector);
+        $this->loader = new Loader(
+            $this->serviceResolver,
+            $this->logger,
+            $customHydrators,
+            $this->lineageCollector,
+            null, // cascadeCollector
+            $this->mappingCache,
+            $this->mappingStrategyEnabled
+        );
         LoaderRegistry::set($this->loader);
         
         // Set logger for context registry
@@ -91,9 +107,9 @@ final class DataMapper
         return $this;
     }
 
-    public function getCache(): ?CacheInterface
+    public function getDataSourceCache(): ?CacheInterface
     {
-        return $this->cache;
+        return $this->dataSourceCache;
     }
 
     /**

--- a/src/DataMapperBuilder.php
+++ b/src/DataMapperBuilder.php
@@ -24,8 +24,10 @@ use Psr\Log\LoggerInterface;
 final class DataMapperBuilder
 {
     private ?ContainerInterface $container = null;
-    private ?CacheInterface $cache = null;
+    private ?CacheInterface $dataSourceCache = null;
+    private ?CacheInterface $mappingCache = null;
     private ?LoggerInterface $logger = null;
+    private bool $mappingStrategyEnabled = false;
     
     /** @var ServiceLocatorInterface[] */
     private array $locators = [];
@@ -57,9 +59,50 @@ final class DataMapperBuilder
         return $this;
     }
 
-    public function setCache(CacheInterface $cache): self
+    public function setDataSourceCache(CacheInterface $dataSourceCache): self
     {
-        $this->cache = $cache;
+        $this->dataSourceCache = $dataSourceCache;
+        return $this;
+    }
+
+    /**
+     * Set the mapping cache for MappingStrategy conversions.
+     * 
+     * When MappingStrategy is enabled, case conversions can be expensive.
+     * Providing a persistent cache (e.g., Redis, filesystem) significantly
+     * improves performance by memoizing conversion results.
+     * 
+     * If no cache is provided, an in-memory array cache will be used
+     * which only persists for the current request.
+     *
+     * @param CacheInterface $mappingCache PSR-16 cache for mapping conversions
+     * @return self
+     */
+    public function setMappingCache(CacheInterface $mappingCache): self
+    {
+        $this->mappingCache = $mappingCache;
+        return $this;
+    }
+
+    /**
+     * Enable the MappingStrategy feature.
+     * 
+     * MappingStrategy allows automatic field name conversion between different
+     * case formats (underscore_case, dash-case, PascalCase, etc.) and camelCase
+     * properties.
+     * 
+     * This feature is disabled by default because it has a performance cost
+     * due to case conversion calculations. When disabled, Property::sourceField
+     * must be used for explicit field mapping.
+     * 
+     * When enabled, it's recommended to provide a persistent cache via
+     * setMappingCache() to minimize performance impact.
+     *
+     * @return self
+     */
+    public function enableMappingStrategy(): self
+    {
+        $this->mappingStrategyEnabled = true;
         return $this;
     }
 
@@ -242,7 +285,9 @@ final class DataMapperBuilder
         // Create the DataMapper which will create and register the Loader
         return new DataMapper(
             $serviceResolver,
-            $this->cache,
+            $this->dataSourceCache,
+            $this->mappingCache,
+            $this->mappingStrategyEnabled,
             $this->logger,
             $this->customHydrators,
             $this->customObjectMappers,

--- a/src/Exception/MappingStrategyException.php
+++ b/src/Exception/MappingStrategyException.php
@@ -74,4 +74,22 @@ class MappingStrategyException extends \InvalidArgumentException
             $context
         ));
     }
+
+    /**
+     * Create exception when MappingStrategy attribute is used but the feature is not enabled.
+     * 
+     * This helps guide users who add MappingStrategy attributes but forget to enable
+     * the feature via DataMapperBuilder::enableMappingStrategy().
+     */
+    public static function mappingStrategyNotEnabled(string $propertyName, string $className): self
+    {
+        return new self(sprintf(
+            'MappingStrategy attribute found on property "%s" in class "%s", but the MappingStrategy feature ' .
+            'is not enabled. Please call DataMapperBuilder::enableMappingStrategy() to enable this feature. ' .
+            'Note: When enabled, MappingStrategy has a performance cost. Consider providing a persistent cache ' .
+            'via DataMapperBuilder::setMappingCache() to minimize this impact.',
+            $propertyName,
+            $className
+        ));
+    }
 }

--- a/src/Expression/SourceFunctionProvider.php
+++ b/src/Expression/SourceFunctionProvider.php
@@ -21,16 +21,16 @@ class SourceFunctionProvider
     private $dataSourceExecutor;
     
     /** @var CacheInterface|null PSR-16 cache for DataSource results */
-    private ?CacheInterface $cache;
+    private ?CacheInterface $dataSourceCache;
 
     /**
      * @param callable $dataSourceExecutor Callback to execute a DataSource: function(string $sourceId): mixed
-     * @param CacheInterface|null $cache Optional PSR-16 cache for storing DataSource results
+     * @param CacheInterface|null $dataSourceCache Optional PSR-16 cache for storing DataSource results
      */
-    public function __construct(callable $dataSourceExecutor, ?CacheInterface $cache = null)
+    public function __construct(callable $dataSourceExecutor, ?CacheInterface $dataSourceCache = null)
     {
         $this->dataSourceExecutor = $dataSourceExecutor;
-        $this->cache = $cache;
+        $this->dataSourceCache = $dataSourceCache;
     }
 
     /**
@@ -42,15 +42,15 @@ class SourceFunctionProvider
      */
     public function getSourceResult(string $sourceId)
     {
-        if ($this->cache !== null) {
+        if ($this->dataSourceCache !== null) {
             $cacheKey = $this->getCacheKey($sourceId);
             
-            if ($this->cache->has($cacheKey)) {
-                return $this->cache->get($cacheKey);
+            if ($this->dataSourceCache->has($cacheKey)) {
+                return $this->dataSourceCache->get($cacheKey);
             }
             
             $result = ($this->dataSourceExecutor)($sourceId);
-            $this->cache->set($cacheKey, $result);
+            $this->dataSourceCache->set($cacheKey, $result);
             
             return $result;
         }
@@ -60,17 +60,17 @@ class SourceFunctionProvider
     }
 
     /**
-     * Clear the cache for a specific source or all sources
+     * Clear the data source cache for a specific source or all sources
      *
      * @param string|null $sourceId If null, clears entire cache
      */
-    public function clearCache(?string $sourceId = null): void
+    public function clearDataSourceCache(?string $sourceId = null): void
     {
-        if ($this->cache !== null) {
+        if ($this->dataSourceCache !== null) {
             if ($sourceId !== null) {
-                $this->cache->delete($this->getCacheKey($sourceId));
+                $this->dataSourceCache->delete($this->getCacheKey($sourceId));
             } else {
-                $this->cache->clear();
+                $this->dataSourceCache->clear();
             }
         }
     }
@@ -81,13 +81,13 @@ class SourceFunctionProvider
      * @param string $sourceId
      * @return bool
      */
-    public function isCached(string $sourceId): bool
+    public function isDataSourceCached(string $sourceId): bool
     {
-        if ($this->cache === null) {
+        if ($this->dataSourceCache === null) {
             return false;
         }
         
-        return $this->cache->has($this->getCacheKey($sourceId));
+        return $this->dataSourceCache->has($this->getCacheKey($sourceId));
     }
 
     /**

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -43,6 +43,7 @@ use Kassko\DataMapper\Registry\PropertyMappingRegistry;
 use Kassko\DataMapper\ServiceResolver;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use ReflectionProperty;
 use WeakMap;
@@ -70,6 +71,15 @@ class Loader implements LoaderInterface
     private ?DataLineageCollector $lineageCollector;
     private ?AttributeCascadeCollector $cascadeCollector;
     
+    /** @var CacheInterface|null PSR-16 cache for mapping strategy conversions */
+    private ?CacheInterface $mappingCache;
+    
+    /** @var bool Whether MappingStrategy feature is enabled */
+    private bool $mappingStrategyEnabled;
+    
+    /** @var array<string, string> In-memory cache for mapping conversions (fallback when no cache provided) */
+    private array $mappingCacheArray = [];
+    
     /** @var array<string, callable> */
     private array $customHydrators;
     
@@ -88,13 +98,17 @@ class Loader implements LoaderInterface
      * @param array<string, callable> $customHydrators
      * @param DataLineageCollector|null $lineageCollector
      * @param AttributeCascadeCollector|null $cascadeCollector
+     * @param CacheInterface|null $mappingCache PSR-16 cache for mapping strategy conversions
+     * @param bool $mappingStrategyEnabled Whether MappingStrategy feature is enabled
      */
     public function __construct(
         ServiceResolver $serviceResolver,
         ?LoggerInterface $logger = null,
         array $customHydrators = [],
         ?DataLineageCollector $lineageCollector = null,
-        ?AttributeCascadeCollector $cascadeCollector = null
+        ?AttributeCascadeCollector $cascadeCollector = null,
+        ?CacheInterface $mappingCache = null,
+        bool $mappingStrategyEnabled = false
     ) {
         $this->loadedProperties = new WeakMap();
         $this->sourceFunctionProviders = new WeakMap();
@@ -107,6 +121,8 @@ class Loader implements LoaderInterface
         $this->lineageCollector = $lineageCollector;
         $this->cascadeCollector = $cascadeCollector ?? new AttributeCascadeCollector($this->logger);
         $this->attributeReader = new AttributeReader($this->cascadeCollector);
+        $this->mappingCache = $mappingCache;
+        $this->mappingStrategyEnabled = $mappingStrategyEnabled;
     }
 
     public function getServiceResolver(): ServiceResolver
@@ -1784,7 +1800,7 @@ class Loader implements LoaderInterface
      * that corresponds to this PHP object property.
      * 
      * If a sourceField is explicitly defined via the Property attribute, it is returned.
-     * If a MappingStrategy is defined, it converts the property name using the preset.
+     * If MappingStrategy is enabled and defined, it converts the property name using the preset.
      * Otherwise, the property name is used as the default (convention over configuration).
      *
      * @param ReflectionProperty $property The reflection property
@@ -1794,6 +1810,7 @@ class Loader implements LoaderInterface
     {
         $propertyName = $property->getName();
         $reflectionClass = $property->getDeclaringClass();
+        $className = $reflectionClass->getName();
         
         // Use Property attribute's sourceField if defined
         $propertyAttr = $this->attributeReader->readProperty($property);
@@ -1803,23 +1820,68 @@ class Loader implements LoaderInterface
             if ($mappingStrategy !== null) {
                 throw MappingStrategyException::sourceFieldAndMappingStrategyAreMutuallyExclusive(
                     $propertyName,
-                    $reflectionClass->getName()
+                    $className
                 );
             }
             return $propertyAttr->sourceField;
         }
         
-        // Check for MappingStrategy
+        // Check for MappingStrategy attribute on property or class
         $mappingStrategy = $this->attributeReader->getEffectiveMappingStrategy($property, $reflectionClass);
         
         if ($mappingStrategy !== null && $mappingStrategy->hasPreset()) {
+            // Check if MappingStrategy feature is enabled
+            if (!$this->mappingStrategyEnabled) {
+                throw MappingStrategyException::mappingStrategyNotEnabled(
+                    $propertyName,
+                    $className
+                );
+            }
+            
             $preset = $mappingStrategy->getPresetEnum() ?? MappingStrategyPreset::default();
-            // Convert property name to expected source field format
-            return CaseConverter::convertReverse($propertyName, $preset);
+            
+            // Use cached conversion if available
+            return $this->getCachedMappingConversion($className, $propertyName, $preset);
         }
         
         // Default: use property name as source field name (convention over configuration)
         return $propertyName;
+    }
+
+    /**
+     * Get a cached mapping conversion result.
+     * 
+     * Uses the configured mapping cache if available, otherwise falls back
+     * to an in-memory array cache.
+     *
+     * @param string $className The class name
+     * @param string $propertyName The property name
+     * @param MappingStrategyPreset $preset The mapping strategy preset
+     * @return string The converted source field name
+     */
+    private function getCachedMappingConversion(string $className, string $propertyName, MappingStrategyPreset $preset): string
+    {
+        $cacheKey = 'data_mapper_mapping_' . md5($className . '::' . $propertyName . '::' . $preset->value);
+        
+        // Try PSR-16 cache first
+        if ($this->mappingCache !== null) {
+            if ($this->mappingCache->has($cacheKey)) {
+                return $this->mappingCache->get($cacheKey);
+            }
+            
+            $result = CaseConverter::convertReverse($propertyName, $preset);
+            $this->mappingCache->set($cacheKey, $result);
+            return $result;
+        }
+        
+        // Fallback to in-memory array cache
+        if (isset($this->mappingCacheArray[$cacheKey])) {
+            return $this->mappingCacheArray[$cacheKey];
+        }
+        
+        $result = CaseConverter::convertReverse($propertyName, $preset);
+        $this->mappingCacheArray[$cacheKey] = $result;
+        return $result;
     }
 
     /**
@@ -1860,7 +1922,6 @@ class Loader implements LoaderInterface
         // If no Property attribute, try to create a synthetic one from PHP typehint
         if ($propertyAttr === null) {
             $propertyAttr = $this->createSyntheticPropertyFromTypehint($property);
-
             
             // If still no Property attribute (no instantiable class in typehint), return value as-is
             if ($propertyAttr === null) {
@@ -1925,9 +1986,9 @@ class Loader implements LoaderInterface
                 }
                 
                 // Determine the class for collection items:
-                // 1. Use itemClass if defined (preferred for collections)
-                // 2. Fall back to class for backward compatibility
-                $itemClassName = $itemPropertyAttr->itemClass ?? $itemPropertyAttr->class ?? null;
+                // - For polymorphic resolution via configCandidates: use class from resolved PropertyConfig
+                // - For standard collections: use itemClass from Property attribute
+                $itemClassName = $itemPropertyAttr->itemClass ?? ($hasConfigCandidates ? $itemPropertyAttr->class : null);
                 
                 // If still no class defined, skip this item
                 if ($itemClassName === null) {
@@ -2204,16 +2265,16 @@ class Loader implements LoaderInterface
                 if ($setter->type === Setter::TYPE_ADDER && is_array($value)) {
                     // Adder: call method for each item in the array
                     foreach ($value as $item) {
-                        $this->callMethodWithParams($object, $setter->name, $property, [$item]);
+                        $this->callMethodWithParams($object, $setter->name, $property, [$item], true);
                     }
                 } elseif ($setter->type === Setter::TYPE_INDEXED_ADDER && is_array($value)) {
                     // Indexed adder: call method with index and item
                     foreach ($value as $index => $item) {
-                        $this->callMethodWithParams($object, $setter->name, $property, [$index, $item]);
+                        $this->callMethodWithParams($object, $setter->name, $property, [$index, $item], true);
                     }
                 } else {
                     // Regular setter
-                    $this->callMethodWithParams($object, $setter->name, $property, [$value]);
+                    $this->callMethodWithParams($object, $setter->name, $property, [$value], false);
                 }
                 // Execute after_set_property hooks
                 $this->executeSettingHooks($object, $property, 'after', $value);
@@ -2237,14 +2298,22 @@ class Loader implements LoaderInterface
         // 3. Look for setter method
         $setterMethod = 'set' . ucfirst($propertyName);
         if (method_exists($object, $setterMethod)) {
-            $object->$setterMethod($value);
+            try {
+                $object->$setterMethod($value);
+            } catch (\TypeError $e) {
+                throw $this->enhanceSetterTypeError($e, $object, $property, $setterMethod, $value);
+            }
             // Execute after_set_property hooks
             $this->executeSettingHooks($object, $property, 'after', $value);
             return;
         }
         
         // 4. Fall back to direct property assignment via reflection
-        $property->setValue($object, $value);
+        try {
+            $property->setValue($object, $value);
+        } catch (\TypeError $e) {
+            throw $this->enhancePropertyTypeError($e, $object, $property, $value);
+        }
         
         // Execute after_set_property hooks
         $this->executeSettingHooks($object, $property, 'after', $value);
@@ -2257,8 +2326,9 @@ class Loader implements LoaderInterface
      * @param string $methodName The method name
      * @param ReflectionProperty $property The property (for context)
      * @param array $baseArgs The base arguments (value for setter, [item] for adder, [index, item] for indexed adder)
+     * @param bool $isAdder Whether this is an adder method call
      */
-    private function callMethodWithParams(object $object, string $methodName, ReflectionProperty $property, array $baseArgs): void
+    private function callMethodWithParams(object $object, string $methodName, ReflectionProperty $property, array $baseArgs, bool $isAdder = false): void
     {
         $reflectionMethod = new \ReflectionMethod($object, $methodName);
         $parameters = $reflectionMethod->getParameters();
@@ -2281,7 +2351,78 @@ class Loader implements LoaderInterface
             }
         }
         
-        $reflectionMethod->invokeArgs($object, $resolvedArgs);
+        try {
+            $reflectionMethod->invokeArgs($object, $resolvedArgs);
+        } catch (\TypeError $e) {
+            throw $this->enhanceMethodTypeError($e, $object, $property, $methodName, $resolvedArgs[0] ?? null, $isAdder);
+        }
+    }
+
+    /**
+     * Enhance a TypeError from a method call (setter or adder) with helpful context.
+     *
+     * @param \TypeError $originalError The original TypeError
+     * @param object $object The object being hydrated
+     * @param ReflectionProperty $property The property
+     * @param string $methodName The method name
+     * @param mixed $value The first argument value that likely caused the error
+     * @param bool $isAdder Whether this was an adder method
+     * @return \TypeError Enhanced TypeError with better message
+     */
+    private function enhanceMethodTypeError(
+        \TypeError $originalError,
+        object $object,
+        ReflectionProperty $property,
+        string $methodName,
+        mixed $value,
+        bool $isAdder
+    ): \TypeError {
+        if (!is_array($value)) {
+            return $originalError;
+        }
+        
+        $propertyName = $property->getName();
+        $className = get_class($object);
+        
+        $reflectionMethod = new \ReflectionMethod($object, $methodName);
+        $parameters = $reflectionMethod->getParameters();
+        
+        if (!empty($parameters)) {
+            $expectedType = $parameters[0]->getType();
+            $expectedTypeName = $expectedType instanceof \ReflectionNamedType 
+                ? $expectedType->getName() 
+                : (string) $expectedType;
+            
+            if ($expectedTypeName !== 'array' && $expectedTypeName !== 'mixed') {
+                if ($isAdder) {
+                    return new \TypeError(sprintf(
+                        'Type mismatch for property "%s" in class "%s": Adder method "%s" expects type "%s", ' .
+                        'but received an array. This typically happens when the property or collection items ' .
+                        'are not typed. Consider adding #[Property(itemClass: %s::class)] attribute to specify ' .
+                        'the collection item type.',
+                        $propertyName,
+                        $className,
+                        $methodName,
+                        $expectedTypeName,
+                        $expectedTypeName
+                    ), 0, $originalError);
+                } else {
+                    return new \TypeError(sprintf(
+                        'Type mismatch for property "%s" in class "%s": Setter method "%s" expects type "%s", ' .
+                        'but received an array. This typically happens when the property is not typed with ' .
+                        'the expected class. Consider adding #[Property(class: %s::class)] attribute or typing ' .
+                        'the property.',
+                        $propertyName,
+                        $className,
+                        $methodName,
+                        $expectedTypeName,
+                        $expectedTypeName
+                    ), 0, $originalError);
+                }
+            }
+        }
+        
+        return $originalError;
     }
 
     /**
@@ -3418,7 +3559,14 @@ class Loader implements LoaderInterface
         $mappingStrategy = $this->attributeReader->getEffectiveMappingStrategy($property, $reflectionClass);
         
         if ($mappingStrategy !== null) {
-            return $this->findSourceFieldWithMappingStrategy($propertyName, $data, $mappingStrategy);
+            // Check if MappingStrategy feature is enabled
+            if (!$this->mappingStrategyEnabled) {
+                throw MappingStrategyException::mappingStrategyNotEnabled(
+                    $propertyName,
+                    $reflectionClass->getName()
+                );
+            }
+            return $this->findSourceFieldWithMappingStrategy($propertyName, $data, $mappingStrategy, $reflectionClass->getName());
         }
         
         // No explicit sourceField or MappingStrategy - use default logic (camel + dash + underscore)
@@ -3455,22 +3603,71 @@ class Loader implements LoaderInterface
      * @param string $propertyName The property name (camelCase)
      * @param array $data The raw data to search in
      * @param MappingStrategy $mappingStrategy The mapping strategy to use
+     * @param string $className The class name for caching purposes
      * @return string The source field name
      */
-    private function findSourceFieldWithMappingStrategy(string $propertyName, array $data, MappingStrategy $mappingStrategy): string
+    private function findSourceFieldWithMappingStrategy(string $propertyName, array $data, MappingStrategy $mappingStrategy, string $className): string
     {
-        // Custom callable takes precedence
+        // Custom callable takes precedence (no caching for custom logic)
         if ($mappingStrategy->hasCustom()) {
             return $this->resolveSourceFieldWithCustomCallable($propertyName, $data, $mappingStrategy);
         }
         
-        // Use preset strategy
+        // Use preset strategy with caching
         $preset = $mappingStrategy->getPresetEnum();
         if ($preset === null) {
             $preset = MappingStrategyPreset::default();
         }
         
-        return CaseConverter::findSourceField($propertyName, $data, $preset);
+        // Use cached findSourceField result
+        return $this->getCachedFindSourceField($className, $propertyName, $data, $preset);
+    }
+
+    /**
+     * Get a cached findSourceField result.
+     * 
+     * Uses the configured mapping cache if available, otherwise falls back
+     * to an in-memory array cache.
+     *
+     * @param string $className The class name
+     * @param string $propertyName The property name
+     * @param array $data The raw data to search in
+     * @param MappingStrategyPreset $preset The mapping strategy preset
+     * @return string The source field name
+     */
+    private function getCachedFindSourceField(string $className, string $propertyName, array $data, MappingStrategyPreset $preset): string
+    {
+        $cacheKey = 'data_mapper_find_' . md5($className . '::' . $propertyName . '::' . $preset->value);
+        
+        // Try PSR-16 cache first
+        if ($this->mappingCache !== null) {
+            if ($this->mappingCache->has($cacheKey)) {
+                $cachedField = $this->mappingCache->get($cacheKey);
+                // Verify the cached field exists in current data
+                if (array_key_exists($cachedField, $data)) {
+                    return $cachedField;
+                }
+                // Cached value not in current data - compute fresh
+            }
+            
+            $result = CaseConverter::findSourceField($propertyName, $data, $preset);
+            $this->mappingCache->set($cacheKey, $result);
+            return $result;
+        }
+        
+        // Fallback to in-memory array cache
+        if (isset($this->mappingCacheArray[$cacheKey])) {
+            $cachedField = $this->mappingCacheArray[$cacheKey];
+            // Verify the cached field exists in current data
+            if (array_key_exists($cachedField, $data)) {
+                return $cachedField;
+            }
+            // Cached value not in current data - compute fresh
+        }
+        
+        $result = CaseConverter::findSourceField($propertyName, $data, $preset);
+        $this->mappingCacheArray[$cacheKey] = $result;
+        return $result;
     }
 
     /**
@@ -3535,5 +3732,134 @@ class Loader implements LoaderInterface
         PropertyMappingRegistry::register($object, $propertyName, $sourceField);
         
         return $sourceField;
+    }
+
+    /**
+     * Enhance a TypeError from a setter method with helpful context.
+     * 
+     * This method provides a better error message when a setter receives a value
+     * of the wrong type, particularly when the property is not typed but the setter is.
+     *
+     * @param \TypeError $originalError The original TypeError
+     * @param object $object The object being hydrated
+     * @param ReflectionProperty $property The property
+     * @param string $setterMethod The setter method name
+     * @param mixed $value The value that caused the error
+     * @return \TypeError Enhanced TypeError with better message
+     */
+    private function enhanceSetterTypeError(
+        \TypeError $originalError,
+        object $object,
+        ReflectionProperty $property,
+        string $setterMethod,
+        mixed $value
+    ): \TypeError {
+        $propertyName = $property->getName();
+        $className = get_class($object);
+        $valueType = get_debug_type($value);
+        
+        // Check if this is an array value being passed to a typed setter
+        if (is_array($value)) {
+            // Get the setter's expected type
+            $reflectionMethod = new \ReflectionMethod($object, $setterMethod);
+            $parameters = $reflectionMethod->getParameters();
+            
+            if (!empty($parameters)) {
+                $expectedType = $parameters[0]->getType();
+                $expectedTypeName = $expectedType instanceof \ReflectionNamedType 
+                    ? $expectedType->getName() 
+                    : (string) $expectedType;
+                
+                // Check if property is not typed (or typed as array/mixed)
+                $propertyType = $property->getType();
+                $propertyHasClassType = $propertyType instanceof \ReflectionNamedType 
+                    && !$propertyType->isBuiltin();
+                
+                if (!$propertyHasClassType && $expectedTypeName !== 'array' && $expectedTypeName !== 'mixed') {
+                    // The property is not typed with a class, but the setter expects a class
+                    if ($this->isListArray($value)) {
+                        return new \TypeError(sprintf(
+                            'Type mismatch for property "%s" in class "%s": Setter "%s" expects type "%s", ' .
+                            'but received an array. This typically happens when the property is not typed with ' .
+                            'the expected class. Consider adding #[Property(itemClass: %s::class)] attribute ' .
+                            'to specify the collection item type, or type the property with the expected class.',
+                            $propertyName,
+                            $className,
+                            $setterMethod,
+                            $expectedTypeName,
+                            $expectedTypeName
+                        ), 0, $originalError);
+                    } else {
+                        return new \TypeError(sprintf(
+                            'Type mismatch for property "%s" in class "%s": Setter "%s" expects type "%s", ' .
+                            'but received an array. This typically happens when the property is not typed with ' .
+                            'the expected class. Consider adding #[Property(class: %s::class)] attribute ' .
+                            'to specify the object type, or type the property with the expected class.',
+                            $propertyName,
+                            $className,
+                            $setterMethod,
+                            $expectedTypeName,
+                            $expectedTypeName
+                        ), 0, $originalError);
+                    }
+                }
+            }
+        }
+        
+        // Return the original error if we can't provide better context
+        return $originalError;
+    }
+
+    /**
+     * Enhance a TypeError from direct property assignment with helpful context.
+     *
+     * @param \TypeError $originalError The original TypeError
+     * @param object $object The object being hydrated
+     * @param ReflectionProperty $property The property
+     * @param mixed $value The value that caused the error
+     * @return \TypeError Enhanced TypeError with better message
+     */
+    private function enhancePropertyTypeError(
+        \TypeError $originalError,
+        object $object,
+        ReflectionProperty $property,
+        mixed $value
+    ): \TypeError {
+        $propertyName = $property->getName();
+        $className = get_class($object);
+        $valueType = get_debug_type($value);
+        
+        $propertyType = $property->getType();
+        $expectedTypeName = $propertyType instanceof \ReflectionNamedType 
+            ? $propertyType->getName() 
+            : (string) $propertyType;
+        
+        // Check if this is an array value being assigned to a class-typed property
+        if (is_array($value) && $propertyType instanceof \ReflectionNamedType && !$propertyType->isBuiltin()) {
+            if ($this->isListArray($value)) {
+                return new \TypeError(sprintf(
+                    'Type mismatch for property "%s" in class "%s": Property expects type "%s", ' .
+                    'but received an array. For collections, use #[Property(itemClass: %s::class)] ' .
+                    'to specify the item type so each array element is hydrated as an object.',
+                    $propertyName,
+                    $className,
+                    $expectedTypeName,
+                    $expectedTypeName
+                ), 0, $originalError);
+            } else {
+                return new \TypeError(sprintf(
+                    'Type mismatch for property "%s" in class "%s": Property expects type "%s", ' .
+                    'but received an array. Ensure the array data structure matches what the hydrator ' .
+                    'expects, or add #[Property(class: %s::class)] to explicitly specify the class.',
+                    $propertyName,
+                    $className,
+                    $expectedTypeName,
+                    $expectedTypeName
+                ), 0, $originalError);
+            }
+        }
+        
+        // Return the original error if we can't provide better context
+        return $originalError;
     }
 }

--- a/tests/Integration/Attributes/MappingStrategy/MappingStrategyTest.php
+++ b/tests/Integration/Attributes/MappingStrategy/MappingStrategyTest.php
@@ -48,6 +48,7 @@ class MappingStrategyTest extends TestCase
     protected function setUp(): void
     {
         $builder = new DataMapperBuilder();
+        $builder->enableMappingStrategy();
         $this->dataMapper = $builder->build();
         $this->hydrator = $this->dataMapper->getHydrator();
     }
@@ -206,6 +207,7 @@ class MappingStrategyTest extends TestCase
         
         $builder = new DataMapperBuilder();
         $builder->addServiceLocator($locator);
+        $builder->enableMappingStrategy();
         
         $dataMapper = $builder->build();
         $hydrator = $dataMapper->getHydrator();
@@ -291,5 +293,27 @@ class MappingStrategyTest extends TestCase
         $this->assertFalse($strategy->enabled);
         $this->assertNull($strategy->preset);
         $this->assertNull($strategy->custom);
+    }
+
+    /**
+     * Test that using MappingStrategy without enabling the feature throws a helpful exception.
+     */
+    public function testMappingStrategyNotEnabledThrowsException(): void
+    {
+        // Create a new DataMapper WITHOUT enabling MappingStrategy
+        $builder = new DataMapperBuilder();
+        $dataMapper = $builder->build();
+        $hydrator = $dataMapper->getHydrator();
+
+        $data = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ];
+
+        $this->expectException(MappingStrategyException::class);
+        $this->expectExceptionMessage('MappingStrategy feature is not enabled');
+        $this->expectExceptionMessage('enableMappingStrategy()');
+
+        $hydrator->hydrate(PersonFromUnderscoreCase::class, $data);
     }
 }

--- a/tests/Integration/Features/NamingConvention/NamingConventionTest.php
+++ b/tests/Integration/Features/NamingConvention/NamingConventionTest.php
@@ -169,7 +169,7 @@ class CompanyWithEmployees
 {
     public string $companyName = '';
 
-    #[Property(class: Employee::class)]
+    #[Property(itemClass: Employee::class)]
     public array $employees = [];
 }
 


### PR DESCRIPTION
# Pull Request: MappingCache and More

**Branch:** `feat/code/mapping_cache_and_more`
**Date:** 2026-01-31

## Summary

This PR introduces several enhancements to the DataMapper library focusing on cache management, MappingStrategy feature control, improved error messages, and cleanup of backward compatibility code.

## Changes

### 1. Removed Backward Compatibility Fallback for itemClass

**File:** `src/Loader/Loader.php`

Removed the BC fallback that allowed using `Property::class` for collection items. Now `itemClass` must be used explicitly for collections.

```php
// Before (BC fallback allowed)
#[Property(class: Employee::class)]  // Also worked for arrays
private array $employees = [];

// After (correct usage)
#[Property(itemClass: Employee::class)]
private array $employees = [];
```

**Note:** The `class` attribute is still used for `configCandidates` (polymorphism) where `PropertyConfig::class` represents the element type.

### 2. Renamed Cache to DataSourceCache

**Files:**
- `src/DataMapperBuilder.php`
- `src/DataMapper.php`
- `src/Expression/SourceFunctionProvider.php`

Renamed `$cache` → `$dataSourceCache` and `setCache()` → `setDataSourceCache()` to clarify its purpose.

### 3. Added Mapping Cache

**Files:**
- `src/DataMapperBuilder.php`
- `src/DataMapper.php`
- `src/Loader/Loader.php`

Added a dedicated cache for MappingStrategy conversions:

```php
$builder = new DataMapperBuilder();
$builder->setMappingCache($psr16Cache);  // Optional PSR-16 cache
$dataMapper = $builder->build();
```

An in-memory array cache is used automatically as fallback when no external cache is provided.

### 4. Added enableMappingStrategy() Option

**Files:**
- `src/DataMapperBuilder.php`
- `src/DataMapper.php`
- `src/Loader/Loader.php`
- `src/Exception/MappingStrategyException.php`

MappingStrategy is now **disabled by default** for performance. Users must explicitly enable it:

```php
$builder = new DataMapperBuilder();
$builder->enableMappingStrategy();  // Required to use MappingStrategy attribute
$dataMapper = $builder->build();
```

If MappingStrategy attributes are used without enabling the feature, a `MappingStrategyException` is thrown with a helpful message.

### 5. Improved Setter Type Mismatch Error Messages

**File:** `src/Loader/Loader.php`

Added enhanced error messages when a setter or adder method receives an incorrect type (e.g., array instead of object):

```
TypeError: MyClass::setEmployee() expects Employee, array given.
Consider adding #[Property(class: Employee::class)] attribute to 'employee' property
to specify the object type and enable automatic hydration.
```

For collections:
```
TypeError: MyClass::addItem() expects Item, array given.
Consider adding #[Property(itemClass: Item::class)] attribute to 'items' property
to specify the collection item type and enable automatic hydration.
```

### 6. Updated Documentation

**Files:**
- `README.md`
- `EXAMPLE.md`
- `docs/attributes/MappingStrategy.md`

Added documentation for:
- New cache configuration options
- MappingStrategy activation requirements
- Performance considerations and caching recommendations

## Breaking Changes

1. **Cache method renamed:** `setCache()` → `setDataSourceCache()`
2. **MappingStrategy disabled by default:** Must call `enableMappingStrategy()` to use MappingStrategy attributes
3. **itemClass required for collections:** `Property::class` no longer works as fallback for array items

## Migration Guide

### From previous version

1. **Update cache calls:**
   ```php
   // Before
   $builder->setCache($cache);
   
   // After
   $builder->setDataSourceCache($cache);
   ```

2. **Enable MappingStrategy if used:**
   ```php
   $builder->enableMappingStrategy();
   ```

3. **Update collection property attributes:**
   ```php
   // Before
   #[Property(class: Item::class)]
   private array $items = [];
   
   // After
   #[Property(itemClass: Item::class)]
   private array $items = [];
   ```

## Tests

All 508 tests passing in data-mapper library.

